### PR TITLE
feat: add config-based CWD substring filter for session exclusion

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,10 @@ before:
   hooks:
     - npm install --prefix frontend
     - npm run build --prefix frontend
+    # internal/assets/dist/ is tracked (with .gitkeep) so the embed compiles
+    # on a bare clone. Plain `cp -r SRC DST` over an existing dir nests as
+    # DST/SRC/, so we wipe the target first.
+    - rm -rf internal/assets/dist
     - cp -r frontend/dist internal/assets/dist
 
 builds:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: build
 
 # Build with frontend (TUI + GUI support)
 build: frontend
+	rm -rf internal/assets/dist
 	cp -r frontend/dist internal/assets/dist
 	go build -o lazyagent .
 
@@ -26,6 +27,7 @@ install:
 # Dev mode: rebuild frontend and run GUI app
 dev: bindings
 	cd frontend && npm run build
+	rm -rf internal/assets/dist
 	cp -r frontend/dist internal/assets/dist
 	go run . --gui
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -26,6 +26,7 @@ lazyagent reads `~/.config/lazyagent/config.json` (or `$XDG_CONFIG_HOME/lazyagen
     "pi": true
   },
   "claude_dirs": [],
+  "exclude_cwd_substrings": [],
   "api_salt": "lazyagent-api-v1-2CwLr3D6GKbVv5m0Pu1nHQ",
   "tui": {
     "theme": "dark"
@@ -90,6 +91,23 @@ Default: `[]`. Extra Claude base directories to scan. Each entry must be a direc
 ```
 
 When empty, lazyagent auto-detects from the `CLAUDE_CONFIG_DIR` environment variable, falling back to `~/.claude`. Use this field if you keep Claude sessions somewhere non-standard and want lazyagent to pick them up without setting env vars every time.
+
+### `exclude_cwd_substrings`
+
+Default: `[]`. List of substrings; any session whose working directory (CWD) contains one of them is hidden from every interface (TUI, tray panel, HTTP API). Matching is a literal substring check on the full CWD path, case-sensitive.
+
+```json
+{
+  "exclude_cwd_substrings": [
+    ".claude-mem/observer-sessions",
+    "/tmp/scratch"
+  ]
+}
+```
+
+Useful for hiding background or automated sessions (e.g. observer processes, autonomous loops) that run without user attention and would otherwise clutter the active list. Sessions are still on disk and visible to other tools — this only affects what lazyagent shows.
+
+Substring matching is intentional and broad: `"test"` would also hide `/home/me/projects/latest`. Use a path-shaped fragment (with a `/` in it) when you want to be specific.
 
 ### `api_passphrase`
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -54,6 +54,7 @@ func New(host string, provider core.SessionProvider, bearerToken, authSalt strin
 
 	cfg := core.LoadConfig()
 	manager := core.NewSessionManager(cfg.WindowMinutes, provider)
+	manager.SetExcludeCWDSubstrings(cfg.ExcludeCWDSubstrings)
 
 	s := &Server{
 		manager:  manager,

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -18,13 +18,13 @@ type TUIConfig struct {
 
 // Config holds application settings shared by TUI and GUI.
 type Config struct {
-	WindowMinutes  int             `json:"window_minutes"`
-	DefaultFilter  string          `json:"default_filter"`
-	Editor         string          `json:"editor"`
-	LaunchAtLogin  bool            `json:"launch_at_login"`
-	Notifications  bool            `json:"notifications"`
-	NotifyAfterSec int             `json:"notify_after_sec"`
-	Agents         map[string]bool `json:"agents"`
+	WindowMinutes        int             `json:"window_minutes"`
+	DefaultFilter        string          `json:"default_filter"`
+	Editor               string          `json:"editor"`
+	LaunchAtLogin        bool            `json:"launch_at_login"`
+	Notifications        bool            `json:"notifications"`
+	NotifyAfterSec       int             `json:"notify_after_sec"`
+	Agents               map[string]bool `json:"agents"`
 	ClaudeDirs           []string        `json:"claude_dirs,omitempty"`
 	ExcludeCWDSubstrings []string        `json:"exclude_cwd_substrings"`
 	TUI                  TUIConfig       `json:"tui"`

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -25,8 +25,9 @@ type Config struct {
 	Notifications  bool            `json:"notifications"`
 	NotifyAfterSec int             `json:"notify_after_sec"`
 	Agents         map[string]bool `json:"agents"`
-	ClaudeDirs     []string        `json:"claude_dirs,omitempty"`
-	TUI            TUIConfig       `json:"tui"`
+	ClaudeDirs           []string        `json:"claude_dirs,omitempty"`
+	ExcludeCWDSubstrings []string        `json:"exclude_cwd_substrings"`
+	TUI                  TUIConfig       `json:"tui"`
 	// APIPassphrase is the secret used to derive the bearer token that
 	// protects the HTTP API. Empty means the API has not been configured yet
 	// — `lazyagent --api` will prompt for one on first run.
@@ -54,7 +55,8 @@ func DefaultConfig() Config {
 			"codex":    true,
 			"amp":      true,
 		},
-		TUI: TUIConfig{Theme: "dark"},
+		ExcludeCWDSubstrings: []string{},
+		TUI:                  TUIConfig{Theme: "dark"},
 	}
 }
 
@@ -123,6 +125,10 @@ func LoadConfig() Config {
 				changed = true
 			}
 		}
+	}
+	if cfg.ExcludeCWDSubstrings == nil {
+		cfg.ExcludeCWDSubstrings = defaults.ExcludeCWDSubstrings
+		changed = true
 	}
 	if changed {
 		_ = SaveConfig(cfg)

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig_ExcludeCWDSubstrings(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.ExcludeCWDSubstrings == nil {
+		t.Fatal("DefaultConfig().ExcludeCWDSubstrings should not be nil")
+	}
+	if len(cfg.ExcludeCWDSubstrings) != 0 {
+		t.Errorf("DefaultConfig().ExcludeCWDSubstrings = %v, want empty slice", cfg.ExcludeCWDSubstrings)
+	}
+}
+
+func TestLoadConfig_BackfillsExcludeCWDSubstrings(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Write a config file without ExcludeCWDSubstrings.
+	cfgDir := filepath.Join(tmpDir, "lazyagent")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	minimalCfg := map[string]interface{}{
+		"window_minutes": 30,
+		"agents":         map[string]bool{"claude": true},
+	}
+	data, _ := json.Marshal(minimalCfg)
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadConfig()
+	if cfg.ExcludeCWDSubstrings == nil {
+		t.Fatal("LoadConfig() did not backfill ExcludeCWDSubstrings")
+	}
+	if len(cfg.ExcludeCWDSubstrings) != 0 {
+		t.Errorf("LoadConfig().ExcludeCWDSubstrings = %v, want []", cfg.ExcludeCWDSubstrings)
+	}
+}
+
+func TestLoadConfig_PreservesExistingExcludeCWDSubstrings(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	// Write a config file with custom ExcludeCWDSubstrings.
+	cfgDir := filepath.Join(tmpDir, "lazyagent")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	customCfg := map[string]interface{}{
+		"window_minutes":         30,
+		"agents":                 map[string]bool{"claude": true},
+		"exclude_cwd_substrings": []string{"/custom/path", "/another"},
+	}
+	data, _ := json.Marshal(customCfg)
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := LoadConfig()
+	if len(cfg.ExcludeCWDSubstrings) != 2 {
+		t.Fatalf("LoadConfig() ExcludeCWDSubstrings length = %d, want 2", len(cfg.ExcludeCWDSubstrings))
+	}
+	if cfg.ExcludeCWDSubstrings[0] != "/custom/path" || cfg.ExcludeCWDSubstrings[1] != "/another" {
+		t.Errorf("LoadConfig().ExcludeCWDSubstrings = %v, want [/custom/path /another]", cfg.ExcludeCWDSubstrings)
+	}
+}

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -65,7 +65,7 @@ func NewSessionManager(windowMinutes int, provider SessionProvider) *SessionMana
 // sessions from filtered views (VisibleSessions / QuerySessions).
 func (m *SessionManager) SetExcludeCWDSubstrings(patterns []string) {
 	m.mu.Lock()
-	m.excludeCWDSubstrings = patterns
+	m.excludeCWDSubstrings = slices.Clone(patterns)
 	m.mu.Unlock()
 }
 

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -44,10 +44,11 @@ type SessionManager struct {
 	provider SessionProvider
 	names    *SessionNames
 
-	windowMinutes    int
-	activityFilter   ActivityKind
-	searchQuery      string
-	lastPollDiscover time.Time
+	windowMinutes        int
+	activityFilter       ActivityKind
+	searchQuery          string
+	lastPollDiscover     time.Time
+	excludeCWDSubstrings []string
 }
 
 // NewSessionManager creates a new SessionManager with the given provider.
@@ -58,6 +59,14 @@ func NewSessionManager(windowMinutes int, provider SessionProvider) *SessionMana
 		provider:      provider,
 		names:         NewSessionNames(),
 	}
+}
+
+// SetExcludeCWDSubstrings sets the CWD substring patterns used to exclude
+// sessions from filtered views (VisibleSessions / QuerySessions).
+func (m *SessionManager) SetExcludeCWDSubstrings(patterns []string) {
+	m.mu.Lock()
+	m.excludeCWDSubstrings = patterns
+	m.mu.Unlock()
 }
 
 // SessionName returns the custom name for a session, or empty string.
@@ -225,6 +234,17 @@ func (m *SessionManager) filterSessionsLocked(search string, filter ActivityKind
 	lowerQuery := strings.ToLower(search)
 	var visible []*model.Session
 	for _, s := range m.sessions {
+		// CWD-based exclusion: skip sessions whose CWD contains any excluded substring.
+		excluded := false
+		for _, pattern := range m.excludeCWDSubstrings {
+			if pattern != "" && strings.Contains(s.CWD, pattern) {
+				excluded = true
+				break
+			}
+		}
+		if excluded {
+			continue
+		}
 		if s.IsSidechain || !s.LastActivity.After(cutoff) {
 			continue
 		}

--- a/internal/core/session_test.go
+++ b/internal/core/session_test.go
@@ -54,3 +54,100 @@ func TestReload_PreservesUserSetNames(t *testing.T) {
 		t.Errorf("SessionName(s1) = %q, want 'My custom name'", got)
 	}
 }
+
+func TestFilterSessionsLocked_ExcludesCWDSubstrings(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	provider := fakeProvider{
+		sessions: []*model.Session{
+			{SessionID: "normal", CWD: "/home/user/project", LastActivity: now},
+			{SessionID: "excluded", CWD: "/home/user/.claude-mem/observer-sessions/abc", LastActivity: now},
+			{SessionID: "also-normal", CWD: "/home/user/other-project", LastActivity: now},
+		},
+	}
+
+	mgr := NewSessionManager(60, provider)
+	mgr.SetExcludeCWDSubstrings([]string{".claude-mem/observer-sessions"})
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+
+	// Sessions() returns all raw sessions (unfiltered by CWD exclusion).
+	raw := mgr.Sessions()
+	if len(raw) != 3 {
+		t.Errorf("Sessions() returned %d sessions, want 3", len(raw))
+	}
+
+	// VisibleSessions should exclude the matching session.
+	visible := mgr.VisibleSessions()
+	for _, s := range visible {
+		if s.SessionID == "excluded" {
+			t.Error("VisibleSessions() should not contain the excluded session")
+		}
+	}
+	if len(visible) != 2 {
+		t.Errorf("VisibleSessions() returned %d sessions, want 2", len(visible))
+	}
+
+	// QuerySessions should also exclude the matching session.
+	queried := mgr.QuerySessions("", "")
+	for _, s := range queried {
+		if s.SessionID == "excluded" {
+			t.Error("QuerySessions() should not contain the excluded session")
+		}
+	}
+	if len(queried) != 2 {
+		t.Errorf("QuerySessions() returned %d sessions, want 2", len(queried))
+	}
+}
+
+func TestFilterSessionsLocked_NoExcludePatterns(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	provider := fakeProvider{
+		sessions: []*model.Session{
+			{SessionID: "s1", CWD: "/home/user/project", LastActivity: now},
+			{SessionID: "s2", CWD: "/home/user/.claude-mem/observer-sessions/abc", LastActivity: now},
+		},
+	}
+
+	mgr := NewSessionManager(60, provider)
+	// No SetExcludeCWDSubstrings call — empty/nil patterns.
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+
+	visible := mgr.VisibleSessions()
+	if len(visible) != 2 {
+		t.Errorf("VisibleSessions() returned %d sessions, want 2 (no exclusion)", len(visible))
+	}
+}
+
+func TestFilterSessionsLocked_MultipleExcludePatterns(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	provider := fakeProvider{
+		sessions: []*model.Session{
+			{SessionID: "normal", CWD: "/home/user/project", LastActivity: now},
+			{SessionID: "obs", CWD: "/home/user/.claude-mem/observer-sessions/x", LastActivity: now},
+			{SessionID: "tmp", CWD: "/tmp/scratch/build", LastActivity: now},
+		},
+	}
+
+	mgr := NewSessionManager(60, provider)
+	mgr.SetExcludeCWDSubstrings([]string{".claude-mem/observer-sessions", "/tmp/scratch"})
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+
+	visible := mgr.VisibleSessions()
+	if len(visible) != 1 {
+		t.Errorf("VisibleSessions() returned %d sessions, want 1", len(visible))
+	}
+	if len(visible) > 0 && visible[0].SessionID != "normal" {
+		t.Errorf("expected 'normal' session, got %q", visible[0].SessionID)
+	}
+}

--- a/internal/tray/service.go
+++ b/internal/tray/service.go
@@ -48,6 +48,7 @@ func (s *SessionService) ServiceStartup(ctx context.Context, options application
 		}
 	}
 	s.manager = core.NewSessionManager(cfg.WindowMinutes, provider)
+	s.manager.SetExcludeCWDSubstrings(cfg.ExcludeCWDSubstrings)
 	if err := s.manager.StartWatcher(); err != nil {
 		return err
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -116,6 +116,7 @@ func NewModel(provider core.SessionProvider) Model {
 	cfg := core.LoadConfig()
 	t := LoadTheme(cfg.TUI.Theme)
 	mgr := core.NewSessionManager(cfg.WindowMinutes, provider)
+	mgr.SetExcludeCWDSubstrings(cfg.ExcludeCWDSubstrings)
 	_ = mgr.StartWatcher()
 	return Model{
 		theme:     t,

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/illegalstudio/lazyagent/internal/api"
 	"github.com/illegalstudio/lazyagent/internal/apiauth"
+	"github.com/illegalstudio/lazyagent/internal/assets"
 	"github.com/illegalstudio/lazyagent/internal/compact"
 	"github.com/illegalstudio/lazyagent/internal/core"
 	"github.com/illegalstudio/lazyagent/internal/demo"
@@ -138,6 +139,14 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 			fmt.Fprintln(os.Stderr, "Error: --gui is not available in this build")
 			os.Exit(1)
 		}
+		// Pre-flight: the parent forks the tray with stderr suppressed, so a
+		// missing frontend embed would exit silently. Catch it here for a
+		// terminal-visible diagnostic.
+		if !assets.HasFrontend() {
+			fmt.Fprintln(os.Stderr, "Error: --gui requires embedded frontend assets that are missing from this binary.")
+			fmt.Fprintln(os.Stderr, "Rebuild with 'make build' from source, or reinstall the official release.")
+			os.Exit(1)
+		}
 
 		if os.Getenv("LAZYAGENT_DETACHED") == "" {
 			// Always fork the tray as a separate process (macOS Cocoa needs its own main thread).
@@ -151,6 +160,7 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 			defer os.Remove(trayPidFile)
 
 			if err := tray.Run(*demoMode, *agentMode); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
 			return


### PR DESCRIPTION
## Summary

- Adds `exclude_cwd_substrings` config option to filter sessions by CWD substring matching
- Opt-in design: default is empty array, users add patterns they want excluded
- Covers all interfaces (TUI, HTTP API, tray) via single `filterSessionsLocked` gate

## Motivation

Background/automated agent sessions (observer processes, autonomous loops) run without user attention but appear in the session list alongside interactive ones, creating noise. This gives users a simple way to hide them.

## Changes

- `internal/core/config.go`: `ExcludeCWDSubstrings` field, `DefaultConfig` empty default, `LoadConfig` backfill
- `internal/core/session.go`: `SetExcludeCWDSubstrings` setter, CWD exclusion in `filterSessionsLocked`
- `internal/ui/app.go`, `internal/tray/service.go`, `internal/api/server.go`: wiring
- `internal/core/session_test.go`, `internal/core/config_test.go`: unit tests

## Example config

```json
{
  "exclude_cwd_substrings": [".claude-mem/observer-sessions"]
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/core/ -v` — all tests pass
- [x] `go vet ./...` clean
- [x] Manual TUI verification: observer sessions hidden with config set

Closes #30