### PR TITLE
feature/api key authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,10 @@
 # Frontend build
 frontend/node_modules/
 frontend/dist/
-internal/assets/dist/
+# Track an empty internal/assets/dist/ so go:embed has a target even on a
+# bare clone (the Makefile copies frontend/dist into it before building).
+internal/assets/dist/*
+!internal/assets/dist/.gitkeep
 
 # Claude Code
 .claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ make build
 ```
 lazyagent                        Launch the terminal UI (monitors all agents)
 lazyagent --agent claude         Monitor only Claude Code sessions
-lazyagent --api                  Start the HTTP API on 127.0.0.1:7421
+lazyagent --api                  Start the HTTP API (Bearer-token protected)
 lazyagent --gui                  Launch the macOS menu bar app
 lazyagent --tui --gui --api      Run everything together
 lazyagent prune --days N         Delete chat sessions older than N days
 lazyagent compact                Shrink chat files by truncating bulky payloads
 lazyagent search "query"         Search chat transcripts with snippets
 lazyagent limits                 Show 5h / weekly rate-limit usage and pace
+lazyagent passphrase             Set or rotate the HTTP API passphrase
 lazyagent --help                 Show full help
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -35,7 +35,7 @@ lazyagent --gui --api
 
 runs the menu bar app and the API side by side from a single process. See [Recipes](../usage/recipes.md) for more combinations.
 
-The first time you launch `--api`, lazyagent prompts for a passphrase, derives a Bearer token from it (PBKDF2-SHA256), and prints the token to stderr. Any client that knows the passphrase can derive the same token locally — see [HTTP API → Authentication](../interfaces/http-api.md#authentication).
+The first time you launch `--api`, lazyagent prompts for a passphrase, derives a Bearer token from it (PBKDF2-SHA256), and prints the token to stderr once. Clients can fetch the public salt from `/api/auth` and derive the same token locally — see [HTTP API → Authentication](../interfaces/http-api.md#authentication).
 
 ## Scope to one agent
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -24,7 +24,7 @@ lazyagent is a single binary with three interfaces, selectable by flag:
 ```bash
 lazyagent              # Terminal UI (default)
 lazyagent --gui        # macOS menu bar app (detaches from the terminal)
-lazyagent --api        # HTTP API on http://127.0.0.1:7421
+lazyagent --api        # HTTP API on http://127.0.0.1:7421 (Bearer-token protected)
 ```
 
 They're combinable — on a typical macOS setup:
@@ -34,6 +34,8 @@ lazyagent --gui --api
 ```
 
 runs the menu bar app and the API side by side from a single process. See [Recipes](../usage/recipes.md) for more combinations.
+
+The first time you launch `--api`, lazyagent prompts for a passphrase, derives a Bearer token from it (PBKDF2-SHA256), and prints the token to stderr. Any client that knows the passphrase can derive the same token locally — see [HTTP API → Authentication](../interfaces/http-api.md#authentication).
 
 ## Scope to one agent
 

--- a/docs/interfaces/http-api.md
+++ b/docs/interfaces/http-api.md
@@ -15,7 +15,7 @@ Starts an HTTP API on `http://127.0.0.1:7421`. If the port is busy the server tr
 
 ## Authentication
 
-All endpoints under `/api/*` require a Bearer token. The token is **derived from a passphrase** with PBKDF2-SHA256 — you set the passphrase once, and any client (mobile app, browser, curl) that knows the passphrase can compute the same token locally.
+All data endpoints under `/api/*` require a Bearer token. The token is **derived from a passphrase** with PBKDF2-SHA256 plus a public per-install salt. `GET /api` and `GET /api/auth` are public so browsers and clients can load the playground and fetch the KDF parameters before deriving the token locally.
 
 ### First run
 
@@ -23,7 +23,7 @@ All endpoints under `/api/*` require a Bearer token. The token is **derived from
 lazyagent --api
 ```
 
-If no passphrase is configured, lazyagent prompts for one (twice, for confirmation), saves it to `~/.config/lazyagent/config.json` under `api_passphrase`, and prints the derived bearer token to stderr:
+If no passphrase is configured, lazyagent prompts for one (twice, for confirmation), requires at least 12 characters, saves it to `~/.config/lazyagent/config.json` under `api_passphrase`, and prints the derived bearer token to stderr once for the interactive setup:
 
 ```
 API authentication enabled.
@@ -31,7 +31,7 @@ Bearer token: zqh9_r0QeYpLiLSQGZMYriIWqNZgZOu3Qc_l7wtraV4
 Use header:   Authorization: Bearer <token>
 ```
 
-The token is printed on every subsequent startup too — copy it into clients as needed.
+On later startups the token is not printed to avoid leaking it into service logs. Use `lazyagent passphrase --show` when you explicitly need the raw token.
 
 ### Non-interactive setup
 
@@ -46,8 +46,8 @@ The env var takes precedence over the config file value and is never written to 
 ### Rotating the passphrase
 
 ```bash
-lazyagent passphrase             # prompt for a new one, save, print new bearer token
-lazyagent passphrase --show      # print the current bearer token without changing anything
+lazyagent passphrase             # prompt for a new one and save it
+lazyagent passphrase --show      # print the current bearer token without prompting
 ```
 
 The `passphrase` subcommand is independent of the server — change credentials any time. Any running `lazyagent --api` keeps the old token until you restart it.
@@ -55,30 +55,35 @@ The `passphrase` subcommand is independent of the server — change credentials 
 ### Token derivation algorithm
 
 ```
-salt        = "lazyagent-api-v1"     # public, fixed, domain-separating
+salt        = value from GET /api/auth, also stored as api_salt in config
 iterations  = 600_000
 hash        = SHA-256
 key length  = 32 bytes
 encoding    = base64url, no padding  → 43-char token
 ```
 
-**Test vector** — every client implementation must produce this exact value:
+**Test vector** — every client implementation must produce this exact value for the sample salt:
 
-| Passphrase | Bearer token                                  |
-|------------|-----------------------------------------------|
-| `pippo`    | `zqh9_r0QeYpLiLSQGZMYriIWqNZgZOu3Qc_l7wtraV4` |
+| Passphrase | Salt                 | Bearer token                                  |
+|------------|----------------------|-----------------------------------------------|
+| `pippo`    | `lazyagent-api-v1`   | `zqh9_r0QeYpLiLSQGZMYriIWqNZgZOu3Qc_l7wtraV4` |
 
 #### JavaScript (browser, Web Crypto)
 
 ```javascript
-async function deriveToken(passphrase) {
+async function getAuthInfo(baseURL = "") {
+  const res = await fetch(`${baseURL}/api/auth`);
+  return await res.json();
+}
+
+async function deriveToken(passphrase, salt) {
   const enc = new TextEncoder();
   const baseKey = await crypto.subtle.importKey(
     "raw", enc.encode(passphrase.trim()), { name: "PBKDF2" }, false, ["deriveBits"]
   );
   const bits = await crypto.subtle.deriveBits(
     { name: "PBKDF2", hash: "SHA-256",
-      salt: enc.encode("lazyagent-api-v1"), iterations: 600_000 },
+      salt: enc.encode(salt), iterations: 600_000 },
     baseKey, 32 * 8
   );
   const bytes = new Uint8Array(bits);
@@ -92,15 +97,15 @@ async function deriveToken(passphrase) {
 ```swift
 import CommonCrypto
 
-func deriveToken(_ passphrase: String) -> String {
+func deriveToken(_ passphrase: String, salt: String) -> String {
     let pp = passphrase.trimmingCharacters(in: .whitespaces)
-    let salt = Array("lazyagent-api-v1".utf8)
+    let saltBytes = Array(salt.utf8)
     var key = [UInt8](repeating: 0, count: 32)
     _ = pp.withCString { ppPtr in
         CCKeyDerivationPBKDF(
             CCPBKDFAlgorithm(kCCPBKDF2),
             ppPtr, strlen(ppPtr),
-            salt, salt.count,
+            saltBytes, saltBytes.count,
             CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
             600_000, &key, 32)
     }
@@ -118,10 +123,10 @@ import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.PBEKeySpec
 import android.util.Base64
 
-fun deriveToken(passphrase: String): String {
+fun deriveToken(passphrase: String, salt: String): String {
     val spec = PBEKeySpec(
         passphrase.trim().toCharArray(),
-        "lazyagent-api-v1".toByteArray(Charsets.UTF_8),
+        salt.toByteArray(Charsets.UTF_8),
         600_000, 32 * 8)
     val key = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
         .generateSecret(spec).encoded
@@ -132,12 +137,18 @@ fun deriveToken(passphrase: String): String {
 #### curl / shell
 
 ```bash
-PASSPHRASE='pippo'
-TOKEN=$(printf '%s' "$PASSPHRASE" | python3 -c '
-import sys, hashlib, base64
-pp = sys.stdin.read().strip().encode()
-key = hashlib.pbkdf2_hmac("sha256", pp, b"lazyagent-api-v1", 600_000, dklen=32)
-print(base64.urlsafe_b64encode(key).rstrip(b"=").decode())')
+PASSPHRASE='your-configured-passphrase'
+SALT=$(curl -s http://127.0.0.1:7421/api/auth | python3 -c '
+import json, sys
+print(json.load(sys.stdin)["salt"])')
+TOKEN=$(PASSPHRASE="$PASSPHRASE" SALT="$SALT" python3 - <<'PY'
+import os, hashlib, base64
+salt = os.environ["SALT"].encode()
+pp = os.environ["PASSPHRASE"].strip().encode()
+key = hashlib.pbkdf2_hmac("sha256", pp, salt, 600_000, dklen=32)
+print(base64.urlsafe_b64encode(key).rstrip(b"=").decode())
+PY
+)
 
 curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:7421/api/sessions
 ```
@@ -149,7 +160,7 @@ curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:7421/api/sessions
 | Regular fetch / curl              | `Authorization: Bearer <token>` header           |
 | Browser `EventSource` (SSE)       | `?token=<token>` query string (header not supported) |
 
-The query-string fallback is **only** documented for SSE clients that cannot set custom headers. Avoid it elsewhere — query strings appear in server logs and shell history.
+The query-string fallback is **only accepted** on `/api/events` for SSE clients that cannot set custom headers. Use the `Authorization` header everywhere else; query strings appear in server logs and shell history.
 
 ## Interactive playground
 
@@ -303,9 +314,25 @@ Summary statistics.
 }
 ```
 
+### `GET /api/auth`
+
+Public KDF metadata needed to derive the Bearer token from a passphrase. This endpoint is intentionally unauthenticated; the salt is public and not a secret.
+
+**Response: `200 OK`**
+
+```json
+{
+  "salt": "lazyagent-api-v1-2CwLr3D6GKbVv5m0Pu1nHQ",
+  "iterations": 600000,
+  "key_length": 32,
+  "hash": "SHA-256",
+  "encoding": "base64url-no-padding"
+}
+```
+
 ### `GET /api/config`
 
-Current lazyagent configuration. The `api_passphrase` field is always omitted from the response — the server never echoes the secret back to clients, even authenticated ones.
+Current lazyagent configuration. The `api_passphrase` and `api_salt` fields are omitted from this response; use `GET /api/auth` for public auth metadata. The server never echoes the passphrase back to clients, even authenticated ones.
 
 **Response: `200 OK`**
 
@@ -344,7 +371,8 @@ The `data` JSON contains:
 
 ```javascript
 // EventSource cannot set headers — pass the token in the query string.
-const token = await deriveToken(passphrase);   // see "Token derivation algorithm"
+const { salt } = await getAuthInfo('http://127.0.0.1:7421');
+const token = await deriveToken(passphrase, salt);   // see "Token derivation algorithm"
 const evtSource = new EventSource(
   `http://127.0.0.1:7421/api/events?token=${encodeURIComponent(token)}`
 );
@@ -366,7 +394,9 @@ const res = await fetch('http://127.0.0.1:7421/api/sessions', {
 ```typescript
 import EventSource from 'react-native-sse';
 
-const token = await deriveToken(passphrase);   // see "Token derivation algorithm"
+const auth = await fetch('http://YOUR_HOST:7421/api/auth').then(r => r.json());
+const salt = auth.salt;
+const token = await deriveToken(passphrase, salt);   // see "Token derivation algorithm"
 
 // react-native-sse supports Authorization headers natively.
 const es = new EventSource('http://YOUR_HOST:7421/api/events', {

--- a/docs/interfaces/http-api.md
+++ b/docs/interfaces/http-api.md
@@ -9,13 +9,153 @@ sidebar:
 lazyagent --api
 ```
 
-Starts a read-only HTTP API on `http://127.0.0.1:7421`. If the port is busy the server tries up to 10 sequential ports (7421–7431) and binds to the first available one; the actual address is printed to stderr on startup. Pass `--host` to pin a custom address and disable the fallback.
+Starts an HTTP API on `http://127.0.0.1:7421`. If the port is busy the server tries up to 10 sequential ports (7421–7431) and binds to the first available one; the actual address is printed to stderr on startup. Pass `--host` to pin a custom address and disable the fallback.
 
 ![lazyagent API playground](../../assets/api.png)
 
+## Authentication
+
+All endpoints under `/api/*` require a Bearer token. The token is **derived from a passphrase** with PBKDF2-SHA256 — you set the passphrase once, and any client (mobile app, browser, curl) that knows the passphrase can compute the same token locally.
+
+### First run
+
+```bash
+lazyagent --api
+```
+
+If no passphrase is configured, lazyagent prompts for one (twice, for confirmation), saves it to `~/.config/lazyagent/config.json` under `api_passphrase`, and prints the derived bearer token to stderr:
+
+```
+API authentication enabled.
+Bearer token: zqh9_r0QeYpLiLSQGZMYriIWqNZgZOu3Qc_l7wtraV4
+Use header:   Authorization: Bearer <token>
+```
+
+The token is printed on every subsequent startup too — copy it into clients as needed.
+
+### Non-interactive setup
+
+If `--api` runs without a TTY (e.g. from `launchd`, a service, CI), set the passphrase via env var instead:
+
+```bash
+LAZYAGENT_API_PASSPHRASE='your-passphrase' lazyagent --api
+```
+
+The env var takes precedence over the config file value and is never written to disk.
+
+### Rotating the passphrase
+
+```bash
+lazyagent passphrase             # prompt for a new one, save, print new bearer token
+lazyagent passphrase --show      # print the current bearer token without changing anything
+```
+
+The `passphrase` subcommand is independent of the server — change credentials any time. Any running `lazyagent --api` keeps the old token until you restart it.
+
+### Token derivation algorithm
+
+```
+salt        = "lazyagent-api-v1"     # public, fixed, domain-separating
+iterations  = 600_000
+hash        = SHA-256
+key length  = 32 bytes
+encoding    = base64url, no padding  → 43-char token
+```
+
+**Test vector** — every client implementation must produce this exact value:
+
+| Passphrase | Bearer token                                  |
+|------------|-----------------------------------------------|
+| `pippo`    | `zqh9_r0QeYpLiLSQGZMYriIWqNZgZOu3Qc_l7wtraV4` |
+
+#### JavaScript (browser, Web Crypto)
+
+```javascript
+async function deriveToken(passphrase) {
+  const enc = new TextEncoder();
+  const baseKey = await crypto.subtle.importKey(
+    "raw", enc.encode(passphrase.trim()), { name: "PBKDF2" }, false, ["deriveBits"]
+  );
+  const bits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", hash: "SHA-256",
+      salt: enc.encode("lazyagent-api-v1"), iterations: 600_000 },
+    baseKey, 32 * 8
+  );
+  const bytes = new Uint8Array(bits);
+  let s = ""; for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+```
+
+#### Swift (iOS, CommonCrypto)
+
+```swift
+import CommonCrypto
+
+func deriveToken(_ passphrase: String) -> String {
+    let pp = passphrase.trimmingCharacters(in: .whitespaces)
+    let salt = Array("lazyagent-api-v1".utf8)
+    var key = [UInt8](repeating: 0, count: 32)
+    _ = pp.withCString { ppPtr in
+        CCKeyDerivationPBKDF(
+            CCPBKDFAlgorithm(kCCPBKDF2),
+            ppPtr, strlen(ppPtr),
+            salt, salt.count,
+            CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+            600_000, &key, 32)
+    }
+    return Data(key).base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+```
+
+#### Kotlin (Android, javax.crypto)
+
+```kotlin
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import android.util.Base64
+
+fun deriveToken(passphrase: String): String {
+    val spec = PBEKeySpec(
+        passphrase.trim().toCharArray(),
+        "lazyagent-api-v1".toByteArray(Charsets.UTF_8),
+        600_000, 32 * 8)
+    val key = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        .generateSecret(spec).encoded
+    return Base64.encodeToString(key, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+}
+```
+
+#### curl / shell
+
+```bash
+PASSPHRASE='pippo'
+TOKEN=$(printf '%s' "$PASSPHRASE" | python3 -c '
+import sys, hashlib, base64
+pp = sys.stdin.read().strip().encode()
+key = hashlib.pbkdf2_hmac("sha256", pp, b"lazyagent-api-v1", 600_000, dklen=32)
+print(base64.urlsafe_b64encode(key).rstrip(b"=").decode())')
+
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:7421/api/sessions
+```
+
+### Sending the token
+
+| Use case                          | How                                              |
+|-----------------------------------|--------------------------------------------------|
+| Regular fetch / curl              | `Authorization: Bearer <token>` header           |
+| Browser `EventSource` (SSE)       | `?token=<token>` query string (header not supported) |
+
+The query-string fallback is **only** documented for SSE clients that cannot set custom headers. Avoid it elsewhere — query strings appear in server logs and shell history.
+
 ## Interactive playground
 
-Open **http://127.0.0.1:7421/api** in a browser for the interactive playground. You can try every endpoint, inspect payloads, and connect to the SSE stream with a single click — useful while prototyping a client.
+Open **http://127.0.0.1:7421/api** in a browser for the interactive playground. The page prompts for your passphrase, derives the token in-browser using the same PBKDF2 algorithm, and uses it for every subsequent call. Your passphrase never leaves the page; only the derived token is sent to the server.
+
+The playground HTML page itself is unauthenticated so the browser can load it; all data endpoints behind it require the token.
 
 ## Data freshness
 
@@ -35,7 +175,7 @@ By default the server binds to `127.0.0.1` (localhost only). To expose it on the
 lazyagent --api --host 0.0.0.0:7421
 ```
 
-> ⚠️ **No authentication.** Only expose the API on trusted networks. The API is read-only apart from session renaming, but exposing internals (paths, prompts, token usage) to the open internet is a bad idea.
+The Bearer-token requirement applies regardless of bind address, but the API is **plain HTTP** — anyone on the network can read your traffic. For internet-facing exposure put the server behind an HTTPS reverse proxy (nginx, Caddy, Cloudflare Tunnel).
 
 ## Endpoints
 
@@ -165,7 +305,7 @@ Summary statistics.
 
 ### `GET /api/config`
 
-Current lazyagent configuration.
+Current lazyagent configuration. The `api_passphrase` field is always omitted from the response — the server never echoes the secret back to clients, even authenticated ones.
 
 **Response: `200 OK`**
 
@@ -203,14 +343,21 @@ The `data` JSON contains:
 ### Browser JavaScript
 
 ```javascript
-const evtSource = new EventSource('http://127.0.0.1:7421/api/events');
+// EventSource cannot set headers — pass the token in the query string.
+const token = await deriveToken(passphrase);   // see "Token derivation algorithm"
+const evtSource = new EventSource(
+  `http://127.0.0.1:7421/api/events?token=${encodeURIComponent(token)}`
+);
 
 evtSource.addEventListener('update', (e) => {
   const { sessions, stats } = JSON.parse(e.data);
   console.log(`${stats.active_sessions} active sessions`);
-  sessions.forEach(s => {
-    console.log(`${s.short_name}: ${s.activity}`);
-  });
+  sessions.forEach(s => console.log(`${s.short_name}: ${s.activity}`));
+});
+
+// Other endpoints use the standard Authorization header:
+const res = await fetch('http://127.0.0.1:7421/api/sessions', {
+  headers: { 'Authorization': `Bearer ${token}` }
 });
 ```
 
@@ -219,7 +366,12 @@ evtSource.addEventListener('update', (e) => {
 ```typescript
 import EventSource from 'react-native-sse';
 
-const es = new EventSource('http://YOUR_HOST:7421/api/events');
+const token = await deriveToken(passphrase);   // see "Token derivation algorithm"
+
+// react-native-sse supports Authorization headers natively.
+const es = new EventSource('http://YOUR_HOST:7421/api/events', {
+  headers: { Authorization: `Bearer ${token}` }
+});
 
 es.addEventListener('update', (event) => {
   const { sessions, stats } = JSON.parse(event.data);

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -23,6 +23,7 @@ lazyagent/
 │   ├── pi/                     # pi coding agent JSONL parsing, session discovery
 │   ├── opencode/               # OpenCode SQLite parsing, session discovery
 │   ├── api/                    # HTTP API server (REST + SSE)
+│   ├── apiauth/                # Bearer-token derivation (PBKDF2) + auth middleware
 │   ├── ui/                     # TUI rendering (bubbletea + lipgloss, dark/light themes)
 │   ├── tray/                   # macOS menu bar (Wails v3, build-tagged)
 │   ├── chatops/                # Shared CLI helpers: agent picker, tables, notices, safety

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -26,6 +26,7 @@ lazyagent reads `~/.config/lazyagent/config.json` (or `$XDG_CONFIG_HOME/lazyagen
     "pi": true
   },
   "claude_dirs": [],
+  "api_salt": "lazyagent-api-v1-2CwLr3D6GKbVv5m0Pu1nHQ",
   "tui": {
     "theme": "dark"
   }
@@ -92,11 +93,15 @@ When empty, lazyagent auto-detects from the `CLAUDE_CONFIG_DIR` environment vari
 
 ### `api_passphrase`
 
-Default: `""` (empty — auth not yet configured). The passphrase used to derive the bearer token that protects the [HTTP API](../interfaces/http-api.md). Created interactively on the first run of `lazyagent --api`; you can edit it manually here at any time, and the next API server startup will derive a new token from it.
+Default: `""` (empty — auth not yet configured). The passphrase used with `api_salt` to derive the bearer token that protects the [HTTP API](../interfaces/http-api.md). Created interactively on the first run of `lazyagent --api`; values shorter than 12 characters are rejected. You can edit it manually here at any time, and the next API server startup will derive a new token from it.
 
-Anyone who can read this file can talk to your API. lazyagent does not change file permissions on your behalf — protect your home directory the same way you protect any other secret-bearing config (`~/.ssh`, `~/.aws`, etc).
+Anyone who can read this file can talk to your API. lazyagent writes the config file with `0600` permissions and the config directory with `0700`, but you should still protect your home directory the same way you protect any other secret-bearing config (`~/.ssh`, `~/.aws`, etc).
 
 The `LAZYAGENT_API_PASSPHRASE` environment variable overrides this field at startup and is never persisted to disk — useful for CI or service-managed deployments.
+
+### `api_salt`
+
+Default: generated once per install. Public salt used with `api_passphrase` for PBKDF2 token derivation. It is also available from `GET /api/auth` so clients can derive tokens without reading this file. It is not secret, but keep it stable; changing it invalidates previously derived tokens until clients fetch the new salt.
 
 ### `tui.theme`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -90,6 +90,14 @@ Default: `[]`. Extra Claude base directories to scan. Each entry must be a direc
 
 When empty, lazyagent auto-detects from the `CLAUDE_CONFIG_DIR` environment variable, falling back to `~/.claude`. Use this field if you keep Claude sessions somewhere non-standard and want lazyagent to pick them up without setting env vars every time.
 
+### `api_passphrase`
+
+Default: `""` (empty — auth not yet configured). The passphrase used to derive the bearer token that protects the [HTTP API](../interfaces/http-api.md). Created interactively on the first run of `lazyagent --api`; you can edit it manually here at any time, and the next API server startup will derive a new token from it.
+
+Anyone who can read this file can talk to your API. lazyagent does not change file permissions on your behalf — protect your home directory the same way you protect any other secret-bearing config (`~/.ssh`, `~/.aws`, etc).
+
+The `LAZYAGENT_API_PASSPHRASE` environment variable overrides this field at startup and is never persisted to disk — useful for CI or service-managed deployments.
+
 ### `tui.theme`
 
 Default: `"dark"`. Supported values:

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -57,6 +57,7 @@ sidebar:
 - ✅ Custom bind address
 - ✅ Combinable with TUI and GUI
 - ✅ Session rename endpoints
+- ✅ Passphrase-based Bearer auth (PBKDF2-SHA256)
 
 ## v0.5 — Multi-agent support
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -63,13 +63,15 @@ On non-macOS systems `--gui` prints an error. See [macOS GUI](../interfaces/maco
 
 ### `--api`
 
-Start the read-only HTTP API server.
+Start the HTTP API server.
 
 ```bash
 lazyagent --api              # default bind: 127.0.0.1:7421
 lazyagent --api --host :8080 # custom port, localhost only
 lazyagent --api --host 0.0.0.0:7421   # expose on the network
 ```
+
+On the very first run, `--api` prompts for a passphrase, saves it to `~/.config/lazyagent/config.json`, and prints the derived bearer token to stderr. On subsequent runs it just prints the token. Set `LAZYAGENT_API_PASSPHRASE` in the environment to override the configured value (useful for CI / launchd).
 
 If the chosen port is busy, the default bind falls back across `7421`–`7431`; when `--host` is set, there is no fallback. Full reference: [HTTP API](../interfaces/http-api.md).
 
@@ -136,13 +138,14 @@ Prints the full usage text, including short keybinding reference.
 
 ## Subcommand dispatch
 
-When the first positional argument is `prune`, `compact`, `search`, or `limits`, lazyagent switches into subcommand mode — root-level flags are ignored and the subcommand parses its own set.
+When the first positional argument is `prune`, `compact`, `search`, `limits`, or `passphrase`, lazyagent switches into subcommand mode — root-level flags are ignored and the subcommand parses its own set.
 
 ```bash
 lazyagent prune --days 30          # prune subcommand
 lazyagent compact --agent claude   # compact subcommand
 lazyagent search --agent codex api # search subcommand
 lazyagent limits --agent claude    # limits subcommand
+lazyagent passphrase               # rotate the API passphrase
 lazyagent --agent claude prune     # ❌ wrong: prune is not a flag value
 ```
 
@@ -175,6 +178,19 @@ lazyagent limits --agent codex   # only Codex
 Claude data comes from `/api/oauth/usage` on `api.anthropic.com` — the same undocumented endpoint Claude Code's `/status` calls. Codex data is read from the latest rollout JSONL under `~/.codex/sessions/` (no network call).
 
 Full reference, including disclaimers and token-resolution order: [`limits`](../maintenance/limits.md).
+
+### `passphrase`
+
+`passphrase` sets or rotates the passphrase that protects the [HTTP API](../interfaces/http-api.md). It runs without starting the server, so you can change credentials at any time and let any future `lazyagent --api` pick up the new value.
+
+```bash
+lazyagent passphrase             # interactive prompt, save, print new bearer token
+lazyagent passphrase --show      # print the bearer token for the current passphrase
+```
+
+`passphrase` (no flags) always prompts (double-entry confirmation), even if a passphrase is already configured — it's a rotation, not a setup. `--show` is read-only: it derives the token from the env var if `LAZYAGENT_API_PASSPHRASE` is set, otherwise from the configured value, and exits without writing.
+
+Restart any running `lazyagent --api` after rotating: the server reads the passphrase at startup, so it keeps using the old token until restarted.
 
 ## Common invocations
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -190,6 +190,8 @@ lazyagent passphrase --show      # print the bearer token for the current passph
 
 `passphrase` (no flags) always prompts (double-entry confirmation), even if a passphrase is already configured — it's a rotation, not a setup. `--show` is read-only: it derives the token from the env var if `LAZYAGENT_API_PASSPHRASE` is set, otherwise from the configured value, and exits without writing.
 
+`--show` writes the raw token to **stdout** (single line, no prefix) so it can be captured in a pipe: `TOKEN=$(lazyagent passphrase --show)`. Diagnostics (passphrase source, missing-config hints) go to stderr. Every other invocation of the subcommand keeps all output on stderr.
+
 Restart any running `lazyagent --api` after rotating: the server reads the passphrase at startup, so it keeps using the old token until restarted.
 
 ## Common invocations

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -71,7 +71,7 @@ lazyagent --api --host :8080 # custom port, localhost only
 lazyagent --api --host 0.0.0.0:7421   # expose on the network
 ```
 
-On the very first run, `--api` prompts for a passphrase, saves it to `~/.config/lazyagent/config.json`, and prints the derived bearer token to stderr. On subsequent runs it just prints the token. Set `LAZYAGENT_API_PASSPHRASE` in the environment to override the configured value (useful for CI / launchd).
+On the very first interactive run, `--api` prompts for a passphrase, saves it to `~/.config/lazyagent/config.json`, and prints the derived bearer token to stderr once. On subsequent runs it does not print the token; use `lazyagent passphrase --show` when you explicitly need it. Set `LAZYAGENT_API_PASSPHRASE` in the environment to override the configured value (useful for CI / launchd).
 
 If the chosen port is busy, the default bind falls back across `7421`–`7431`; when `--host` is set, there is no fallback. Full reference: [HTTP API](../interfaces/http-api.md).
 
@@ -184,13 +184,13 @@ Full reference, including disclaimers and token-resolution order: [`limits`](../
 `passphrase` sets or rotates the passphrase that protects the [HTTP API](../interfaces/http-api.md). It runs without starting the server, so you can change credentials at any time and let any future `lazyagent --api` pick up the new value.
 
 ```bash
-lazyagent passphrase             # interactive prompt, save, print new bearer token
+lazyagent passphrase             # interactive prompt and save
 lazyagent passphrase --show      # print the bearer token for the current passphrase
 ```
 
-`passphrase` (no flags) always prompts (double-entry confirmation), even if a passphrase is already configured — it's a rotation, not a setup. `--show` is read-only: it derives the token from the env var if `LAZYAGENT_API_PASSPHRASE` is set, otherwise from the configured value, and exits without writing.
+`passphrase` (no flags) always prompts (double-entry confirmation), even if a passphrase is already configured — it's a rotation, not a setup. `--show` derives the token from the env var if `LAZYAGENT_API_PASSPHRASE` is set, otherwise from the configured value, without prompting or changing the passphrase.
 
-`--show` writes the raw token to **stdout** (single line, no prefix) so it can be captured in a pipe: `TOKEN=$(lazyagent passphrase --show)`. Diagnostics (passphrase source, missing-config hints) go to stderr. Every other invocation of the subcommand keeps all output on stderr.
+`--show` writes the raw token to **stdout** (single line, no prefix) so it can be captured in a pipe: `TOKEN=$(lazyagent passphrase --show)`. Diagnostics (passphrase source, missing-config hints) go to stderr. Other invocations do not print the token.
 
 Restart any running `lazyagent --api` after rotating: the server reads the passphrase at startup, so it keeps using the old token until restarted.
 

--- a/docs/usage/recipes.md
+++ b/docs/usage/recipes.md
@@ -44,7 +44,7 @@ lazyagent --api --host 0.0.0.0:7421
 
 The API exposes an SSE stream that updates in real time. See the [React Native example](../interfaces/http-api.md#react-native) for a full client snippet.
 
-> ⚠️ **No authentication**. Only expose the API on networks you trust.
+The mobile app derives the bearer token from the same passphrase you configured on the laptop, so pairing is just "type the passphrase once". Traffic is plain HTTP — keep it on a trusted network or front it with HTTPS.
 
 ## Check rate-limit usage before a long run
 
@@ -64,16 +64,25 @@ Claude data comes from an undocumented endpoint Anthropic uses for `/status` —
 When you just want to see active sessions without opening a full UI:
 
 ```bash
-curl -s http://127.0.0.1:7421/api/stats
+# Derive the bearer token once, reuse it. See "Token derivation algorithm"
+# in the HTTP API reference for other languages.
+TOKEN=$(printf '%s' "$LAZYAGENT_API_PASSPHRASE" | python3 -c '
+import sys, hashlib, base64
+pp = sys.stdin.read().strip().encode()
+key = hashlib.pbkdf2_hmac("sha256", pp, b"lazyagent-api-v1", 600_000, dklen=32)
+print(base64.urlsafe_b64encode(key).rstrip(b"=").decode())')
+
+curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:7421/api/stats
 # → {"total_sessions":5,"active_sessions":2,"window_minutes":30}
 
-curl -s 'http://127.0.0.1:7421/api/sessions?filter=active' \
+curl -s -H "Authorization: Bearer $TOKEN" \
+  'http://127.0.0.1:7421/api/sessions?filter=active' \
   | jq -r '.[] | "\(.activity)\t\(.short_name)"'
 # → thinking  …/projects/myapp
 # → writing   …/projects/worker
 ```
 
-Requires that `lazyagent --api` is running somewhere on your machine.
+Requires that `lazyagent --api` is running somewhere on your machine and that you've configured an API passphrase. See [HTTP API → Authentication](../interfaces/http-api.md#authentication).
 
 ## Find sessions waiting for your input
 
@@ -81,7 +90,8 @@ Requires that `lazyagent --api` is running somewhere on your machine.
 # TUI: press `f` until the filter lands on "waiting"
 
 # API:
-curl -s 'http://127.0.0.1:7421/api/sessions?filter=waiting' \
+curl -s -H "Authorization: Bearer $TOKEN" \
+  'http://127.0.0.1:7421/api/sessions?filter=waiting' \
   | jq '[.[].short_name]'
 ```
 
@@ -157,7 +167,8 @@ You renamed a session via the TUI and regret it:
 ```bash
 # TUI / GUI: press `r` on the session, submit empty → resets to default
 # API:
-curl -X DELETE http://127.0.0.1:7421/api/sessions/<session-id>/name
+curl -X DELETE -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:7421/api/sessions/<session-id>/name
 ```
 
 Session names live in `~/.config/lazyagent/session-names.json` and are shared across all interfaces in real time.

--- a/docs/usage/recipes.md
+++ b/docs/usage/recipes.md
@@ -44,7 +44,7 @@ lazyagent --api --host 0.0.0.0:7421
 
 The API exposes an SSE stream that updates in real time. See the [React Native example](../interfaces/http-api.md#react-native) for a full client snippet.
 
-The mobile app derives the bearer token from the same passphrase you configured on the laptop, so pairing is just "type the passphrase once". Traffic is plain HTTP — keep it on a trusted network or front it with HTTPS.
+The mobile app fetches the public salt from `/api/auth`, then derives the bearer token from the same passphrase you configured on the laptop, so pairing is just "type the passphrase once". Traffic is plain HTTP — keep it on a trusted network or front it with HTTPS.
 
 ## Check rate-limit usage before a long run
 
@@ -64,13 +64,8 @@ Claude data comes from an undocumented endpoint Anthropic uses for `/status` —
 When you just want to see active sessions without opening a full UI:
 
 ```bash
-# Derive the bearer token once, reuse it. See "Token derivation algorithm"
-# in the HTTP API reference for other languages.
-TOKEN=$(printf '%s' "$LAZYAGENT_API_PASSPHRASE" | python3 -c '
-import sys, hashlib, base64
-pp = sys.stdin.read().strip().encode()
-key = hashlib.pbkdf2_hmac("sha256", pp, b"lazyagent-api-v1", 600_000, dklen=32)
-print(base64.urlsafe_b64encode(key).rstrip(b"=").decode())')
+# Print the bearer token explicitly, then reuse it.
+TOKEN=$(lazyagent passphrase --show)
 
 curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:7421/api/stats
 # → {"total_sessions":5,"active_sessions":2,"window_minutes":30}

--- a/frontend/src/bindings/github.com/illegalstudio/lazyagent/internal/core/models.ts
+++ b/frontend/src/bindings/github.com/illegalstudio/lazyagent/internal/core/models.ts
@@ -25,6 +25,12 @@ export class Config {
      * — `lazyagent --api` will prompt for one on first run.
      */
     "api_passphrase"?: string;
+    /**
+     * APISalt is a public, per-install salt used with APIPassphrase when
+     * deriving the bearer token. It is not secret, but must stay stable so
+     * clients can derive the same token from the same passphrase.
+     */
+    "api_salt"?: string;
 
     /** Creates a new Config instance. */
     constructor($$source: Partial<Config> = {}) {

--- a/frontend/src/bindings/github.com/illegalstudio/lazyagent/internal/core/models.ts
+++ b/frontend/src/bindings/github.com/illegalstudio/lazyagent/internal/core/models.ts
@@ -19,6 +19,13 @@ export class Config {
     "claude_dirs"?: string[];
     "tui": TUIConfig;
 
+    /**
+     * APIPassphrase is the secret used to derive the bearer token that
+     * protects the HTTP API. Empty means the API has not been configured yet
+     * — `lazyagent --api` will prompt for one on first run.
+     */
+    "api_passphrase"?: string;
+
     /** Creates a new Config instance. */
     constructor($$source: Partial<Config> = {}) {
         if (!("window_minutes" in $$source)) {

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,11 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/wailsapp/wails/v3 v3.0.0-alpha.74
+	golang.org/x/crypto v0.49.0
+	golang.org/x/term v0.41.0
 	modernc.org/sqlite v1.47.0
 )
 
@@ -48,7 +51,6 @@ require (
 	github.com/lmittmann/tint v1.1.3 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.21 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
@@ -64,7 +66,6 @@ require (
 	github.com/wailsapp/go-webview2 v1.0.23 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
@@ -27,6 +29,8 @@ github.com/charmbracelet/x/ansi v0.11.6 h1:GhV21SiDz/45W9AnV2R61xZMRri5NlLnl6CVF
 github.com/charmbracelet/x/ansi v0.11.6/go.mod h1:2JNYLgQUsyqaiLovhU2Rv/pb8r6ydXKS3NIttu3VGZQ=
 github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMxoFPAIztPI=
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=

--- a/internal/api/playground.go
+++ b/internal/api/playground.go
@@ -9,7 +9,8 @@ import (
 )
 
 // playgroundHTML is rendered with PBKDF2 parameters injected as JS constants
-// so the in-page client uses exactly the same algorithm as the server.
+// so the in-page client uses exactly the same algorithm and per-install salt as
+// the server.
 const playgroundHTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -127,7 +128,7 @@ const playgroundHTML = `<!DOCTYPE html>
 
 <script>
 // PBKDF2 parameters — MUST match the server constants in internal/apiauth/derive.go.
-const KDF_SALT = "__SALT__";
+const KDF_SALT = __SALT__;
 const KDF_ITER = __ITER__;
 const KDF_LEN  = __LEN__;
 
@@ -319,13 +320,13 @@ function stopSSE() {
 
 func (s *Server) handlePlayground(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte(renderedPlayground))
+	_, _ = w.Write([]byte(renderPlayground(s.authSalt)))
 }
 
-// renderedPlayground is the playground HTML with KDF parameters substituted in.
-// Computed once at package init since the parameters are constants.
-var renderedPlayground = strings.NewReplacer(
-	"__SALT__", apiauth.Salt,
-	"__ITER__", strconv.Itoa(apiauth.Iterations),
-	"__LEN__", strconv.Itoa(apiauth.KeyLength),
-).Replace(playgroundHTML)
+func renderPlayground(salt string) string {
+	return strings.NewReplacer(
+		"__SALT__", strconv.Quote(salt),
+		"__ITER__", strconv.Itoa(apiauth.Iterations),
+		"__LEN__", strconv.Itoa(apiauth.KeyLength),
+	).Replace(playgroundHTML)
+}

--- a/internal/api/playground.go
+++ b/internal/api/playground.go
@@ -131,6 +131,10 @@ const KDF_SALT = "__SALT__";
 const KDF_ITER = __ITER__;
 const KDF_LEN  = __LEN__;
 
+// The token sits in a global so unlocked endpoints can use it without
+// re-deriving. The page is the only HTML the server ever serves and loads
+// no third-party scripts, so XSS exfil isn't a concern today — but if a
+// future change pulls in any external script (analytics, CDN), reconsider.
 let bearerToken = "";  // populated by unlock()
 let evtSource = null;
 

--- a/internal/api/playground.go
+++ b/internal/api/playground.go
@@ -1,7 +1,15 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+	"strings"
 
+	"github.com/illegalstudio/lazyagent/internal/apiauth"
+)
+
+// playgroundHTML is rendered with PBKDF2 parameters injected as JS constants
+// so the in-page client uses exactly the same algorithm as the server.
 const playgroundHTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -13,10 +21,25 @@ const playgroundHTML = `<!DOCTYPE html>
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
          background: #1e1e2e; color: #cdd6f4; padding: 2rem; line-height: 1.6; }
   h1 { color: #89b4fa; margin-bottom: .5rem; font-size: 1.5rem; }
-  p.sub { color: #6c7086; margin-bottom: 2rem; font-size: .9rem; }
+  p.sub { color: #6c7086; margin-bottom: 1rem; font-size: .9rem; }
+  .auth { background: #313244; border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1.5rem; }
+  .auth label { display:block; font-size:.85rem; color:#a6adc8; margin-bottom:.35rem; }
+  .auth input[type=password] { width: 100%; padding: .5rem .75rem; border-radius: 6px;
+     border: 1px solid #45475a; background: #181825; color: #cdd6f4; font-family: monospace;
+     font-size: .9rem; }
+  .auth .row { display: flex; gap: .5rem; align-items: center; margin-top: .5rem; }
+  .auth button { background: #89b4fa; color: #1e1e2e; border: none; padding: .5rem 1rem;
+     border-radius: 6px; cursor: pointer; font-weight: 600; }
+  .auth button:disabled { opacity: .5; cursor: wait; }
+  .auth .status { font-size: .8rem; color: #6c7086; }
+  .auth .status.ready { color: #a6e3a1; }
+  .auth .status.fail { color: #f38ba8; }
+  .auth code { background: #181825; padding: 1px 6px; border-radius: 4px;
+     font-size: .8rem; color: #f5e0dc; word-break: break-all; }
   .endpoint { background: #313244; border-radius: 8px; padding: 1rem 1.25rem;
               margin-bottom: 1rem; cursor: pointer; transition: background .15s; }
   .endpoint:hover { background: #45475a; }
+  .endpoint.locked { opacity: .5; cursor: not-allowed; }
   .method { display: inline-block; font-weight: 700; font-size: .8rem; padding: 2px 8px;
             border-radius: 4px; margin-right: .75rem; }
   .get { background: #a6e3a1; color: #1e1e2e; }
@@ -40,46 +63,59 @@ const playgroundHTML = `<!DOCTYPE html>
 </head>
 <body>
 <h1>lazyagent API</h1>
-<p class="sub">Click an endpoint to test it. All responses are JSON.</p>
+<p class="sub">Enter your passphrase below — the same one in your config — to derive the bearer token. Your passphrase never leaves this page; only the derived token is sent to the server.</p>
 
-<div class="endpoint" onclick="fetchEndpoint('/api/sessions')">
+<div class="auth">
+  <label for="pp">API passphrase</label>
+  <input type="password" id="pp" placeholder="Type your passphrase…" autocomplete="off">
+  <div class="row">
+    <button id="unlock" onclick="unlock()">Unlock</button>
+    <span class="status" id="auth-status">Locked</span>
+  </div>
+  <div class="row" id="token-row" style="display:none">
+    <span class="status">Token:</span>
+    <code id="token-display"></code>
+  </div>
+</div>
+
+<div class="endpoint locked" data-locked="1" onclick="fetchEndpoint('/api/sessions')">
   <span class="method get">GET</span>
   <span class="path">/api/sessions</span>
   <span class="path" style="color:#6c7086">?search=&amp;filter=</span>
   <div class="desc">List all visible sessions (filterable by search query and activity type)</div>
 </div>
 
-<div class="endpoint" onclick="fetchEndpoint('/api/sessions/{id}')">
+<div class="endpoint locked" data-locked="1" onclick="fetchEndpoint('/api/sessions/{id}')">
   <span class="method get">GET</span>
   <span class="path">/api/sessions/{id}</span>
   <div class="desc">Get full session detail (tokens, tools, conversation)</div>
 </div>
 
-<div class="endpoint" onclick="renameSession()">
+<div class="endpoint locked" data-locked="1" onclick="renameSession()">
   <span class="method put">PUT</span>
   <span class="path">/api/sessions/{id}/name</span>
   <div class="desc">Rename a session (JSON body: {"name": "..."}). Empty name resets.</div>
 </div>
 
-<div class="endpoint" onclick="deleteSessionName()">
+<div class="endpoint locked" data-locked="1" onclick="deleteSessionName()">
   <span class="method delete">DELETE</span>
   <span class="path">/api/sessions/{id}/name</span>
   <div class="desc">Remove custom name from a session (reset to path)</div>
 </div>
 
-<div class="endpoint" onclick="fetchEndpoint('/api/stats')">
+<div class="endpoint locked" data-locked="1" onclick="fetchEndpoint('/api/stats')">
   <span class="method get">GET</span>
   <span class="path">/api/stats</span>
   <div class="desc">Summary stats: total sessions, active count, time window</div>
 </div>
 
-<div class="endpoint" onclick="fetchEndpoint('/api/config')">
+<div class="endpoint locked" data-locked="1" onclick="fetchEndpoint('/api/config')">
   <span class="method get">GET</span>
   <span class="path">/api/config</span>
   <div class="desc">Current lazyagent configuration</div>
 </div>
 
-<div class="endpoint" onclick="toggleSSE()">
+<div class="endpoint locked" data-locked="1" onclick="toggleSSE()">
   <span class="method get sse-badge">SSE</span>
   <span class="path">/api/events</span>
   <span id="sse-status" class="disconnected">disconnected</span>
@@ -90,14 +126,89 @@ const playgroundHTML = `<!DOCTYPE html>
 <div id="output"></div>
 
 <script>
+// PBKDF2 parameters — MUST match the server constants in internal/apiauth/derive.go.
+const KDF_SALT = "__SALT__";
+const KDF_ITER = __ITER__;
+const KDF_LEN  = __LEN__;
+
+let bearerToken = "";  // populated by unlock()
 let evtSource = null;
 
+async function deriveToken(passphrase) {
+  passphrase = passphrase.trim();
+  if (!passphrase) return "";
+  const enc = new TextEncoder();
+  const baseKey = await crypto.subtle.importKey(
+    "raw", enc.encode(passphrase), { name: "PBKDF2" }, false, ["deriveBits"]
+  );
+  const bits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", hash: "SHA-256", salt: enc.encode(KDF_SALT), iterations: KDF_ITER },
+    baseKey,
+    KDF_LEN * 8
+  );
+  return base64url(new Uint8Array(bits));
+}
+
+function base64url(bytes) {
+  let s = "";
+  for (const b of bytes) s += String.fromCharCode(b);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function unlock() {
+  const btn = document.getElementById("unlock");
+  const status = document.getElementById("auth-status");
+  const passphrase = document.getElementById("pp").value;
+  if (!passphrase.trim()) { status.textContent = "Enter a passphrase"; status.className = "status fail"; return; }
+  btn.disabled = true;
+  status.textContent = "Deriving token…"; status.className = "status";
+  try {
+    const t = await deriveToken(passphrase);
+    // Probe an endpoint to confirm the token is correct.
+    const r = await fetch("/api/stats", { headers: { "Authorization": "Bearer " + t } });
+    if (r.status === 401) {
+      status.textContent = "Wrong passphrase"; status.className = "status fail";
+      btn.disabled = false; return;
+    }
+    if (!r.ok) {
+      status.textContent = "Server error " + r.status; status.className = "status fail";
+      btn.disabled = false; return;
+    }
+    bearerToken = t;
+    status.textContent = "Unlocked"; status.className = "status ready";
+    document.getElementById("token-display").textContent = t;
+    document.getElementById("token-row").style.display = "flex";
+    document.querySelectorAll(".endpoint.locked").forEach(el => {
+      el.classList.remove("locked");
+      el.removeAttribute("data-locked");
+    });
+  } catch (e) {
+    status.textContent = "Error: " + e.message; status.className = "status fail";
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+document.addEventListener("keydown", function(e) {
+  if (e.key === "Enter" && document.activeElement && document.activeElement.id === "pp") {
+    e.preventDefault(); unlock();
+  }
+});
+
+function requireToken() {
+  if (!bearerToken) {
+    showResult("(locked)", { error: "Unlock with your passphrase first." });
+    return false;
+  }
+  return true;
+}
+
 async function fetchEndpoint(path) {
+  if (!requireToken()) return;
   stopSSE();
   if (path.includes('{id}')) {
-    // Fetch sessions first to get a real ID.
     try {
-      const res = await fetch('/api/sessions');
+      const res = await fetch('/api/sessions', { headers: { "Authorization": "Bearer " + bearerToken } });
       const sessions = await res.json();
       if (sessions.length === 0) {
         showResult(path, {error: 'No sessions available. Start a Claude Code session first.'});
@@ -110,7 +221,7 @@ async function fetchEndpoint(path) {
     }
   }
   try {
-    const res = await fetch(path);
+    const res = await fetch(path, { headers: { "Authorization": "Bearer " + bearerToken } });
     const data = await res.json();
     showResult(path, data);
   } catch(e) {
@@ -130,6 +241,7 @@ function showResult(path, data) {
 }
 
 function toggleSSE() {
+  if (!requireToken()) return;
   if (evtSource) { stopSSE(); return; }
   document.getElementById('output').innerHTML =
     '<h2>/api/events (live)</h2><pre class="sse-log" id="sse-log"></pre>';
@@ -137,7 +249,8 @@ function toggleSSE() {
   document.getElementById('sse-status').className = 'disconnected';
   document.getElementById('sse-stop').style.display = 'inline-block';
 
-  evtSource = new EventSource('/api/events');
+  // EventSource cannot send Authorization headers; use ?token= fallback.
+  evtSource = new EventSource('/api/events?token=' + encodeURIComponent(bearerToken));
   evtSource.addEventListener('update', function(e) {
     document.getElementById('sse-status').textContent = 'connected';
     document.getElementById('sse-status').className = 'connected';
@@ -153,13 +266,14 @@ function toggleSSE() {
 }
 
 async function getFirstSessionId() {
-  const res = await fetch('/api/sessions');
+  const res = await fetch('/api/sessions', { headers: { "Authorization": "Bearer " + bearerToken } });
   const sessions = await res.json();
   if (sessions.length === 0) return null;
   return sessions[0].session_id;
 }
 
 async function renameSession() {
+  if (!requireToken()) return;
   stopSSE();
   try {
     const id = await getFirstSessionId();
@@ -167,7 +281,8 @@ async function renameSession() {
     var name = prompt('Enter custom name (empty to reset):');
     if (name === null) return;
     const res = await fetch('/api/sessions/' + id + '/name', {
-      method: 'PUT', headers: {'Content-Type': 'application/json'},
+      method: 'PUT',
+      headers: {'Content-Type': 'application/json', "Authorization": "Bearer " + bearerToken},
       body: JSON.stringify({name: name})
     });
     showResult('PUT /api/sessions/' + id + '/name', await res.json());
@@ -175,11 +290,15 @@ async function renameSession() {
 }
 
 async function deleteSessionName() {
+  if (!requireToken()) return;
   stopSSE();
   try {
     const id = await getFirstSessionId();
     if (!id) { showResult('DELETE /api/sessions/{id}/name', {error: 'No sessions available.'}); return; }
-    const res = await fetch('/api/sessions/' + id + '/name', {method: 'DELETE'});
+    const res = await fetch('/api/sessions/' + id + '/name', {
+      method: 'DELETE',
+      headers: { "Authorization": "Bearer " + bearerToken }
+    });
     showResult('DELETE /api/sessions/' + id + '/name', await res.json());
   } catch(e) { showResult('DELETE /api/sessions/{id}/name', {error: e.message}); }
 }
@@ -196,5 +315,13 @@ function stopSSE() {
 
 func (s *Server) handlePlayground(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(playgroundHTML))
+	_, _ = w.Write([]byte(renderedPlayground))
 }
+
+// renderedPlayground is the playground HTML with KDF parameters substituted in.
+// Computed once at package init since the parameters are constants.
+var renderedPlayground = strings.NewReplacer(
+	"__SALT__", apiauth.Salt,
+	"__ITER__", strconv.Itoa(apiauth.Iterations),
+	"__LEN__", strconv.Itoa(apiauth.KeyLength),
+).Replace(playgroundHTML)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -59,6 +59,12 @@ func New(host string, provider core.SessionProvider, bearerToken string) (*Serve
 	if bearerToken != "" {
 		auth := apiauth.Middleware(bearerToken, map[string]bool{"/api": true})
 		handler = auth(handler)
+	} else {
+		// Surface accidental misuse: production callers always pass a token,
+		// only tests and explicit opt-outs land here. A loud line in the log
+		// makes a misconfigured deployment obvious instead of silently
+		// running an open API.
+		log.Printf("WARNING: API server starting WITHOUT authentication — every /api/* endpoint is reachable")
 	}
 	s.srv = &http.Server{
 		Handler:           corsMiddleware(handler),

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -196,7 +196,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,8 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/illegalstudio/lazyagent/internal/model"
+	"github.com/illegalstudio/lazyagent/internal/apiauth"
 	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
 )
 
 // DefaultPort is the preferred port. If busy, the server tries sequential ports.
@@ -36,7 +37,14 @@ type Server struct {
 // New creates a new API server.
 // If host is non-empty it binds to that address (e.g. ":7421" or "0.0.0.0:7421").
 // If host is empty it binds to 127.0.0.1 on DefaultPort with fallback.
-func New(host string, provider core.SessionProvider) (*Server, error) {
+//
+// bearerToken is the expected Bearer token. When non-empty, every request to
+// /api/* is rejected with 401 unless it carries Authorization: Bearer <token>
+// (or ?token=<token> as a fallback for SSE EventSource clients). The
+// playground HTML at GET /api is exempt so a browser can load it and ask the
+// user for the passphrase. An empty token disables auth entirely (used only
+// by tests and by callers that explicitly opt out).
+func New(host string, provider core.SessionProvider, bearerToken string) (*Server, error) {
 	cfg := core.LoadConfig()
 	manager := core.NewSessionManager(cfg.WindowMinutes, provider)
 
@@ -46,8 +54,14 @@ func New(host string, provider core.SessionProvider) (*Server, error) {
 	}
 	s.mux = http.NewServeMux()
 	s.routes()
+
+	var handler http.Handler = s.mux
+	if bearerToken != "" {
+		auth := apiauth.Middleware(bearerToken, map[string]bool{"/api": true})
+		handler = auth(handler)
+	}
 	s.srv = &http.Server{
-		Handler:           corsMiddleware(s.mux),
+		Handler:           corsMiddleware(handler),
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
 		MaxHeaderBytes:    1 << 20, // 1 MiB
@@ -273,7 +287,12 @@ func (s *Server) handleGetStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, core.LoadConfig())
+	cfg := core.LoadConfig()
+	// Never expose the passphrase: even a holder of the bearer token has no
+	// reason to need it back, and clients shouldn't be able to round-trip it
+	// through a write to /api/config either (we don't accept writes today).
+	cfg.APIPassphrase = ""
+	writeJSON(w, http.StatusOK, cfg)
 }
 
 func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,10 +24,11 @@ const maxPortAttempts = 10
 
 // Server is the lazyagent HTTP API server.
 type Server struct {
-	manager *core.SessionManager
-	mux     *http.ServeMux
-	srv     *http.Server
-	ln      net.Listener
+	manager  *core.SessionManager
+	mux      *http.ServeMux
+	srv      *http.Server
+	ln       net.Listener
+	authSalt string
 
 	// SSE subscribers.
 	ssemu   sync.Mutex
@@ -41,23 +42,33 @@ type Server struct {
 // bearerToken is the expected Bearer token. When non-empty, every request to
 // /api/* is rejected with 401 unless it carries Authorization: Bearer <token>
 // (or ?token=<token> as a fallback for SSE EventSource clients). The
-// playground HTML at GET /api is exempt so a browser can load it and ask the
-// user for the passphrase. An empty token disables auth entirely (used only
-// by tests and by callers that explicitly opt out).
-func New(host string, provider core.SessionProvider, bearerToken string) (*Server, error) {
+// playground HTML at GET /api and the public KDF metadata at GET /api/auth are
+// exempt so clients can derive the token from the user's passphrase. An empty
+// token disables auth entirely (used only by tests and by callers that
+// explicitly opt out).
+func New(host string, provider core.SessionProvider, bearerToken, authSalt string) (*Server, error) {
+	authSalt = strings.TrimSpace(authSalt)
+	if authSalt == "" {
+		authSalt = apiauth.SaltPrefix
+	}
+
 	cfg := core.LoadConfig()
 	manager := core.NewSessionManager(cfg.WindowMinutes, provider)
 
 	s := &Server{
-		manager: manager,
-		sseSubs: make(map[chan struct{}]struct{}),
+		manager:  manager,
+		authSalt: authSalt,
+		sseSubs:  make(map[chan struct{}]struct{}),
 	}
 	s.mux = http.NewServeMux()
 	s.routes()
 
 	var handler http.Handler = s.mux
 	if bearerToken != "" {
-		auth := apiauth.Middleware(bearerToken, map[string]bool{"/api": true})
+		auth := apiauth.Middleware(bearerToken, map[string]bool{
+			"/api":      true,
+			"/api/auth": true,
+		})
 		handler = auth(handler)
 	} else {
 		// Surface accidental misuse: production callers always pass a token,
@@ -215,6 +226,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api", s.handlePlayground)
+	s.mux.HandleFunc("GET /api/auth", s.handleAuthInfo)
 	s.mux.HandleFunc("GET /api/sessions", s.handleGetSessions)
 	s.mux.HandleFunc("GET /api/sessions/{id}", s.handleGetSession)
 	s.mux.HandleFunc("PUT /api/sessions/{id}/name", s.handleSetSessionName)
@@ -292,12 +304,23 @@ func (s *Server) handleGetStats(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handleAuthInfo(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, AuthInfo{
+		Salt:       s.authSalt,
+		Iterations: apiauth.Iterations,
+		KeyLength:  apiauth.KeyLength,
+		Hash:       "SHA-256",
+		Encoding:   "base64url-no-padding",
+	})
+}
+
 func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	cfg := core.LoadConfig()
 	// Never expose the passphrase: even a holder of the bearer token has no
 	// reason to need it back, and clients shouldn't be able to round-trip it
 	// through a write to /api/config either (we don't accept writes today).
 	cfg.APIPassphrase = ""
+	cfg.APISalt = ""
 	writeJSON(w, http.StatusOK, cfg)
 }
 
@@ -422,6 +445,16 @@ type StatsResponse struct {
 	TotalSessions  int `json:"total_sessions"`
 	ActiveSessions int `json:"active_sessions"`
 	WindowMinutes  int `json:"window_minutes"`
+}
+
+// AuthInfo describes the public KDF parameters clients need before they can
+// derive the bearer token from a passphrase.
+type AuthInfo struct {
+	Salt       string `json:"salt"`
+	Iterations int    `json:"iterations"`
+	KeyLength  int    `json:"key_length"`
+	Hash       string `json:"hash"`
+	Encoding   string `json:"encoding"`
 }
 
 // SSEPayload is the data pushed on each SSE "update" event.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -17,29 +17,50 @@ import (
 type testProvider struct{}
 
 func (testProvider) DiscoverSessions() ([]*model.Session, error) { return nil, nil }
-func (testProvider) UseWatcher() bool                             { return false }
-func (testProvider) RefreshInterval() time.Duration               { return 0 }
-func (testProvider) WatchDirs() []string                          { return nil }
+func (testProvider) UseWatcher() bool                            { return false }
+func (testProvider) RefreshInterval() time.Duration              { return 0 }
+func (testProvider) WatchDirs() []string                         { return nil }
 
+// testToken is the bearer token used by the test helper. Tests authenticate
+// by sending Authorization: Bearer <testToken>. The token value itself is
+// arbitrary — we don't exercise the PBKDF2 derivation here, only the
+// middleware enforcement.
+const testToken = "test-token"
+
+// newTestServer spins up an httptest server with the same handler chain
+// the production server uses (CORS + auth middleware + routes), so tests
+// genuinely exercise the auth middleware.
 func newTestServer(t *testing.T) (*Server, *httptest.Server) {
 	t.Helper()
-	srv, err := New(":0", testProvider{})
+	srv, err := New(":0", testProvider{}, testToken)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	srv.ln.Close()
-	ts := httptest.NewServer(srv.mux)
+	ts := httptest.NewServer(srv.srv.Handler)
 	return srv, ts
+}
+
+// authedGet performs a GET with the test bearer token attached.
+func authedGet(t *testing.T, url string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
 }
 
 func TestGetSessions(t *testing.T) {
 	_, ts := newTestServer(t)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/sessions")
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp := authedGet(t, ts.URL+"/api/sessions")
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
@@ -57,10 +78,7 @@ func TestGetSessionNotFound(t *testing.T) {
 	_, ts := newTestServer(t)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/sessions/nonexistent")
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp := authedGet(t, ts.URL+"/api/sessions/nonexistent")
 	defer resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Fatalf("status = %d, want 404", resp.StatusCode)
@@ -71,10 +89,7 @@ func TestGetStats(t *testing.T) {
 	_, ts := newTestServer(t)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/stats")
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp := authedGet(t, ts.URL+"/api/stats")
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
@@ -92,20 +107,26 @@ func TestGetConfig(t *testing.T) {
 	_, ts := newTestServer(t)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/config")
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp := authedGet(t, ts.URL+"/api/config")
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
+	// /api/config must not echo the passphrase even to an authenticated caller.
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v, ok := body["api_passphrase"]; ok && v != "" {
+		t.Fatalf("api_passphrase should not be returned, got %v", v)
+	}
 }
 
-func TestPlayground(t *testing.T) {
+func TestPlaygroundIsPublic(t *testing.T) {
 	_, ts := newTestServer(t)
 	defer ts.Close()
 
+	// No Authorization header — must still succeed.
 	resp, err := http.Get(ts.URL + "/api")
 	if err != nil {
 		t.Fatal(err)
@@ -119,6 +140,38 @@ func TestPlayground(t *testing.T) {
 	}
 }
 
+func TestEndpointsRejectMissingToken(t *testing.T) {
+	_, ts := newTestServer(t)
+	defer ts.Close()
+
+	for _, path := range []string{"/api/sessions", "/api/stats", "/api/config", "/api/events"} {
+		resp, err := http.Get(ts.URL + path)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("%s: status = %d, want 401", path, resp.StatusCode)
+		}
+	}
+}
+
+func TestEndpointsRejectWrongToken(t *testing.T) {
+	_, ts := newTestServer(t)
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/api/sessions", nil)
+	req.Header.Set("Authorization", "Bearer not-the-right-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
 func TestSSE(t *testing.T) {
 	srv, ts := newTestServer(t)
 	defer ts.Close()
@@ -126,7 +179,9 @@ func TestSSE(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api/events", nil)
+	// SSE clients (EventSource) cannot send custom headers — verify the
+	// query-string fallback works.
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api/events?token="+testToken, nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -138,7 +193,6 @@ func TestSSE(t *testing.T) {
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
-	// Read initial snapshot: expect "event: update" line.
 	gotEvent := false
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -150,7 +204,6 @@ func TestSSE(t *testing.T) {
 			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &payload); err != nil {
 				t.Fatalf("decode SSE data: %v", err)
 			}
-			// Got valid initial frame, success.
 			break
 		}
 	}
@@ -158,7 +211,6 @@ func TestSSE(t *testing.T) {
 		t.Fatal("never received SSE update event")
 	}
 
-	// Trigger a notification and verify a second frame arrives.
 	srv.notifySSE()
 
 	gotSecond := false

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -26,13 +26,15 @@ func (testProvider) WatchDirs() []string                         { return nil }
 // arbitrary — we don't exercise the PBKDF2 derivation here, only the
 // middleware enforcement.
 const testToken = "test-token"
+const testSalt = "lazyagent-api-v1-test"
 
 // newTestServer spins up an httptest server with the same handler chain
 // the production server uses (CORS + auth middleware + routes), so tests
 // genuinely exercise the auth middleware.
 func newTestServer(t *testing.T) (*Server, *httptest.Server) {
 	t.Helper()
-	srv, err := New(":0", testProvider{}, testToken)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	srv, err := New(":0", testProvider{}, testToken, testSalt)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -120,6 +122,9 @@ func TestGetConfig(t *testing.T) {
 	if v, ok := body["api_passphrase"]; ok && v != "" {
 		t.Fatalf("api_passphrase should not be returned, got %v", v)
 	}
+	if v, ok := body["api_salt"]; ok && v != "" {
+		t.Fatalf("api_salt should not be returned from /api/config, got %v", v)
+	}
 }
 
 func TestPlaygroundIsPublic(t *testing.T) {
@@ -137,6 +142,40 @@ func TestPlaygroundIsPublic(t *testing.T) {
 	}
 	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/html") {
 		t.Fatalf("content-type = %q, want text/html", ct)
+	}
+}
+
+func TestPlaygroundQuotesSalt(t *testing.T) {
+	html := renderPlayground(`";alert(1)//`)
+	if strings.Contains(html, `const KDF_SALT = "";alert(1)//";`) {
+		t.Fatal("salt was interpolated into JavaScript without escaping")
+	}
+	if !strings.Contains(html, `const KDF_SALT = "\";alert(1)//";`) {
+		t.Fatal("escaped salt literal not found in playground HTML")
+	}
+}
+
+func TestAuthInfoIsPublic(t *testing.T) {
+	_, ts := newTestServer(t)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/auth")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var info AuthInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if info.Salt != testSalt {
+		t.Fatalf("salt = %q, want %q", info.Salt, testSalt)
+	}
+	if info.Iterations == 0 || info.KeyLength == 0 || info.Hash == "" || info.Encoding == "" {
+		t.Fatalf("incomplete auth info: %+v", info)
 	}
 }
 

--- a/internal/apiauth/derive.go
+++ b/internal/apiauth/derive.go
@@ -1,0 +1,37 @@
+// Package apiauth derives bearer tokens from passphrases and provides HTTP
+// middleware that enforces them. The derivation is deterministic so that any
+// client (browser playground, mobile app, curl) can produce the same token
+// from the same passphrase by reimplementing the algorithm.
+package apiauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// Derivation parameters. These are part of the public protocol — every client
+// that wants to compute a token from a passphrase MUST use exactly these
+// values, otherwise the derived token will not match what the server expects.
+//
+// The "-v1" suffix in the salt allows future migrations: a "-v2" can be
+// introduced without breaking existing v1 clients.
+const (
+	Salt       = "lazyagent-api-v1"
+	Iterations = 600_000
+	KeyLength  = 32
+)
+
+// DeriveToken returns the bearer token for the given passphrase.
+// Returns the empty string when passphrase is empty (callers use this to
+// detect "auth disabled / not configured").
+func DeriveToken(passphrase string) string {
+	passphrase = strings.TrimSpace(passphrase)
+	if passphrase == "" {
+		return ""
+	}
+	key := pbkdf2.Key([]byte(passphrase), []byte(Salt), Iterations, KeyLength, sha256.New)
+	return base64.RawURLEncoding.EncodeToString(key)
+}

--- a/internal/apiauth/derive.go
+++ b/internal/apiauth/derive.go
@@ -5,6 +5,7 @@
 package apiauth
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"strings"
@@ -12,26 +13,39 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
-// Derivation parameters. These are part of the public protocol — every client
-// that wants to compute a token from a passphrase MUST use exactly these
-// values, otherwise the derived token will not match what the server expects.
+// Derivation parameters. These are part of the public protocol: every client
+// that wants to compute a token from a passphrase must use these KDF settings
+// plus the server's public per-install salt.
 //
-// The "-v1" suffix in the salt allows future migrations: a "-v2" can be
-// introduced without breaking existing v1 clients.
+// SaltPrefix marks salts generated for this protocol version and allows future
+// migrations without making salts ambiguous.
 const (
-	Salt       = "lazyagent-api-v1"
+	SaltPrefix = "lazyagent-api-v1"
 	Iterations = 600_000
 	KeyLength  = 32
 )
 
-// DeriveToken returns the bearer token for the given passphrase.
+// NewSalt returns a public, per-install salt for API token derivation.
+func NewSalt() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return SaltPrefix + "-" + base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
+
+// DeriveToken returns the bearer token for the given passphrase and salt.
 // Returns the empty string when passphrase is empty (callers use this to
 // detect "auth disabled / not configured").
-func DeriveToken(passphrase string) string {
+func DeriveToken(passphrase, salt string) string {
 	passphrase = strings.TrimSpace(passphrase)
 	if passphrase == "" {
 		return ""
 	}
-	key := pbkdf2.Key([]byte(passphrase), []byte(Salt), Iterations, KeyLength, sha256.New)
+	salt = strings.TrimSpace(salt)
+	if salt == "" {
+		salt = SaltPrefix
+	}
+	key := pbkdf2.Key([]byte(passphrase), []byte(salt), Iterations, KeyLength, sha256.New)
 	return base64.RawURLEncoding.EncodeToString(key)
 }

--- a/internal/apiauth/derive_test.go
+++ b/internal/apiauth/derive_test.go
@@ -3,21 +3,21 @@ package apiauth
 import "testing"
 
 func TestDeriveTokenDeterministic(t *testing.T) {
-	a := DeriveToken("pippo")
-	b := DeriveToken("pippo")
+	a := DeriveToken("pippo", SaltPrefix)
+	b := DeriveToken("pippo", SaltPrefix)
 	if a != b {
 		t.Fatalf("non-deterministic: %q vs %q", a, b)
 	}
 }
 
 func TestDeriveTokenDifferentPassphrases(t *testing.T) {
-	if DeriveToken("pippo") == DeriveToken("pluto") {
+	if DeriveToken("pippo", SaltPrefix) == DeriveToken("pluto", SaltPrefix) {
 		t.Fatal("different passphrases produced same token")
 	}
 }
 
 func TestDeriveTokenLength(t *testing.T) {
-	tok := DeriveToken("anything")
+	tok := DeriveToken("anything", SaltPrefix)
 	// 32 bytes -> 43 chars in base64url without padding.
 	if len(tok) != 43 {
 		t.Fatalf("token length = %d, want 43", len(tok))
@@ -25,17 +25,40 @@ func TestDeriveTokenLength(t *testing.T) {
 }
 
 func TestDeriveTokenEmpty(t *testing.T) {
-	if DeriveToken("") != "" {
+	if DeriveToken("", SaltPrefix) != "" {
 		t.Fatal("empty passphrase should derive empty token")
 	}
-	if DeriveToken("   ") != "" {
+	if DeriveToken("   ", SaltPrefix) != "" {
 		t.Fatal("whitespace-only passphrase should derive empty token")
 	}
 }
 
 func TestDeriveTokenTrimsWhitespace(t *testing.T) {
-	if DeriveToken("hello") != DeriveToken("  hello  ") {
+	if DeriveToken("hello", SaltPrefix) != DeriveToken("  hello  ", SaltPrefix) {
 		t.Fatal("token differs based on surrounding whitespace")
+	}
+}
+
+func TestDeriveTokenDifferentSalts(t *testing.T) {
+	if DeriveToken("same-passphrase", "salt-a") == DeriveToken("same-passphrase", "salt-b") {
+		t.Fatal("different salts produced same token")
+	}
+}
+
+func TestNewSalt(t *testing.T) {
+	a, err := NewSalt()
+	if err != nil {
+		t.Fatalf("NewSalt: %v", err)
+	}
+	b, err := NewSalt()
+	if err != nil {
+		t.Fatalf("NewSalt: %v", err)
+	}
+	if a == b {
+		t.Fatal("NewSalt returned duplicate salts")
+	}
+	if len(a) <= len(SaltPrefix)+1 || a[:len(SaltPrefix)+1] != SaltPrefix+"-" {
+		t.Fatalf("salt = %q, want %q prefix", a, SaltPrefix+"-")
 	}
 }
 
@@ -44,14 +67,15 @@ func TestDeriveTokenTrimsWhitespace(t *testing.T) {
 // implementation matches the server.
 //
 // Vector:
-//   passphrase = "pippo"
-//   salt       = "lazyagent-api-v1"
-//   iterations = 600_000
-//   hash       = SHA-256
-//   length     = 32 bytes -> base64url (no padding)
+//
+//	passphrase = "pippo"
+//	salt       = "lazyagent-api-v1"
+//	iterations = 600_000
+//	hash       = SHA-256
+//	length     = 32 bytes -> base64url (no padding)
 func TestDeriveTokenKnownVector(t *testing.T) {
 	const want = "zqh9_r0QeYpLiLSQGZMYriIWqNZgZOu3Qc_l7wtraV4"
-	got := DeriveToken("pippo")
+	got := DeriveToken("pippo", SaltPrefix)
 	if got != want {
 		t.Fatalf("token for %q = %q, want %q (algorithm changed?)", "pippo", got, want)
 	}

--- a/internal/apiauth/derive_test.go
+++ b/internal/apiauth/derive_test.go
@@ -1,0 +1,58 @@
+package apiauth
+
+import "testing"
+
+func TestDeriveTokenDeterministic(t *testing.T) {
+	a := DeriveToken("pippo")
+	b := DeriveToken("pippo")
+	if a != b {
+		t.Fatalf("non-deterministic: %q vs %q", a, b)
+	}
+}
+
+func TestDeriveTokenDifferentPassphrases(t *testing.T) {
+	if DeriveToken("pippo") == DeriveToken("pluto") {
+		t.Fatal("different passphrases produced same token")
+	}
+}
+
+func TestDeriveTokenLength(t *testing.T) {
+	tok := DeriveToken("anything")
+	// 32 bytes -> 43 chars in base64url without padding.
+	if len(tok) != 43 {
+		t.Fatalf("token length = %d, want 43", len(tok))
+	}
+}
+
+func TestDeriveTokenEmpty(t *testing.T) {
+	if DeriveToken("") != "" {
+		t.Fatal("empty passphrase should derive empty token")
+	}
+	if DeriveToken("   ") != "" {
+		t.Fatal("whitespace-only passphrase should derive empty token")
+	}
+}
+
+func TestDeriveTokenTrimsWhitespace(t *testing.T) {
+	if DeriveToken("hello") != DeriveToken("  hello  ") {
+		t.Fatal("token differs based on surrounding whitespace")
+	}
+}
+
+// TestDeriveTokenKnownVector pins the algorithm so accidental parameter changes
+// are caught. Clients (mobile app, browser) can use this vector to verify their
+// implementation matches the server.
+//
+// Vector:
+//   passphrase = "pippo"
+//   salt       = "lazyagent-api-v1"
+//   iterations = 600_000
+//   hash       = SHA-256
+//   length     = 32 bytes -> base64url (no padding)
+func TestDeriveTokenKnownVector(t *testing.T) {
+	const want = "zqh9_r0QeYpLiLSQGZMYriIWqNZgZOu3Qc_l7wtraV4"
+	got := DeriveToken("pippo")
+	if got != want {
+		t.Fatalf("token for %q = %q, want %q (algorithm changed?)", "pippo", got, want)
+	}
+}

--- a/internal/apiauth/middleware.go
+++ b/internal/apiauth/middleware.go
@@ -1,0 +1,53 @@
+package apiauth
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// Middleware returns an http middleware that enforces a Bearer token on every
+// request, except:
+//   - CORS preflight (OPTIONS) — browsers do not send Authorization on preflight
+//   - paths in exemptPaths (exact match) — the playground HTML page is exempt
+//     so it can be opened in a browser; it then collects the passphrase and
+//     authenticates subsequent JS calls.
+//
+// For requests that cannot send the Authorization header (notably the browser
+// EventSource API used by /api/events), the token may be supplied via the
+// "token" query parameter. This is documented as a fallback.
+func Middleware(expectedToken string, exemptPaths map[string]bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodOptions || exemptPaths[r.URL.Path] {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			provided := extractToken(r)
+			if provided == "" {
+				writeUnauthorized(w, "missing bearer token")
+				return
+			}
+			if subtle.ConstantTimeCompare([]byte(provided), []byte(expectedToken)) != 1 {
+				writeUnauthorized(w, "invalid bearer token")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func extractToken(r *http.Request) string {
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	return r.URL.Query().Get("token")
+}
+
+func writeUnauthorized(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate", `Bearer realm="lazyagent"`)
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"error":"` + msg + `"}`))
+}

--- a/internal/apiauth/middleware.go
+++ b/internal/apiauth/middleware.go
@@ -13,9 +13,10 @@ import (
 //     so it can be opened in a browser; it then collects the passphrase and
 //     authenticates subsequent JS calls.
 //
-// For requests that cannot send the Authorization header (notably the browser
-// EventSource API used by /api/events), the token may be supplied via the
-// "token" query parameter. This is documented as a fallback.
+// For /api/events requests that cannot send the Authorization header (notably
+// the browser EventSource API), the token may be supplied via the "token" query
+// parameter. Other endpoints intentionally reject query-string tokens because
+// URLs are more likely to end up in logs and shell history.
 func Middleware(expectedToken string, exemptPaths map[string]bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +48,9 @@ func Middleware(expectedToken string, exemptPaths map[string]bool) func(http.Han
 func extractToken(r *http.Request) string {
 	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
 		return strings.TrimPrefix(auth, "Bearer ")
+	}
+	if r.URL.Path != "/api/events" {
+		return ""
 	}
 	return r.URL.Query().Get("token")
 }

--- a/internal/apiauth/middleware.go
+++ b/internal/apiauth/middleware.go
@@ -29,6 +29,12 @@ func Middleware(expectedToken string, exemptPaths map[string]bool) func(http.Han
 				writeUnauthorized(w, "missing bearer token")
 				return
 			}
+			// subtle.ConstantTimeCompare returns 0 immediately on length
+			// mismatch, which technically leaks length. Acceptable here:
+			// expectedToken always has fixed length 43 (32-byte PBKDF2
+			// output, base64url-encoded without padding), so a wrong-length
+			// input only tells the attacker what they could have computed
+			// from the public algorithm anyway.
 			if subtle.ConstantTimeCompare([]byte(provided), []byte(expectedToken)) != 1 {
 				writeUnauthorized(w, "invalid bearer token")
 				return

--- a/internal/apiauth/middleware_test.go
+++ b/internal/apiauth/middleware_test.go
@@ -1,0 +1,86 @@
+package apiauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newHandler(token string, exempt map[string]bool) http.Handler {
+	mw := Middleware(token, exempt)
+	return mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+}
+
+func TestMiddlewareRejectsMissingHeader(t *testing.T) {
+	h := newHandler("expected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/api/sessions", nil))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	if rr.Header().Get("WWW-Authenticate") == "" {
+		t.Fatal("missing WWW-Authenticate header")
+	}
+}
+
+func TestMiddlewareRejectsWrongToken(t *testing.T) {
+	h := newHandler("expected", nil)
+	req := httptest.NewRequest("GET", "/api/sessions", nil)
+	req.Header.Set("Authorization", "Bearer wrong")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestMiddlewareAcceptsCorrectToken(t *testing.T) {
+	h := newHandler("expected", nil)
+	req := httptest.NewRequest("GET", "/api/sessions", nil)
+	req.Header.Set("Authorization", "Bearer expected")
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+}
+
+func TestMiddlewareAcceptsTokenFromQuery(t *testing.T) {
+	h := newHandler("expected", nil)
+	req := httptest.NewRequest("GET", "/api/events?token=expected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (token from query)", rr.Code)
+	}
+}
+
+func TestMiddlewareSkipsOptions(t *testing.T) {
+	h := newHandler("expected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("OPTIONS", "/api/sessions", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (OPTIONS preflight bypass)", rr.Code)
+	}
+}
+
+func TestMiddlewareSkipsExemptPath(t *testing.T) {
+	h := newHandler("expected", map[string]bool{"/api": true})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/api", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (exempt path)", rr.Code)
+	}
+}
+
+func TestMiddlewareNonExemptStillProtected(t *testing.T) {
+	h := newHandler("expected", map[string]bool{"/api": true})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/api/sessions", nil))
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}

--- a/internal/apiauth/middleware_test.go
+++ b/internal/apiauth/middleware_test.go
@@ -48,13 +48,23 @@ func TestMiddlewareAcceptsCorrectToken(t *testing.T) {
 	}
 }
 
-func TestMiddlewareAcceptsTokenFromQuery(t *testing.T) {
+func TestMiddlewareAcceptsTokenFromQueryForSSE(t *testing.T) {
 	h := newHandler("expected", nil)
 	req := httptest.NewRequest("GET", "/api/events?token=expected", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200 (token from query)", rr.Code)
+	}
+}
+
+func TestMiddlewareRejectsTokenFromQueryForNonSSE(t *testing.T) {
+	h := newHandler("expected", nil)
+	req := httptest.NewRequest("GET", "/api/sessions?token=expected", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (query token only allowed for SSE)", rr.Code)
 	}
 }
 

--- a/internal/apiauth/prompt.go
+++ b/internal/apiauth/prompt.go
@@ -15,14 +15,18 @@ import (
 // config file isn't convenient. The env var value is never written to disk.
 const EnvVar = "LAZYAGENT_API_PASSPHRASE"
 
-// MinPassphraseLength is the soft minimum below which we warn the user.
-// Not enforced — short passphrases produce valid (just weaker) tokens.
-const MinPassphraseLength = 8
+// MinPassphraseLength is the minimum accepted API passphrase length. Shorter
+// passphrases are too cheap to brute-force once an attacker has a token oracle
+// or captured token material.
+const MinPassphraseLength = 12
 
 // ErrNoTTY is returned when no passphrase is configured and stdin is not a
 // terminal, so we can't prompt for one. The caller should print actionable
 // guidance and exit.
 var ErrNoTTY = errors.New("no passphrase configured and stdin is not a terminal")
+
+// ErrWeakPassphrase is returned when a configured/env passphrase is too short.
+var ErrWeakPassphrase = errors.New("api passphrase is too short")
 
 // ResolvePassphrase returns the passphrase to use, in priority order:
 //  1. the LAZYAGENT_API_PASSPHRASE env var, if set
@@ -34,9 +38,15 @@ var ErrNoTTY = errors.New("no passphrase configured and stdin is not a terminal"
 // persisted to the config file by the caller.
 func ResolvePassphrase(configured string) (passphrase string, fromPrompt bool, err error) {
 	if env := strings.TrimSpace(os.Getenv(EnvVar)); env != "" {
+		if err := ValidatePassphrase(env); err != nil {
+			return "", false, err
+		}
 		return env, false, nil
 	}
 	if configured = strings.TrimSpace(configured); configured != "" {
+		if err := ValidatePassphrase(configured); err != nil {
+			return "", false, err
+		}
 		return configured, false, nil
 	}
 	pp, err := PromptForNew()
@@ -44,6 +54,18 @@ func ResolvePassphrase(configured string) (passphrase string, fromPrompt bool, e
 		return "", false, err
 	}
 	return pp, true, nil
+}
+
+// ValidatePassphrase enforces the non-interactive passphrase policy. Empty
+// values are handled by callers because they mean "not configured".
+func ValidatePassphrase(passphrase string) error {
+	if strings.TrimSpace(passphrase) == "" {
+		return nil
+	}
+	if len([]rune(strings.TrimSpace(passphrase))) < MinPassphraseLength {
+		return fmt.Errorf("%w: use at least %d characters", ErrWeakPassphrase, MinPassphraseLength)
+	}
+	return nil
 }
 
 // PromptForNew always prompts the user for a new passphrase (double-entry
@@ -77,13 +99,9 @@ func promptPassphraseTwice(in *os.File, out io.Writer) (string, error) {
 			fmt.Fprintln(out, "Passphrase cannot be empty. Try again.")
 			continue
 		}
-		// Warn before asking for confirmation: a short passphrase makes the
-		// derived bearer token cheaper to brute-force, and the user should be
-		// able to abort right away rather than re-typing it just to learn
-		// they should have picked something longer.
-		if len(first) < MinPassphraseLength {
-			fmt.Fprintf(out, "Warning: passphrase is shorter than %d characters. A longer passphrase is harder to brute-force.\n", MinPassphraseLength)
-			fmt.Fprintln(out, "Press Ctrl+C to abort, or confirm to keep this passphrase.")
+		if len([]rune(string(first))) < MinPassphraseLength {
+			fmt.Fprintf(out, "Passphrase must be at least %d characters. Try again.\n", MinPassphraseLength)
+			continue
 		}
 
 		fmt.Fprint(out, "Confirm passphrase:   ")

--- a/internal/apiauth/prompt.go
+++ b/internal/apiauth/prompt.go
@@ -77,6 +77,14 @@ func promptPassphraseTwice(in *os.File, out io.Writer) (string, error) {
 			fmt.Fprintln(out, "Passphrase cannot be empty. Try again.")
 			continue
 		}
+		// Warn before asking for confirmation: a short passphrase makes the
+		// derived bearer token cheaper to brute-force, and the user should be
+		// able to abort right away rather than re-typing it just to learn
+		// they should have picked something longer.
+		if len(first) < MinPassphraseLength {
+			fmt.Fprintf(out, "Warning: passphrase is shorter than %d characters. A longer passphrase is harder to brute-force.\n", MinPassphraseLength)
+			fmt.Fprintln(out, "Press Ctrl+C to abort, or confirm to keep this passphrase.")
+		}
 
 		fmt.Fprint(out, "Confirm passphrase:   ")
 		second, err := term.ReadPassword(int(in.Fd()))
@@ -89,9 +97,6 @@ func promptPassphraseTwice(in *os.File, out io.Writer) (string, error) {
 		if string(first) != string(second) {
 			fmt.Fprintln(out, "Passphrases do not match. Try again.")
 			continue
-		}
-		if len(first) < MinPassphraseLength {
-			fmt.Fprintf(out, "Warning: passphrase is shorter than %d characters. A longer passphrase is harder to brute-force.\n\n", MinPassphraseLength)
 		}
 		return string(first), nil
 	}

--- a/internal/apiauth/prompt.go
+++ b/internal/apiauth/prompt.go
@@ -1,0 +1,98 @@
+package apiauth
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// EnvVar is the environment variable name that overrides the configured
+// passphrase. Useful for CI / non-interactive deployments where editing the
+// config file isn't convenient. The env var value is never written to disk.
+const EnvVar = "LAZYAGENT_API_PASSPHRASE"
+
+// MinPassphraseLength is the soft minimum below which we warn the user.
+// Not enforced — short passphrases produce valid (just weaker) tokens.
+const MinPassphraseLength = 8
+
+// ErrNoTTY is returned when no passphrase is configured and stdin is not a
+// terminal, so we can't prompt for one. The caller should print actionable
+// guidance and exit.
+var ErrNoTTY = errors.New("no passphrase configured and stdin is not a terminal")
+
+// ResolvePassphrase returns the passphrase to use, in priority order:
+//  1. the LAZYAGENT_API_PASSPHRASE env var, if set
+//  2. the configured value, if non-empty
+//  3. an interactive prompt, if stdin is a TTY
+//
+// If none of those apply, ErrNoTTY is returned. The boolean second return is
+// true when the passphrase came from the interactive prompt and should be
+// persisted to the config file by the caller.
+func ResolvePassphrase(configured string) (passphrase string, fromPrompt bool, err error) {
+	if env := strings.TrimSpace(os.Getenv(EnvVar)); env != "" {
+		return env, false, nil
+	}
+	if configured = strings.TrimSpace(configured); configured != "" {
+		return configured, false, nil
+	}
+	pp, err := PromptForNew()
+	if err != nil {
+		return "", false, err
+	}
+	return pp, true, nil
+}
+
+// PromptForNew always prompts the user for a new passphrase (double-entry
+// confirmation), regardless of what's in the env or config. Used by the
+// `lazyagent passphrase` subcommand to rotate the passphrase. Returns
+// ErrNoTTY when stdin isn't a terminal.
+func PromptForNew() (string, error) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", ErrNoTTY
+	}
+	return promptPassphraseTwice(os.Stdin, os.Stderr)
+}
+
+// promptPassphraseTwice asks for the passphrase, then asks again for
+// confirmation. It loops until both entries match and the result is non-empty.
+// Reads from in (which must be a terminal); writes prompts to out.
+func promptPassphraseTwice(in *os.File, out io.Writer) (string, error) {
+	fmt.Fprintln(out, "No API passphrase is configured. Set one now.")
+	fmt.Fprintln(out, "It will be saved to the config file and used to derive your bearer token.")
+	fmt.Fprintln(out)
+
+	for {
+		fmt.Fprint(out, "Enter API passphrase: ")
+		first, err := term.ReadPassword(int(in.Fd()))
+		fmt.Fprintln(out)
+		if err != nil {
+			return "", fmt.Errorf("read passphrase: %w", err)
+		}
+		first = []byte(strings.TrimSpace(string(first)))
+		if len(first) == 0 {
+			fmt.Fprintln(out, "Passphrase cannot be empty. Try again.")
+			continue
+		}
+
+		fmt.Fprint(out, "Confirm passphrase:   ")
+		second, err := term.ReadPassword(int(in.Fd()))
+		fmt.Fprintln(out)
+		if err != nil {
+			return "", fmt.Errorf("read passphrase: %w", err)
+		}
+		second = []byte(strings.TrimSpace(string(second)))
+
+		if string(first) != string(second) {
+			fmt.Fprintln(out, "Passphrases do not match. Try again.")
+			continue
+		}
+		if len(first) < MinPassphraseLength {
+			fmt.Fprintf(out, "Warning: passphrase is shorter than %d characters. A longer passphrase is harder to brute-force.\n\n", MinPassphraseLength)
+		}
+		return string(first), nil
+	}
+}

--- a/internal/apiauth/prompt_test.go
+++ b/internal/apiauth/prompt_test.go
@@ -1,6 +1,9 @@
 package apiauth
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 // The TTY branch of ResolvePassphrase is hard to test in an automated way
 // (it requires a real terminal for term.ReadPassword). These tests cover
@@ -8,13 +11,13 @@ import "testing"
 // fallback. The TTY branch is left to manual testing.
 
 func TestResolvePassphraseEnvVarBeatsConfigured(t *testing.T) {
-	t.Setenv(EnvVar, "from-env")
-	pp, fromPrompt, err := ResolvePassphrase("from-config")
+	t.Setenv(EnvVar, "from-env-passphrase")
+	pp, fromPrompt, err := ResolvePassphrase("from-config-passphrase")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pp != "from-env" {
-		t.Errorf("passphrase = %q, want %q (env should win)", pp, "from-env")
+	if pp != "from-env-passphrase" {
+		t.Errorf("passphrase = %q, want %q (env should win)", pp, "from-env-passphrase")
 	}
 	if fromPrompt {
 		t.Error("fromPrompt = true, want false (env-var path)")
@@ -22,13 +25,13 @@ func TestResolvePassphraseEnvVarBeatsConfigured(t *testing.T) {
 }
 
 func TestResolvePassphraseEnvVarTrimsWhitespace(t *testing.T) {
-	t.Setenv(EnvVar, "  spaced  ")
+	t.Setenv(EnvVar, "  spaced-passphrase  ")
 	pp, _, err := ResolvePassphrase("")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pp != "spaced" {
-		t.Errorf("passphrase = %q, want %q (env trimmed)", pp, "spaced")
+	if pp != "spaced-passphrase" {
+		t.Errorf("passphrase = %q, want %q (env trimmed)", pp, "spaced-passphrase")
 	}
 }
 
@@ -37,23 +40,23 @@ func TestResolvePassphraseEnvVarBlankFallsThrough(t *testing.T) {
 	// could accidentally export an empty value and get past the "no
 	// passphrase configured" guard.
 	t.Setenv(EnvVar, "   ")
-	pp, _, err := ResolvePassphrase("from-config")
+	pp, _, err := ResolvePassphrase("from-config-passphrase")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pp != "from-config" {
-		t.Errorf("passphrase = %q, want %q (whitespace env should fall through)", pp, "from-config")
+	if pp != "from-config-passphrase" {
+		t.Errorf("passphrase = %q, want %q (whitespace env should fall through)", pp, "from-config-passphrase")
 	}
 }
 
 func TestResolvePassphraseConfiguredWhenEnvUnset(t *testing.T) {
 	t.Setenv(EnvVar, "")
-	pp, fromPrompt, err := ResolvePassphrase("from-config")
+	pp, fromPrompt, err := ResolvePassphrase("from-config-passphrase")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pp != "from-config" {
-		t.Errorf("passphrase = %q, want %q", pp, "from-config")
+	if pp != "from-config-passphrase" {
+		t.Errorf("passphrase = %q, want %q", pp, "from-config-passphrase")
 	}
 	if fromPrompt {
 		t.Error("fromPrompt = true, want false (configured path)")
@@ -62,12 +65,12 @@ func TestResolvePassphraseConfiguredWhenEnvUnset(t *testing.T) {
 
 func TestResolvePassphraseConfiguredTrimsWhitespace(t *testing.T) {
 	t.Setenv(EnvVar, "")
-	pp, _, err := ResolvePassphrase("  spaced  ")
+	pp, _, err := ResolvePassphrase("  spaced-passphrase  ")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pp != "spaced" {
-		t.Errorf("passphrase = %q, want %q (configured trimmed)", pp, "spaced")
+	if pp != "spaced-passphrase" {
+		t.Errorf("passphrase = %q, want %q (configured trimmed)", pp, "spaced-passphrase")
 	}
 }
 
@@ -79,5 +82,21 @@ func TestResolvePassphraseNoSourcesReturnsErrNoTTY(t *testing.T) {
 	_, _, err := ResolvePassphrase("")
 	if err != ErrNoTTY {
 		t.Fatalf("err = %v, want ErrNoTTY", err)
+	}
+}
+
+func TestResolvePassphraseRejectsShortEnvVar(t *testing.T) {
+	t.Setenv(EnvVar, "short")
+	_, _, err := ResolvePassphrase("from-config-passphrase")
+	if !errors.Is(err, ErrWeakPassphrase) {
+		t.Fatalf("err = %v, want ErrWeakPassphrase", err)
+	}
+}
+
+func TestResolvePassphraseRejectsShortConfigured(t *testing.T) {
+	t.Setenv(EnvVar, "")
+	_, _, err := ResolvePassphrase("short")
+	if !errors.Is(err, ErrWeakPassphrase) {
+		t.Fatalf("err = %v, want ErrWeakPassphrase", err)
 	}
 }

--- a/internal/apiauth/prompt_test.go
+++ b/internal/apiauth/prompt_test.go
@@ -1,0 +1,83 @@
+package apiauth
+
+import "testing"
+
+// The TTY branch of ResolvePassphrase is hard to test in an automated way
+// (it requires a real terminal for term.ReadPassword). These tests cover
+// the two non-TTY branches: env-var precedence and the configured-value
+// fallback. The TTY branch is left to manual testing.
+
+func TestResolvePassphraseEnvVarBeatsConfigured(t *testing.T) {
+	t.Setenv(EnvVar, "from-env")
+	pp, fromPrompt, err := ResolvePassphrase("from-config")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pp != "from-env" {
+		t.Errorf("passphrase = %q, want %q (env should win)", pp, "from-env")
+	}
+	if fromPrompt {
+		t.Error("fromPrompt = true, want false (env-var path)")
+	}
+}
+
+func TestResolvePassphraseEnvVarTrimsWhitespace(t *testing.T) {
+	t.Setenv(EnvVar, "  spaced  ")
+	pp, _, err := ResolvePassphrase("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pp != "spaced" {
+		t.Errorf("passphrase = %q, want %q (env trimmed)", pp, "spaced")
+	}
+}
+
+func TestResolvePassphraseEnvVarBlankFallsThrough(t *testing.T) {
+	// Whitespace-only env var must be treated as unset, otherwise the user
+	// could accidentally export an empty value and get past the "no
+	// passphrase configured" guard.
+	t.Setenv(EnvVar, "   ")
+	pp, _, err := ResolvePassphrase("from-config")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pp != "from-config" {
+		t.Errorf("passphrase = %q, want %q (whitespace env should fall through)", pp, "from-config")
+	}
+}
+
+func TestResolvePassphraseConfiguredWhenEnvUnset(t *testing.T) {
+	t.Setenv(EnvVar, "")
+	pp, fromPrompt, err := ResolvePassphrase("from-config")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pp != "from-config" {
+		t.Errorf("passphrase = %q, want %q", pp, "from-config")
+	}
+	if fromPrompt {
+		t.Error("fromPrompt = true, want false (configured path)")
+	}
+}
+
+func TestResolvePassphraseConfiguredTrimsWhitespace(t *testing.T) {
+	t.Setenv(EnvVar, "")
+	pp, _, err := ResolvePassphrase("  spaced  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pp != "spaced" {
+		t.Errorf("passphrase = %q, want %q (configured trimmed)", pp, "spaced")
+	}
+}
+
+// When nothing is configured and there's no TTY (the standard test runner
+// state), ResolvePassphrase must surface ErrNoTTY rather than block on
+// stdin or return a misleading empty passphrase.
+func TestResolvePassphraseNoSourcesReturnsErrNoTTY(t *testing.T) {
+	t.Setenv(EnvVar, "")
+	_, _, err := ResolvePassphrase("")
+	if err != ErrNoTTY {
+		t.Fatalf("err = %v, want ErrNoTTY", err)
+	}
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -120,7 +120,11 @@ func LoadConfig() Config {
 	return cfg
 }
 
-// SaveConfig writes the config to disk.
+// SaveConfig writes the config to disk. The file is created with mode 0o600
+// because it carries the API passphrase: anyone who can read it can derive
+// the bearer token. Existing files are chmod'ed back to 0o600 on every save
+// so that historical files (originally 0o644) get tightened on first write
+// after upgrading.
 func SaveConfig(cfg Config) error {
 	path := ConfigPath()
 	if path == "" {
@@ -128,7 +132,7 @@ func SaveConfig(cfg Config) error {
 	}
 
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 
@@ -137,5 +141,10 @@ func SaveConfig(cfg Config) error {
 		return err
 	}
 
-	return os.WriteFile(path, data, 0o644)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return err
+	}
+	// os.WriteFile only honors the mode at file creation; force-tighten any
+	// pre-existing file that may have been created before this change.
+	return os.Chmod(path, 0o600)
 }

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -2,8 +2,13 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/apiauth"
 )
 
 // TUIConfig holds TUI-specific settings.
@@ -26,6 +31,10 @@ type Config struct {
 	// protects the HTTP API. Empty means the API has not been configured yet
 	// — `lazyagent --api` will prompt for one on first run.
 	APIPassphrase string `json:"api_passphrase,omitempty"`
+	// APISalt is a public, per-install salt used with APIPassphrase when
+	// deriving the bearer token. It is not secret, but must stay stable so
+	// clients can derive the same token from the same passphrase.
+	APISalt string `json:"api_salt,omitempty"`
 }
 
 // DefaultConfig returns a Config with sensible defaults.
@@ -94,30 +103,58 @@ func LoadConfig() Config {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		// File doesn't exist — create it with defaults.
+		ensureAPISalt(&cfg)
 		_ = SaveConfig(cfg)
 		return cfg
 	}
 
 	_ = json.Unmarshal(data, &cfg)
 
-	// Backfill any missing agent keys so the file stays complete.
+	// Backfill any missing generated/config keys so the file stays complete.
+	changed := ensureAPISalt(&cfg)
 	defaults := DefaultConfig()
 	if cfg.Agents == nil {
 		cfg.Agents = defaults.Agents
+		changed = true
 	} else {
-		changed := false
 		for k, v := range defaults.Agents {
 			if _, ok := cfg.Agents[k]; !ok {
 				cfg.Agents[k] = v
 				changed = true
 			}
 		}
-		if changed {
-			_ = SaveConfig(cfg)
-		}
+	}
+	if changed {
+		_ = SaveConfig(cfg)
 	}
 
 	return cfg
+}
+
+// EnsureAPISalt backfills the public per-install API salt when missing.
+// It returns true when cfg was changed.
+func EnsureAPISalt(cfg *Config) bool {
+	salt := strings.TrimSpace(cfg.APISalt)
+	if salt != "" {
+		if salt == cfg.APISalt {
+			return false
+		}
+		cfg.APISalt = salt
+		return true
+	}
+	generated, err := apiauth.NewSalt()
+	if err != nil {
+		// The salt is public and only needs uniqueness, not secrecy. crypto/rand
+		// failure is extremely unlikely; this fallback avoids silently reverting
+		// to the global legacy salt in constrained environments.
+		generated = fmt.Sprintf("%s-%d-%d", apiauth.SaltPrefix, os.Getpid(), time.Now().UnixNano())
+	}
+	cfg.APISalt = generated
+	return true
+}
+
+func ensureAPISalt(cfg *Config) bool {
+	return EnsureAPISalt(cfg)
 }
 
 // SaveConfig writes the config to disk. The file is created with mode 0o600

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	Agents         map[string]bool `json:"agents"`
 	ClaudeDirs     []string        `json:"claude_dirs,omitempty"`
 	TUI            TUIConfig       `json:"tui"`
+	// APIPassphrase is the secret used to derive the bearer token that
+	// protects the HTTP API. Empty means the API has not been configured yet
+	// — `lazyagent --api` will prompt for one on first run.
+	APIPassphrase string `json:"api_passphrase,omitempty"`
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/internal/passphrase/run.go
+++ b/internal/passphrase/run.go
@@ -52,6 +52,13 @@ Flags:
 	return runRotate(&cfg)
 }
 
+// runShow prints the bearer token for the current passphrase. The raw token
+// goes to stdout (single line, no prefix) so it can be captured in a pipe:
+//
+//	TOKEN=$(lazyagent passphrase --show)
+//
+// All diagnostic context (source of the passphrase, hints on missing config)
+// goes to stderr and never pollutes stdout.
 func runShow(cfg core.Config) int {
 	pp := strings.TrimSpace(os.Getenv(apiauth.EnvVar))
 	source := apiauth.EnvVar
@@ -64,11 +71,14 @@ func runShow(cfg core.Config) int {
 		fmt.Fprintln(os.Stderr, "Run `lazyagent passphrase` to set one.")
 		return 1
 	}
-	fmt.Printf("Bearer token: %s\n", apiauth.DeriveToken(pp))
+	fmt.Println(apiauth.DeriveToken(pp))
 	fmt.Fprintf(os.Stderr, "(passphrase source: %s)\n", source)
 	return 0
 }
 
+// runRotate prompts for a new passphrase and saves it. All output goes to
+// stderr — same convention as the auth setup banner in main.go — so a user
+// who pipes the command somewhere doesn't end up with a token in their pipe.
 func runRotate(cfg *core.Config) int {
 	pp, err := apiauth.PromptForNew()
 	if err != nil {
@@ -85,7 +95,7 @@ func runRotate(cfg *core.Config) int {
 		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
 		return 1
 	}
-	fmt.Printf("Bearer token: %s\n", apiauth.DeriveToken(pp))
+	fmt.Fprintf(os.Stderr, "Bearer token: %s\n", apiauth.DeriveToken(pp))
 	fmt.Fprintf(os.Stderr, "Passphrase saved to %s\n", core.ConfigPath())
 	fmt.Fprintln(os.Stderr, "Restart `lazyagent --api` for the new token to take effect.")
 	return 0

--- a/internal/passphrase/run.go
+++ b/internal/passphrase/run.go
@@ -80,6 +80,16 @@ func runShow(cfg core.Config) int {
 // stderr — same convention as the auth setup banner in main.go — so a user
 // who pipes the command somewhere doesn't end up with a token in their pipe.
 func runRotate(cfg *core.Config) int {
+	// If the env var is set it will silently override the saved value on the
+	// next `--api` start, making the rotation appear to do nothing. Warn up
+	// front so the user can choose to unset it (or stop the rotation).
+	if env := strings.TrimSpace(os.Getenv(apiauth.EnvVar)); env != "" {
+		fmt.Fprintf(os.Stderr, "Warning: %s is set in your environment.\n", apiauth.EnvVar)
+		fmt.Fprintln(os.Stderr, "It will keep overriding the saved passphrase on the next --api start.")
+		fmt.Fprintln(os.Stderr, "Unset it after this rotation if you want the new value to win.")
+		fmt.Fprintln(os.Stderr)
+	}
+
 	pp, err := apiauth.PromptForNew()
 	if err != nil {
 		if err == apiauth.ErrNoTTY {

--- a/internal/passphrase/run.go
+++ b/internal/passphrase/run.go
@@ -1,0 +1,92 @@
+// Package passphrase implements the `lazyagent passphrase` subcommand:
+// a small interactive utility to set or rotate the API passphrase without
+// having to start the server. Useful when the user wants to change their
+// passphrase, share the bearer token with a new device, or recover the
+// token they forgot from a configured passphrase.
+package passphrase
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/illegalstudio/lazyagent/internal/apiauth"
+	"github.com/illegalstudio/lazyagent/internal/core"
+)
+
+// Run is the entry point invoked by main.go for `lazyagent passphrase ...`.
+func Run(args []string) int {
+	fs := flag.NewFlagSet("passphrase", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	var showOnly bool
+	fs.BoolVar(&showOnly, "show", false, "Print the bearer token for the current passphrase and exit (no prompt)")
+
+	fs.Usage = func() {
+		fmt.Fprint(os.Stderr, `lazyagent passphrase — set or rotate the HTTP API passphrase
+
+Usage:
+  lazyagent passphrase           Prompt for a new passphrase, save it, print the bearer token
+  lazyagent passphrase --show    Print the current bearer token without prompting
+
+The passphrase lives in ~/.config/lazyagent/config.json under "api_passphrase".
+The bearer token is derived from it using PBKDF2-SHA256 — every client (mobile
+app, browser playground, curl) that knows the passphrase can reproduce the
+same token locally. See docs/interfaces/http-api.md for the full algorithm.
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cfg := core.LoadConfig()
+
+	if showOnly {
+		return runShow(cfg)
+	}
+	return runRotate(&cfg)
+}
+
+func runShow(cfg core.Config) int {
+	pp := strings.TrimSpace(os.Getenv(apiauth.EnvVar))
+	source := apiauth.EnvVar
+	if pp == "" {
+		pp = strings.TrimSpace(cfg.APIPassphrase)
+		source = core.ConfigPath()
+	}
+	if pp == "" {
+		fmt.Fprintln(os.Stderr, "No passphrase configured.")
+		fmt.Fprintln(os.Stderr, "Run `lazyagent passphrase` to set one.")
+		return 1
+	}
+	fmt.Printf("Bearer token: %s\n", apiauth.DeriveToken(pp))
+	fmt.Fprintf(os.Stderr, "(passphrase source: %s)\n", source)
+	return 0
+}
+
+func runRotate(cfg *core.Config) int {
+	pp, err := apiauth.PromptForNew()
+	if err != nil {
+		if err == apiauth.ErrNoTTY {
+			fmt.Fprintln(os.Stderr, "Error: cannot prompt — stdin is not a terminal.")
+			fmt.Fprintln(os.Stderr, "Edit ~/.config/lazyagent/config.json directly to change the passphrase.")
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	cfg.APIPassphrase = pp
+	if err := core.SaveConfig(*cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Bearer token: %s\n", apiauth.DeriveToken(pp))
+	fmt.Fprintf(os.Stderr, "Passphrase saved to %s\n", core.ConfigPath())
+	fmt.Fprintln(os.Stderr, "Restart `lazyagent --api` for the new token to take effect.")
+	return 0
+}

--- a/internal/passphrase/run.go
+++ b/internal/passphrase/run.go
@@ -60,10 +60,13 @@ Flags:
 // All diagnostic context (source of the passphrase, hints on missing config)
 // goes to stderr and never pollutes stdout.
 func runShow(cfg core.Config) int {
-	pp := strings.TrimSpace(os.Getenv(apiauth.EnvVar))
+	envPP := strings.TrimSpace(os.Getenv(apiauth.EnvVar))
+	cfgPP := strings.TrimSpace(cfg.APIPassphrase)
+
+	pp := envPP
 	source := apiauth.EnvVar
 	if pp == "" {
-		pp = strings.TrimSpace(cfg.APIPassphrase)
+		pp = cfgPP
 		source = core.ConfigPath()
 	}
 	if pp == "" {
@@ -73,6 +76,12 @@ func runShow(cfg core.Config) int {
 	}
 	fmt.Println(apiauth.DeriveToken(pp))
 	fmt.Fprintf(os.Stderr, "(passphrase source: %s)\n", source)
+	// If both sources are set but disagree, the token shown is the one that
+	// will be used at runtime (env wins). Surface the divergence so a user
+	// who just rotated and forgot to unset the env var isn't confused.
+	if envPP != "" && cfgPP != "" && envPP != cfgPP {
+		fmt.Fprintln(os.Stderr, "Note: configured value differs from the env var; the env var wins on --api start.")
+	}
 	return 0
 }
 

--- a/internal/passphrase/run.go
+++ b/internal/passphrase/run.go
@@ -27,13 +27,14 @@ func Run(args []string) int {
 		fmt.Fprint(os.Stderr, `lazyagent passphrase — set or rotate the HTTP API passphrase
 
 Usage:
-  lazyagent passphrase           Prompt for a new passphrase, save it, print the bearer token
+  lazyagent passphrase           Prompt for a new passphrase and save it
   lazyagent passphrase --show    Print the current bearer token without prompting
 
 The passphrase lives in ~/.config/lazyagent/config.json under "api_passphrase".
+The public per-install salt lives next to it under "api_salt".
 The bearer token is derived from it using PBKDF2-SHA256 — every client (mobile
-app, browser playground, curl) that knows the passphrase can reproduce the
-same token locally. See docs/interfaces/http-api.md for the full algorithm.
+app, browser playground, curl) needs the passphrase and public salt to derive
+the same token locally. See docs/interfaces/http-api.md for the full algorithm.
 
 Flags:
 `)
@@ -74,7 +75,12 @@ func runShow(cfg core.Config) int {
 		fmt.Fprintln(os.Stderr, "Run `lazyagent passphrase` to set one.")
 		return 1
 	}
-	fmt.Println(apiauth.DeriveToken(pp))
+	if err := apiauth.ValidatePassphrase(pp); err != nil {
+		fmt.Fprintf(os.Stderr, "Configured passphrase is invalid: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Run `lazyagent passphrase` to set a stronger one.")
+		return 1
+	}
+	fmt.Println(apiauth.DeriveToken(pp, cfg.APISalt))
 	fmt.Fprintf(os.Stderr, "(passphrase source: %s)\n", source)
 	// If both sources are set but disagree, the token shown is the one that
 	// will be used at runtime (env wins). Surface the divergence so a user
@@ -110,12 +116,13 @@ func runRotate(cfg *core.Config) int {
 		return 1
 	}
 	cfg.APIPassphrase = pp
+	core.EnsureAPISalt(cfg)
 	if err := core.SaveConfig(*cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "Error saving config: %v\n", err)
 		return 1
 	}
-	fmt.Fprintf(os.Stderr, "Bearer token: %s\n", apiauth.DeriveToken(pp))
 	fmt.Fprintf(os.Stderr, "Passphrase saved to %s\n", core.ConfigPath())
+	fmt.Fprintln(os.Stderr, "Run `lazyagent passphrase --show` to print the bearer token.")
 	fmt.Fprintln(os.Stderr, "Restart `lazyagent --api` for the new token to take effect.")
 	return 0
 }

--- a/internal/search/extractors.go
+++ b/internal/search/extractors.go
@@ -151,8 +151,6 @@ func extractChunks(src sourceState, cfg core.Config) ([]chunk, error) {
 	default:
 		return nil, fmt.Errorf("unsupported agent %q", src.Agent)
 	}
-	_ = cfg
-	return nil, nil
 }
 
 type genericBlock struct {

--- a/internal/tray/service.go
+++ b/internal/tray/service.go
@@ -386,9 +386,13 @@ func (s *SessionService) OpenReleases() {
 	browser.OpenURL("https://github.com/illegalstudio/lazyagent/releases")
 }
 
-// GetConfig returns the current config.
+// GetConfig returns the current config. The API passphrase is scrubbed
+// before returning so the secret never crosses the Wails IPC boundary into
+// the frontend (mirrors what /api/config does for HTTP callers).
 func (s *SessionService) GetConfig() core.Config {
-	return core.LoadConfig()
+	cfg := core.LoadConfig()
+	cfg.APIPassphrase = ""
+	return cfg
 }
 
 // Detach switches from tray panel to a normal detached window.

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/core"
 	"github.com/illegalstudio/lazyagent/internal/demo"
 	"github.com/illegalstudio/lazyagent/internal/limits"
+	"github.com/illegalstudio/lazyagent/internal/passphrase"
 	"github.com/illegalstudio/lazyagent/internal/prune"
 	"github.com/illegalstudio/lazyagent/internal/search"
 	"github.com/illegalstudio/lazyagent/internal/tray"
@@ -40,6 +41,8 @@ func main() {
 			os.Exit(search.Run(os.Args[2:]))
 		case "limits":
 			os.Exit(limits.Run(os.Args[2:]))
+		case "passphrase":
+			os.Exit(passphrase.Run(os.Args[2:]))
 		}
 	}
 
@@ -80,6 +83,8 @@ Subcommands:
   lazyagent search "query"      Search chat transcripts with highlighted snippets
   lazyagent limits              Show 5h / weekly rate-limit usage and pace
   lazyagent limits --help       Show limits options (--agent claude|codex|all)
+  lazyagent passphrase          Set or rotate the HTTP API passphrase
+  lazyagent passphrase --show   Print the current bearer token without prompting
 
 Flags:
 `, version.String())

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/illegalstudio/lazyagent/internal/api"
+	"github.com/illegalstudio/lazyagent/internal/apiauth"
 	"github.com/illegalstudio/lazyagent/internal/compact"
 	"github.com/illegalstudio/lazyagent/internal/core"
 	"github.com/illegalstudio/lazyagent/internal/demo"
@@ -158,7 +159,13 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 	var apiDone chan struct{}
 
 	if runAPI {
-		srv, err := api.New(*apiHost, provider)
+		bearerToken, err := setupAPIAuth(&cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		srv, err := api.New(*apiHost, provider, bearerToken)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
@@ -201,6 +208,41 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 			<-apiDone
 		}
 	}
+}
+
+// setupAPIAuth resolves the API passphrase (env var, configured value, or
+// interactive prompt), persists it if the user just chose one, and returns
+// the bearer token derived from it. It also prints the bearer token to
+// stderr so the user can copy it into clients (mobile app, curl).
+//
+// Returns an error when no passphrase is configured and stdin is not a
+// terminal — in that case the API server cannot start.
+func setupAPIAuth(cfg *core.Config) (string, error) {
+	passphrase, fromPrompt, err := apiauth.ResolvePassphrase(cfg.APIPassphrase)
+	if err != nil {
+		if err == apiauth.ErrNoTTY {
+			fmt.Fprintln(os.Stderr, "Error: API passphrase not configured.")
+			fmt.Fprintln(os.Stderr, "Run `lazyagent --api` from a terminal to set one,")
+			fmt.Fprintf(os.Stderr, "or set the %s environment variable.\n", apiauth.EnvVar)
+			return "", fmt.Errorf("no passphrase available")
+		}
+		return "", err
+	}
+
+	if fromPrompt {
+		cfg.APIPassphrase = passphrase
+		if err := core.SaveConfig(*cfg); err != nil {
+			return "", fmt.Errorf("save config: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Passphrase saved to %s\n\n", core.ConfigPath())
+	}
+
+	token := apiauth.DeriveToken(passphrase)
+	fmt.Fprintln(os.Stderr, "API authentication enabled.")
+	fmt.Fprintf(os.Stderr, "Bearer token: %s\n", token)
+	fmt.Fprintln(os.Stderr, "Use header:   Authorization: Bearer <token>")
+	fmt.Fprintln(os.Stderr)
+	return token, nil
 }
 
 // forkTray launches the tray as a detached background process with its own main thread.

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 			os.Exit(1)
 		}
 
-		srv, err := api.New(*apiHost, provider, bearerToken)
+		srv, err := api.New(*apiHost, provider, bearerToken, cfg.APISalt)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
@@ -217,8 +217,7 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 
 // setupAPIAuth resolves the API passphrase (env var, configured value, or
 // interactive prompt), persists it if the user just chose one, and returns
-// the bearer token derived from it. It also prints the bearer token to
-// stderr so the user can copy it into clients (mobile app, curl).
+// the bearer token derived from it.
 //
 // Returns an error when no passphrase is configured and stdin is not a
 // terminal — in that case the API server cannot start.
@@ -234,18 +233,27 @@ func setupAPIAuth(cfg *core.Config) (string, error) {
 		return "", err
 	}
 
+	saltChanged := core.EnsureAPISalt(cfg)
 	if fromPrompt {
 		cfg.APIPassphrase = passphrase
+	}
+	if fromPrompt || saltChanged {
 		if err := core.SaveConfig(*cfg); err != nil {
 			return "", fmt.Errorf("save config: %w", err)
 		}
+	}
+	if fromPrompt {
 		fmt.Fprintf(os.Stderr, "Passphrase saved to %s\n\n", core.ConfigPath())
 	}
 
-	token := apiauth.DeriveToken(passphrase)
+	token := apiauth.DeriveToken(passphrase, cfg.APISalt)
 	fmt.Fprintln(os.Stderr, "API authentication enabled.")
-	fmt.Fprintf(os.Stderr, "Bearer token: %s\n", token)
-	fmt.Fprintln(os.Stderr, "Use header:   Authorization: Bearer <token>")
+	if fromPrompt {
+		fmt.Fprintf(os.Stderr, "Bearer token: %s\n", token)
+		fmt.Fprintln(os.Stderr, "Use header:   Authorization: Bearer <token>")
+	} else {
+		fmt.Fprintln(os.Stderr, "Use `lazyagent passphrase --show` to print the bearer token.")
+	}
 	fmt.Fprintln(os.Stderr)
 	return token, nil
 }


### PR DESCRIPTION
- **Add apiauth package for Bearer token derivation and middleware**
- **Protect API endpoints with Bearer-token authentication**
- **Add passphrase subcommand to set or rotate the API passphrase**
- **Document passphrase-based API authentication**
- **Track empty internal/assets/dist for go:embed**
- **Tighten config file permissions to 0o600**
- **Scrub passphrase from Wails GetConfig binding**
- **Allow Authorization header in CORS preflight**
- **Standardize stdout/stderr for passphrase subcommand**
- **Warn when env var would override a passphrase rotation**
- **Test ResolvePassphrase priority ladder**
- **Warn about short passphrase before asking for confirmation**
- **Warn loudly when API server starts without authentication**
- **Flag env/config divergence in passphrase --show**
- **Document subtle invariants in apiauth and playground**
- **Harden API passphrase authentication**
- **Document hardened API authentication**
- **Remove unreachable search extractor code**
