### PR TITLE
fix: show clear error when --gui lacks frontend assets

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/illegalstudio/lazyagent/internal/api"
+	"github.com/illegalstudio/lazyagent/internal/assets"
 	"github.com/illegalstudio/lazyagent/internal/apiauth"
 	"github.com/illegalstudio/lazyagent/internal/compact"
 	"github.com/illegalstudio/lazyagent/internal/core"
@@ -138,6 +139,10 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 			fmt.Fprintln(os.Stderr, "Error: --gui is not available in this build")
 			os.Exit(1)
 		}
+		if !assets.HasFrontend() {
+			fmt.Fprintln(os.Stderr, "Error: frontend assets not found — run 'make build' to include the menu bar app")
+			os.Exit(1)
+		}
 
 		if os.Getenv("LAZYAGENT_DETACHED") == "" {
 			// Always fork the tray as a separate process (macOS Cocoa needs its own main thread).
@@ -151,6 +156,7 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 			defer os.Remove(trayPidFile)
 
 			if err := tray.Run(*demoMode, *agentMode); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 				os.Exit(1)
 			}
 			return


### PR DESCRIPTION
## Summary

`lazyagent --gui` silently exits with no output when the binary lacks embedded frontend assets (e.g. Homebrew Cask install of v0.8.9). This happens because:

1. `forkTray()` sets child `stdout/stderr = nil`
2. Child's `tray.Run()` returns an error when `assets.HasFrontend()` fails
3. `main.go:153` calls `os.Exit(1)` without printing the error

## Fix

- Add a pre-fork `assets.HasFrontend()` check in the parent process (which still has stderr) so users see:
  ```
  Error: frontend assets not found — run 'make build' to include the menu bar app
  ```
- Also print the error in the detached child path for completeness

## Testing

- macOS 15 (Apple Silicon, M4 Max)
- Built from source with `make build` → `--gui` works correctly, menu bar app launches and shows sessions
- Currently using the self-built binary with `--gui` as my daily driver — confirmed working
- Built without frontend (`go build .`) → now shows clear error instead of silent exit

## Note

The release binary distributed via Homebrew Cask (`illegalstudio/homebrew-tap`) appears to lack frontend assets. Including frontend assets in the release build pipeline would allow Homebrew users to use `--gui` out of the box.

Fixes #32