### PR TITLE
refactor: remove dead code, fix stringly-typed cache, optimize hot paths

### DIFF
--- a/internal/claude/jsonl.go
+++ b/internal/claude/jsonl.go
@@ -115,17 +115,19 @@ func ParseJSONL(path string) (*Session, error) {
 			prevTimestamp = ts
 		}
 
+		// Extract metadata from whichever entry provides it first.
+		if session.CWD == "" && e.CWD != "" {
+			session.CWD = e.CWD
+		}
+		if session.Version == "" && e.Version != "" {
+			session.Version = e.Version
+		}
+		if session.GitBranch == "" && e.GitBranch != "" {
+			session.GitBranch = e.GitBranch
+		}
+
 		switch e.Type {
 		case "user":
-			if session.CWD == "" && e.CWD != "" {
-				session.CWD = e.CWD
-			}
-			if session.Version == "" && e.Version != "" {
-				session.Version = e.Version
-			}
-			if session.GitBranch == "" && e.GitBranch != "" {
-				session.GitBranch = e.GitBranch
-			}
 			lastMeaningful = &e
 			if e.Message != nil && !isToolResult(e.Message) {
 				session.UserMessages++
@@ -139,15 +141,6 @@ func ParseJSONL(path string) (*Session, error) {
 				}
 			}
 		case "assistant":
-			if session.CWD == "" && e.CWD != "" {
-				session.CWD = e.CWD
-			}
-			if session.Version == "" && e.Version != "" {
-				session.Version = e.Version
-			}
-			if session.GitBranch == "" && e.GitBranch != "" {
-				session.GitBranch = e.GitBranch
-			}
 			lastMeaningful = &e
 			if e.Message != nil {
 				session.AssistantMessages++
@@ -169,12 +162,9 @@ func ParseJSONL(path string) (*Session, error) {
 							recentTools = recentTools[len(recentTools)-20:]
 						}
 						if c.Name == "Write" || c.Name == "Edit" || c.Name == "NotebookEdit" {
-							var input map[string]any
-							if err := json.Unmarshal(c.Input, &input); err == nil {
-								if fp, ok := input["file_path"].(string); ok && fp != "" {
-									session.LastFileWrite = fp
-									session.LastFileWriteAt = ts
-								}
+							if fp := extractFilePath(c.Input); fp != "" {
+								session.LastFileWrite = fp
+								session.LastFileWriteAt = ts
 							}
 						}
 					}
@@ -234,6 +224,18 @@ func firstText(m *jsonlMessage) string {
 		if c.Type == "text" && c.Text != "" {
 			return c.Text
 		}
+	}
+	return ""
+}
+
+// extractFilePath extracts the "file_path" value from a tool_use input
+// without unmarshaling the entire JSON into a map.
+func extractFilePath(raw json.RawMessage) string {
+	var obj struct {
+		FilePath string `json:"file_path"`
+	}
+	if json.Unmarshal(raw, &obj) == nil {
+		return obj.FilePath
 	}
 	return ""
 }

--- a/internal/claude/process.go
+++ b/internal/claude/process.go
@@ -63,8 +63,12 @@ func DiscoverSessions() ([]*Session, error) {
 		return nil, fmt.Errorf("could not read projects dir: %w", err)
 	}
 
-	// Cache worktree lookups per CWD to avoid redundant git calls
-	wtCache := make(map[string][2]string) // cwd → [isWT, mainRepo]
+	// Cache worktree lookups per CWD to avoid redundant git calls.
+	type wtInfo struct {
+		isWorktree bool
+		mainRepo   string
+	}
+	wtCache := make(map[string]wtInfo)
 
 	var sessions []*Session
 	for _, projectEntry := range entries {
@@ -90,16 +94,11 @@ func DiscoverSessions() ([]*Session, error) {
 
 			if _, seen := wtCache[session.CWD]; !seen {
 				isWT, mainRepo := IsWorktree(session.CWD)
-				v := [2]string{"", ""}
-				if isWT {
-					v[0] = "1"
-				}
-				v[1] = mainRepo
-				wtCache[session.CWD] = v
+				wtCache[session.CWD] = wtInfo{isWorktree: isWT, mainRepo: mainRepo}
 			}
 			wt := wtCache[session.CWD]
-			session.IsWorktree = wt[0] == "1"
-			session.MainRepo = wt[1]
+			session.IsWorktree = wt.isWorktree
+			session.MainRepo = wt.mainRepo
 
 			sessions = append(sessions, session)
 		}

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -181,11 +181,3 @@ func (m Model) activityFor(sessionID string) ActivityKind {
 	return ActivityIdle
 }
 
-// renderActivity returns a styled activity label for use in the list row.
-func renderActivity(kind ActivityKind) string {
-	color, ok := activityColors[kind]
-	if !ok {
-		color = colorMuted
-	}
-	return lipgloss.NewStyle().Foreground(color).Bold(true).Render(string(kind))
-}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -316,6 +316,7 @@ func nextActivityFilter(current ActivityKind) ActivityKind {
 // Must be called whenever sessions, filters, search, or time window change.
 func (m *Model) refreshVisible() {
 	cutoff := time.Now().Add(-time.Duration(m.windowMinutes) * time.Minute)
+	lowerQuery := strings.ToLower(m.searchQuery)
 	m.visible = m.visible[:0]
 	for _, s := range m.sessions {
 		if s.IsSidechain || !s.LastActivity.After(cutoff) {
@@ -324,8 +325,8 @@ func (m *Model) refreshVisible() {
 		if m.activityFilter != "" && m.activityFor(s.SessionID) != m.activityFilter {
 			continue
 		}
-		if m.searchQuery != "" &&
-			!strings.Contains(strings.ToLower(s.CWD), strings.ToLower(m.searchQuery)) {
+		if lowerQuery != "" &&
+			!strings.Contains(strings.ToLower(s.CWD), lowerQuery) {
 			continue
 		}
 		m.visible = append(m.visible, s)
@@ -709,8 +710,6 @@ func (m Model) renderHelp() string {
 		return helpStyle.Width(m.width).Render(strings.Join(parts, "  "))
 	}
 
-
-
 	if m.focus == 0 {
 		parts = []string{
 			helpKeyStyle.Render("k/↑") + helpStyle.Render(" prev"),
@@ -794,9 +793,3 @@ func clamp(lo, hi, v int) int {
 	return v
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -7,23 +7,12 @@ var (
 	colorPrimary     = lipgloss.Color("#7C3AED")
 	colorAccent      = lipgloss.Color("#10B981")
 	colorWarning     = lipgloss.Color("#F59E0B")
-	colorDanger      = lipgloss.Color("#EF4444")
 	colorMuted       = lipgloss.Color("#6B7280")
 	colorText        = lipgloss.Color("#F9FAFB")
 	colorSubtext     = lipgloss.Color("#9CA3AF")
 	colorBorder      = lipgloss.Color("#374151")
 	colorBorderFocus = lipgloss.Color("#7C3AED")
 	colorSelBg       = lipgloss.Color("#3730A3") // visible indigo selection
-
-	// Status colors map
-	statusColors = map[string]lipgloss.Color{
-		"waiting":    colorAccent,
-		"thinking":   colorWarning,
-		"tool":       colorPrimary,
-		"processing": colorWarning,
-		"idle":       colorMuted,
-		"unknown":    colorMuted,
-	}
 
 	// Panels: border only, no padding (avoids width overflow)
 	panelStyle = lipgloss.NewStyle().
@@ -59,21 +48,3 @@ var (
 			Bold(true).
 			Padding(0, 1)
 )
-
-// statusDot returns a single ASCII dot colored by status (no emoji = no width bugs).
-func statusDot(status string) string {
-	color, ok := statusColors[status]
-	if !ok {
-		color = colorMuted
-	}
-	return lipgloss.NewStyle().Foreground(color).Render("●")
-}
-
-// statusLabel returns the status string styled with its color.
-func statusLabel(status string) string {
-	color, ok := statusColors[status]
-	if !ok {
-		color = colorMuted
-	}
-	return lipgloss.NewStyle().Foreground(color).Bold(true).Render(status)
-}


### PR DESCRIPTION
- Remove unused functions: statusDot, statusLabel, renderActivity, max
- Remove unused variables: colorDanger, statusColors map
- Replace stringly-typed [2]string worktree cache with proper wtInfo struct
- Deduplicate metadata extraction (CWD, Version, GitBranch) in ParseJSONL
- Cache lowercased search query in refreshVisible to avoid per-session ToLower
- Use targeted struct unmarshal for file_path extraction instead of map[string]any