### PR TITLE
feature/grok integration

### DIFF
--- a/docs/concepts/supported-agents.md
+++ b/docs/concepts/supported-agents.md
@@ -69,22 +69,11 @@ OpenCode uses SQLite with relational tables (`session`, `message`, `part`). lazy
 
 ### Grok CLI
 
-Grok writes one *directory* per session, two levels deep under
-`~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/`. Each session directory
-holds a `summary.json` (metadata), a `chat_history.jsonl` (transcript), an
-`updates.jsonl` stream, and several smaller files. lazyagent reads
-`summary.json` plus `chat_history.jsonl` and decodes the cwd from the standard
-URL percent-encoding of the parent directory name.
+Grok writes one *directory* per session, two levels deep under `~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/`. Each session directory holds a `summary.json` (metadata), a `chat_history.jsonl` (transcript), an `updates.jsonl` stream, and several smaller files. lazyagent reads `summary.json` plus `chat_history.jsonl` and decodes the cwd from the standard URL percent-encoding of the parent directory name.
 
-**No per-session cost.** Grok's on-disk data does not expose an
-input/output/cache token split, so Grok sessions show no per-session token or
-cost figures in any interface — those fields are honestly left at zero. (The
-separate `lazyagent limits` command still reports Grok's monthly billing
-window; that uses Grok's billing API, not on-disk session data.)
+**No per-session cost.** Grok's on-disk data does not expose an input/output/cache token split, so Grok sessions show no per-session token or cost figures in any interface — those fields are left at zero. (The separate `lazyagent limits` command still reports Grok's monthly billing window; that uses Grok's billing API, not on-disk session data.)
 
-**Subagent sessions** (`session_kind: "subagent"` in `summary.json`) are
-treated as sidechains and hidden from the default list, the same as Claude's
-sub-agent sessions.
+**Subagent sessions** (`session_kind: "subagent"` in `summary.json`) are treated as sidechains and hidden from the default list, the same as Claude's sub-agent sessions.
 
 ## What's not supported (yet)
 

--- a/docs/concepts/supported-agents.md
+++ b/docs/concepts/supported-agents.md
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-lazyagent supports seven agents out of the box. Each has a dedicated provider that knows the agent's on-disk layout.
+lazyagent supports eight agents out of the box. Each has a dedicated provider that knows the agent's on-disk layout.
 
 | Agent | Path | Format | Prefix |
 |-------|------|--------|--------|
@@ -16,6 +16,7 @@ lazyagent supports seven agents out of the box. Each has a dedicated provider th
 | [Amp CLI](https://ampcode.com/) | `~/.local/share/amp/threads/*.json` | Per-thread JSON | `A` |
 | [pi coding agent](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/*/` | JSONL | `π` |
 | [OpenCode](https://opencode.ai/) | `~/.local/share/opencode/opencode.db` | SQLite | `O` |
+| [Grok CLI](https://github.com/xai-org/grok-cli) | `~/.grok/sessions/<encoded-cwd>/<uuid>/` | Directory per session (JSONL + JSON) | `G` |
 
 The prefix appears next to each session in the TUI list, the GUI panel, and the API response so you can tell at a glance which agent produced a session.
 
@@ -30,6 +31,7 @@ lazyagent --agent codex
 lazyagent --agent amp
 lazyagent --agent pi
 lazyagent --agent opencode
+lazyagent --agent grok
 lazyagent --agent all       # default
 ```
 
@@ -64,6 +66,25 @@ Pi writes JSONL into `~/.pi/agent/sessions/--<encoded-cwd>--/`. The encoding is 
 ### OpenCode
 
 OpenCode uses SQLite with relational tables (`session`, `message`, `part`). lazyagent polls every 3 seconds and detects sub-agents via `parent_id`. Tool names are normalized to the same activity taxonomy as the other agents.
+
+### Grok CLI
+
+Grok writes one *directory* per session, two levels deep under
+`~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/`. Each session directory
+holds a `summary.json` (metadata), a `chat_history.jsonl` (transcript), an
+`updates.jsonl` stream, and several smaller files. lazyagent reads
+`summary.json` plus `chat_history.jsonl` and decodes the cwd from the standard
+URL percent-encoding of the parent directory name.
+
+**No per-session cost.** Grok's on-disk data does not expose an
+input/output/cache token split, so Grok sessions show no per-session token or
+cost figures in any interface — those fields are honestly left at zero. (The
+separate `lazyagent limits` command still reports Grok's monthly billing
+window; that uses Grok's billing API, not on-disk session data.)
+
+**Subagent sessions** (`session_kind: "subagent"` in `summary.json`) are
+treated as sidechains and hidden from the default list, the same as Claude's
+sub-agent sessions.
 
 ## What's not supported (yet)
 

--- a/docs/interfaces/http-api.md
+++ b/docs/interfaces/http-api.md
@@ -266,6 +266,8 @@ Full details for a single session.
 }
 ```
 
+The `timestamp` field in `recent_tools` and `recent_messages` is optional and omitted when the time is unknown. Agents such as Grok record no per-item timestamp in their transcripts; only the most recent tool call and the most recent message carry a timestamp (the session's last-activity time — the best available).
+
 Returns **`404 Not Found`** if the session doesn't exist.
 
 ### `PUT /api/sessions/{id}/name`

--- a/docs/maintenance/compact.md
+++ b/docs/maintenance/compact.md
@@ -25,7 +25,7 @@ All flags are optional. With no flags, compact opens the interactive agent picke
 | Flag | Type | Default | Summary |
 |------|------|---------|---------|
 | `--days N` | int | `0` (unset) | Only compact sessions idle more than N days |
-| `--agent LIST` | string | *unset* | Comma-separated subset: `claude,pi,codex`. Empty opens the picker |
+| `--agent LIST` | string | *unset* | Comma-separated subset: `claude,pi,codex,grok`. Empty opens the picker |
 | `--threshold-kb N` | int | `10` | Truncate JSON string values larger than N KiB |
 | `--min-size-kb N` | int | `512` | Skip files smaller than N KiB |
 | `--dry-run` | bool | `false` | Print a grouped summary, rewrite nothing |
@@ -75,7 +75,7 @@ Tuning guide:
 
 ## Agent selection
 
-Same interactive picker as `prune` when `--agent` is omitted — see [Prune: agent selection](prune.md#agent-selection) for the keybindings. Pass `--agent claude,codex,pi` to skip the picker.
+Same interactive picker as `prune` when `--agent` is omitted — see [Prune: agent selection](prune.md#agent-selection) for the keybindings. Pass `--agent claude,codex,pi,grok` to skip the picker.
 
 ## What gets truncated
 
@@ -108,6 +108,10 @@ Each agent has its own set of field paths. Only oversized values are touched; sh
 - `payload.message` — long agent_message payloads
 - `payload.arguments` — function call arguments
 - `payload.content[].text` / `input_text` / `output_text` — message content blocks
+
+### Grok CLI
+
+For Grok, compact rewrites the bulky files inside the session directory — `updates.jsonl`, oversized `tool_result` payloads in `chat_history.jsonl`, `rewind_points.jsonl`, and `terminal/*.log`. Truncating `rewind_points.jsonl` disables Grok's rewind feature for that session.
 
 ## Dry runs
 
@@ -163,6 +167,7 @@ mv session.jsonl.bak session.jsonl
 - **claude** (Claude Code CLI and Desktop share the same JSONL format)
 - **pi**
 - **codex**
+- **grok**
 
 Not supported:
 

--- a/docs/maintenance/compact.md
+++ b/docs/maintenance/compact.md
@@ -111,7 +111,12 @@ Each agent has its own set of field paths. Only oversized values are touched; sh
 
 ### Grok CLI
 
-For Grok, compact rewrites the bulky files inside the session directory — `updates.jsonl`, oversized `tool_result` payloads in `chat_history.jsonl`, `rewind_points.jsonl`, and `terminal/*.log`. Truncating `rewind_points.jsonl` disables Grok's rewind feature for that session.
+- `updates.jsonl` — the ACP update stream
+- `chat_history.jsonl` — oversized `tool_result` payloads
+- `rewind_points.jsonl` — checkpoint snapshots
+- `terminal/*.log` — raw terminal capture logs
+
+Truncating `rewind_points.jsonl` disables Grok's rewind feature for that session.
 
 ## Dry runs
 

--- a/docs/maintenance/prune.md
+++ b/docs/maintenance/prune.md
@@ -26,7 +26,7 @@ At least one of `--days` or `--orphaned` is required.
 |------|------|---------|---------|
 | `--days N` | int | *unset* | Include sessions idle more than N days |
 | `--orphaned` | bool | `false` | Include sessions whose project folder is gone |
-| `--agent LIST` | string | *unset* | Comma-separated subset: `claude,pi,codex`. Empty opens the picker |
+| `--agent LIST` | string | *unset* | Comma-separated subset: `claude,pi,codex,grok`. Empty opens the picker |
 | `--dry-run` | bool | `false` | Print a grouped summary, delete nothing |
 | `--dry-run-verbose` | bool | `false` | Print one row per file, delete nothing |
 | `--yes` | bool | `false` | Skip the destructive-op disclaimer |
@@ -39,7 +39,7 @@ lazyagent prune --orphaned                      # sessions whose project folder 
 lazyagent prune --days 30 --orphaned            # both filters (OR)
 lazyagent prune --days 30 --dry-run             # preview: group by project
 lazyagent prune --days 30 --dry-run-verbose     # preview: one row per file
-lazyagent prune --days 30 --agent claude,codex  # limit to specific agents
+lazyagent prune --days 30 --agent claude,codex,grok  # limit to specific agents
 lazyagent prune --days 30 --yes                 # skip the confirmation prompt
 ```
 
@@ -49,6 +49,8 @@ At least one of `--days` or `--orphaned` is required. They combine with **OR**: 
 
 - **`--days N`** — `LastActivity` is older than N days. Sessions without a recorded timestamp are skipped.
 - **`--orphaned`** — the session's `CWD` no longer resolves to an existing directory on disk. An empty CWD is treated as orphaned (the session can't be attributed to a project anyway).
+
+Grok sessions are stored as directories, so pruning a Grok session deletes the entire session directory recursively.
 
 ## Agent selection
 
@@ -62,6 +64,7 @@ If `--agent` is omitted, a bordered interactive picker opens with a checkbox for
   │ ▸ ○  ●  Claude Code    claude │
   │   ○  ●  pi coding agent pi    │
   │   ○  ●  Codex CLI      codex  │
+  │   ○  ●  Grok CLI       grok   │
   └───────────────────────────────┘
    ↑/↓ move   space toggle   a toggle-all   enter confirm   q cancel
 ```
@@ -125,7 +128,7 @@ The disclaimer and prompt are both skipped when `--yes` is passed, which is the 
 
 - **Active sessions** touched in the last 5 minutes are never deleted — the originating agent might still be writing.
 - **Sub-agent transcripts** are skipped to avoid breaking their parent's file.
-- A **path guard** refuses to delete anything outside the known agent roots (`~/.claude/projects`, `~/.pi/agent/sessions`, `~/.codex/sessions`).
+- A **path guard** refuses to delete anything outside the known agent roots (`~/.claude/projects`, `~/.pi/agent/sessions`, `~/.codex/sessions`, `~/.grok/sessions`).
 - **Codex index**: the per-session name index at `~/.codex/session_index.jsonl` is rewritten atomically (temp file + rename) so no dangling names remain.
 - **Claude Desktop sidecars**: when a CLI JSONL is deleted, the matching desktop metadata JSON (`~/Library/Application Support/Claude/claude-code-sessions/local_*.json`) is cleaned up alongside.
 - **Empty project folders** left behind after deletions are removed — but never the agent roots themselves.
@@ -135,6 +138,7 @@ The disclaimer and prompt are both skipped when `--yes` is passed, which is the 
 - **claude** — including Claude Desktop sidecars
 - **pi**
 - **codex** — including the session-name index
+- **grok** — session directory deleted recursively
 
 Not supported:
 
@@ -151,7 +155,7 @@ lazyagent prune --days 90
 lazyagent prune --orphaned --dry-run-verbose
 
 # Scheduled weekly sweep (script-safe)
-lazyagent prune --days 30 --orphaned --agent claude,codex,pi --yes
+lazyagent prune --days 30 --orphaned --agent claude,codex,pi,grok --yes
 
 # Target a single noisy agent
 lazyagent prune --agent codex --days 14

--- a/docs/maintenance/search.md
+++ b/docs/maintenance/search.md
@@ -77,6 +77,8 @@ Type a 1-based result number to open that session in the originating agent. lazy
 
 The command runs from the session's original CWD when that directory still exists, otherwise from the current shell directory. Pressing <kbd>Enter</kbd> on an empty line exits without opening anything.
 
+> **Grok sessions** are indexed and searchable, but `search` cannot resume them directly — Grok exposes no resume command, so selecting a Grok result reports that and exits.
+
 ## Index management
 
 The index updates *incrementally* on every run — there's normally no reason to think about it. Two situations call for a manual rebuild:

--- a/docs/maintenance/search.md
+++ b/docs/maintenance/search.md
@@ -7,7 +7,7 @@ sidebar:
 
 `lazyagent search` finds messages across every chat transcript on your machine. Run a query, get a ranked list of sessions with highlighted snippets, optionally pick one and resume it directly with the originating agent.
 
-It works with the agents that store transcripts as plain text files: **Claude Code** (CLI and Desktop), **Codex CLI**, **pi**, and **Amp**. Cursor and OpenCode are excluded because they keep history inside third-party SQLite databases that lazyagent doesn't index.
+It works with the agents that store transcripts as plain text files: **Claude Code** (CLI and Desktop), **Codex CLI**, **pi**, **Amp**, and **Grok**. Cursor and OpenCode are excluded because they keep history inside third-party SQLite databases that lazyagent doesn't index.
 
 ## Synopsis
 
@@ -23,7 +23,7 @@ lazyagent search [QUERY] [--agent LIST]
 
 | Flag | Type | Default | Summary |
 |------|------|---------|---------|
-| `--agent LIST` | string | `all` | Comma-separated subset: `claude,codex,pi,amp`, or `all` |
+| `--agent LIST` | string | `all` | Comma-separated subset: `claude,codex,pi,amp,grok`, or `all` |
 | `--limit N` | int | `20` | Maximum chat sessions to show |
 | `--snippets N` | int | `2` | Maximum snippet lines per session |
 | `--reindex` | bool | `false` | Drop the local index and rebuild it before searching |
@@ -105,6 +105,7 @@ The next `lazyagent search` invocation will rebuild it.
 - **codex** — Codex CLI (`~/.codex/sessions/`)
 - **pi** — pi coding agent (`~/.pi/agent/sessions/`)
 - **amp** — Amp CLI (`~/.local/share/amp/threads/`)
+- **grok** — Grok CLI (`~/.grok/sessions/`)
 
 Not supported:
 

--- a/docs/superpowers/plans/2026-05-20-grok-agent-integration.md
+++ b/docs/superpowers/plans/2026-05-20-grok-agent-integration.md
@@ -1,0 +1,2312 @@
+# Grok Agent Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add xAI's Grok CLI as a first-class agent in `lazyagent` — discovered in the TUI/GUI/API, searchable, prunable, and compactable — alongside Claude, Codex, Cursor, Amp, pi, and OpenCode.
+
+**Architecture:** A new `internal/grok` provider package, modeled on `internal/pi`, walks `~/.grok/sessions/<encoded-cwd>/<uuid>/` (depth exactly 2), parses each session directory into a `model.Session`, and integrates with `model.SessionCache`. Grok sessions are *directories* (not single JSONL files), so `prune` and `compact` get directory-aware branches. Subagent sessions are hidden by reusing the existing `IsSidechain` filter. Token/cost fields stay zero — Grok's on-disk data exposes no input/output/cache split.
+
+**Tech Stack:** Go 1.x, standard library (`encoding/json`, `net/url`, `path/filepath`, `bufio`), `modernc.org/sqlite` (search index only — Grok's own FTS index is not reused).
+
+---
+
+## Design decisions locked in before implementation
+
+These resolve ambiguities and minor tensions in the spec. They are binding for every task below.
+
+1. **`model.Session.JSONLPath` = the session *directory* absolute path** (spec §4.2 lists this as the first option). `prune` deletes it with `os.RemoveAll`; `compact` treats it as a directory of files. Search builds its own sources and does not use `JSONLPath`.
+2. **Cache invalidation key = `chat_history.jsonl`** (its path, mtime, size — via `model.SessionCache`). It is always present and grows on every message, so its mtime captures live activity. `summary.json` is small and re-read on every parse. A directory mtime would *not* catch in-file content changes, so the directory itself is not the key.
+3. **`EntryTimestamps` (activity sparkline) = a bounded tail of `updates.jsonl`.** Spec §4.2 maps the sparkline to `updates.jsonl` timestamps; spec §11 risk #6 says never read the *whole* `updates.jsonl` (it can be ~18 MB). A bounded 512 KiB tail satisfies both — it is not "the whole file", and the sparkline window is short so recent timestamps are all that matter.
+4. **Subagent sessions** (`summary.json` → `session_kind == "subagent"`) set `IsSidechain = true`. Verified: `core.SessionManager.filterSessionsLocked` (`internal/core/session.go:248`) drops `IsSidechain` sessions, and it backs the TUI (`VisibleSessions`), the tray/GUI (`internal/tray/service.go`), and the HTTP API (`QuerySessions`, `internal/api/server.go`). No new filter code is needed.
+5. **Token/cost fields stay zero** for Grok (`InputTokens`, `OutputTokens`, `CacheCreationTokens`, `CacheReadTokens`, `CostUSD`). Grok's data has no input/output/cache split. Documented as a per-agent caveat in Phase 5.
+6. **Test fixtures are synthetic temp directories** built by a shared `t.TempDir()` helper — exactly the pattern `internal/pi/process_test.go` uses (the spec names `internal/pi` as the authoritative template). No committed `testdata/` directory is needed; oversized-payload compact fixtures are also generated synthetically.
+7. **Resume command for `search` is out of scope.** The spec's integration file list (§5) does not include `internal/search/run.go`'s `resumeCommand`. `openResult` already prints a graceful "No resume command available" message for unknown agents — Grok search results are indexed, displayed, and openable-to-CWD, just not auto-resumed.
+
+---
+
+## File structure
+
+| File | Status | Responsibility |
+|------|--------|----------------|
+| `internal/grok/types.go` | Create | Go structs for `summary.json`, `chat_history.jsonl`, `signals.json`, `updates.jsonl`. |
+| `internal/grok/parse.go` | Create | `ParseGrokSession(dir)` → `*model.Session`; transcript / signals / updates-tail helpers. |
+| `internal/grok/process.go` | Create | `GrokSessionsDir()`, `DiscoverSessions(cache)`, `SessionDirs()`, `SessionDiskBytes(dir)`, depth-2 walk, parallel parse. |
+| `internal/grok/parse_test.go` | Create | Unit tests for `ParseGrokSession`. |
+| `internal/grok/process_test.go` | Create | Unit tests for discovery + the shared `writeGrokSession` test helper. |
+| `internal/core/provider.go` | Modify | `GrokProvider` type, `NewGrokProvider()`, `BuildProvider` case, `"all"` inclusion, import. |
+| `internal/core/config.go` | Modify | `"grok": true` in `DefaultConfig().Agents`. |
+| `internal/core/provider_test.go` | Create/Modify | `BuildProvider("grok", …)` returns a `*GrokProvider`. |
+| `main.go` | Modify | `grok` in the `--agent` flag help, usage block, and validation switch. |
+| `internal/ui/app.go` | Modify | `G ` prefix for `s.Agent == "grok"`. |
+| `internal/search/types.go` | Modify | `"grok"` in `supportedAgents`. |
+| `internal/search/extractors.go` | Modify | `listGrokSources`, `extractGrok`, `listSources`/`extractChunks` cases. |
+| `internal/search/run.go` | Modify | `grok` in the `--agent` help text. |
+| `internal/search/extractors_test.go` | Create | `extractGrok` test. |
+| `internal/prune/prune.go` | Modify | `"grok"` in `SupportedAgents`; package doc comment. |
+| `internal/prune/delete.go` | Modify | `deleteGrokSession`, `executeDelete` case, `removeEmptyDirs` grok root. |
+| `internal/prune/report.go` | Modify | `totalBytes` directory-aware branch for Grok. |
+| `internal/prune/delete_test.go` | Create/Modify | `deleteGrokSession` test. |
+| `internal/compact/grok.go` | Create | `compactGrokSession`, `estimateGrokSession`, `sessionSizeBytes`, deep-truncation helpers. |
+| `internal/compact/compact.go` | Modify | `grok` in `supportedAgents`; `collectCandidates` size branch. |
+| `internal/compact/rewrite.go` | Modify | `guardPath` grok root; `estimateSizes`/`executeCompact` grok branches; extract `estimateJSONL`. |
+| `internal/compact/grok_test.go` | Create | `compactGrokSession` test (oversized payload). |
+| `docs/superpowers/plans/2026-05-20-grok-compact-phase0-findings.md` | Create (Task 7) | Recorded outcome of the compact resume-verification. |
+| `docs/concepts/supported-agents.md` | Modify | Table row + per-agent "Grok" note. |
+| `docs/maintenance/prune.md`, `compact.md`, `search.md` | Modify | Add Grok to supported-agent lists. |
+| `docs/usage/cli.md` | Modify | Add Grok to the `--agent` table and `search`/`compact`/`prune` notes. |
+
+---
+
+## Phase 1 — Core provider
+
+Outcome: Grok sessions visible in TUI / GUI / API. Build stays green.
+
+### Task 1: `internal/grok` types + parser
+
+**Files:**
+- Create: `internal/grok/types.go`
+- Create: `internal/grok/parse.go`
+- Test: `internal/grok/parse_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/grok/parse_test.go`:
+
+```go
+package grok
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// writeSession creates a session directory at root/encodedCWD/uuid and writes
+// the given files (relative paths → contents) into it. Returns the session dir.
+func writeSession(t *testing.T, root, encodedCWD, uuid string, files map[string]string) string {
+	t.Helper()
+	dir := filepath.Join(root, encodedCWD, uuid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+const primarySummary = `{
+  "info": {"id": "019e0000-0000-7000-8000-000000000001", "cwd": "/Users/alice/project"},
+  "session_summary": "fix the parser",
+  "generated_title": "Fix the JSON parser bug",
+  "created_at": "2026-05-17T10:33:00.260953Z",
+  "updated_at": "2026-05-17T11:33:49.449038Z",
+  "last_active_at": "2026-05-17T11:33:49.449038Z",
+  "num_chat_messages": 4,
+  "current_model_id": "grok-build",
+  "head_branch": "feature/parser",
+  "chat_format_version": 1
+}`
+
+const primaryChat = `{"type":"system","content":"system prompt"}
+{"type":"user","content":[{"type":"text","text":"Hello Grok"}]}
+{"type":"assistant","content":"Working on it","tool_calls":[{"id":"call-1","name":"bash","arguments":"{}"}],"model_id":"grok-build"}
+{"type":"tool_result","content":"command output","tool_call_id":"call-1"}
+`
+
+const primarySignals = `{"userMessageCount":1,"assistantMessageCount":1,"contextTokensUsed":1234}`
+
+func TestParseGrokSession_Fields(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2FUsers%2Falice%2Fproject", "019e0000-0000-7000-8000-000000000001", map[string]string{
+		"summary.json":      primarySummary,
+		"chat_history.jsonl": primaryChat,
+		"signals.json":      primarySignals,
+	})
+
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatalf("ParseGrokSession: %v", err)
+	}
+	if s.Agent != "grok" {
+		t.Errorf("Agent = %q, want grok", s.Agent)
+	}
+	if s.SessionID != "019e0000-0000-7000-8000-000000000001" {
+		t.Errorf("SessionID = %q", s.SessionID)
+	}
+	if s.JSONLPath != dir {
+		t.Errorf("JSONLPath = %q, want %q", s.JSONLPath, dir)
+	}
+	if s.CWD != "/Users/alice/project" {
+		t.Errorf("CWD = %q", s.CWD)
+	}
+	if s.Name != "Fix the JSON parser bug" {
+		t.Errorf("Name = %q, want generated_title", s.Name)
+	}
+	if s.Model != "grok-build" {
+		t.Errorf("Model = %q", s.Model)
+	}
+	if s.GitBranch != "feature/parser" {
+		t.Errorf("GitBranch = %q", s.GitBranch)
+	}
+	if s.TotalMessages != 4 {
+		t.Errorf("TotalMessages = %d, want 4", s.TotalMessages)
+	}
+	if s.UserMessages != 1 || s.AssistantMessages != 1 {
+		t.Errorf("counts = (%d,%d), want (1,1)", s.UserMessages, s.AssistantMessages)
+	}
+	if s.LastActivity.IsZero() {
+		t.Error("LastActivity is zero")
+	}
+	if s.IsSidechain {
+		t.Error("primary session must not be a sidechain")
+	}
+	// Token/cost fields stay zero — Grok exposes no input/output/cache split.
+	if s.InputTokens != 0 || s.OutputTokens != 0 || s.CacheReadTokens != 0 ||
+		s.CacheCreationTokens != 0 || s.CostUSD != 0 {
+		t.Error("token/cost fields must stay zero for Grok")
+	}
+	if s.Status != model.StatusProcessingResult {
+		t.Errorf("Status = %v, want ProcessingResult (last entry is tool_result)", s.Status)
+	}
+}
+
+func TestParseGrokSession_TitleFallback(t *testing.T) {
+	root := t.TempDir()
+	// No generated_title, no session_summary → fall back to first user message.
+	summary := `{"info":{"id":"x","cwd":"/tmp/p"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z"}`
+	chat := `{"type":"user","content":[{"type":"text","text":"Please refactor auth"}]}` + "\n"
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "x", map[string]string{
+		"summary.json": summary, "chat_history.jsonl": chat,
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Name != "Please refactor auth" {
+		t.Errorf("Name = %q, want first user message", s.Name)
+	}
+}
+
+func TestParseGrokSession_CountsFromTranscriptWhenNoSignals(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "y", map[string]string{
+		"summary.json":      primarySummary,
+		"chat_history.jsonl": primaryChat,
+		// signals.json deliberately absent
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.UserMessages != 1 || s.AssistantMessages != 1 {
+		t.Errorf("counts from transcript = (%d,%d), want (1,1)", s.UserMessages, s.AssistantMessages)
+	}
+}
+
+func TestParseGrokSession_Subagent(t *testing.T) {
+	root := t.TempDir()
+	summary := `{"info":{"id":"sub","cwd":"/tmp/wt"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z","session_kind":"subagent"}`
+	dir := writeSession(t, root, "%2Ftmp%2Fwt", "sub", map[string]string{
+		"summary.json": summary, "chat_history.jsonl": "",
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.IsSidechain {
+		t.Error("subagent session must have IsSidechain = true")
+	}
+}
+
+func TestParseGrokSession_UnsupportedFormatVersion(t *testing.T) {
+	root := t.TempDir()
+	summary := `{"info":{"id":"z","cwd":"/tmp/p"},"chat_format_version":999,
+		"updated_at":"2026-05-17T11:00:00Z"}`
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "z", map[string]string{
+		"summary.json": summary,
+	})
+	if _, err := ParseGrokSession(dir); err == nil {
+		t.Error("expected error for unsupported chat_format_version")
+	}
+}
+
+func TestParseGrokSession_MissingSummary(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "w", map[string]string{
+		"chat_history.jsonl": primaryChat,
+	})
+	if _, err := ParseGrokSession(dir); err == nil {
+		t.Error("expected error when summary.json is missing")
+	}
+}
+
+func TestDecodeGrokDirName(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"%2FUsers%2Falice%2Fproject", "/Users/alice/project"},
+		{"%2Ftmp", "/tmp"},
+		{"plain", "plain"},
+	}
+	for _, tt := range tests {
+		if got := decodeGrokDirName(tt.in); got != tt.want {
+			t.Errorf("decodeGrokDirName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/grok/...`
+Expected: FAIL — `undefined: ParseGrokSession`, `undefined: decodeGrokDirName`.
+
+- [ ] **Step 3: Create `internal/grok/types.go`**
+
+```go
+package grok
+
+import "encoding/json"
+
+// grokSummary mirrors the subset of summary.json this package reads.
+// Timestamps are RFC3339 UTC strings with microseconds and a trailing Z.
+type grokSummary struct {
+	Info struct {
+		ID  string `json:"id"`
+		CWD string `json:"cwd"`
+	} `json:"info"`
+	SessionSummary    string `json:"session_summary"`
+	GeneratedTitle    string `json:"generated_title"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+	LastActiveAt      string `json:"last_active_at"`
+	NumChatMessages   int    `json:"num_chat_messages"`
+	CurrentModelID    string `json:"current_model_id"`
+	GitRootDir        string `json:"git_root_dir"`
+	HeadBranch        string `json:"head_branch"`
+	ChatFormatVersion int    `json:"chat_format_version"`
+	// SessionKind is present ONLY on subagent sessions ("subagent").
+	SessionKind string `json:"session_kind"`
+}
+
+// grokChatEntry is one line of chat_history.jsonl. content is a plain string
+// for system/assistant/tool_result entries and an array of blocks for user
+// entries — kept as RawMessage so the caller picks the right decode path.
+type grokChatEntry struct {
+	Type       string          `json:"type"` // system | user | assistant | tool_result
+	Content    json.RawMessage `json:"content"`
+	Reasoning  string          `json:"reasoning"`
+	ToolCalls  []grokToolCall  `json:"tool_calls"`
+	ToolCallID string          `json:"tool_call_id"`
+	ModelID    string          `json:"model_id"`
+}
+
+// grokToolCall is one entry of an assistant message's tool_calls[].
+type grokToolCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // a JSON-encoded string
+}
+
+// grokContentBlock is one block of a user entry's content array.
+type grokContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// grokSignals mirrors the subset of signals.json this package reads.
+// signals.json is absent in ~11% of sessions (very short / aborted ones).
+type grokSignals struct {
+	UserMessageCount      int `json:"userMessageCount"`
+	AssistantMessageCount int `json:"assistantMessageCount"`
+	ContextTokensUsed     int `json:"contextTokensUsed"`
+}
+
+// grokUpdate is the minimal shape of an updates.jsonl line. timestamp is
+// Unix epoch seconds (fractional).
+type grokUpdate struct {
+	Timestamp float64 `json:"timestamp"`
+}
+```
+
+- [ ] **Step 4: Create `internal/grok/parse.go`**
+
+```go
+package grok
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// supportedChatFormatVersion is the highest summary.json chat_format_version
+// this parser understands. A session declaring a newer version is skipped so
+// a future Grok upgrade cannot crash discovery.
+const supportedChatFormatVersion = 1
+
+const (
+	maxRecentMessages  = 10
+	maxRecentTools     = 20
+	maxEntryTimestamps = 500
+	// maxUpdatesTailBytes bounds how much of updates.jsonl is read for the
+	// activity sparkline. updates.jsonl can reach ~18 MB; only the recent
+	// tail matters for the (short) sparkline window.
+	maxUpdatesTailBytes = 512 * 1024
+)
+
+// ParseGrokSession reads one Grok session directory into a model.Session.
+// It returns an error when summary.json is missing/unreadable or declares an
+// unsupported chat_format_version; callers skip such sessions.
+func ParseGrokSession(sessionDir string) (*model.Session, error) {
+	summary, err := readGrokSummary(filepath.Join(sessionDir, "summary.json"))
+	if err != nil {
+		return nil, err
+	}
+	if summary.ChatFormatVersion > supportedChatFormatVersion {
+		return nil, fmt.Errorf("grok: unsupported chat_format_version %d", summary.ChatFormatVersion)
+	}
+
+	s := &model.Session{
+		Agent:         "grok",
+		SessionID:     summary.Info.ID,
+		JSONLPath:     sessionDir,
+		CWD:           summary.Info.CWD,
+		Model:         summary.CurrentModelID,
+		GitBranch:     summary.HeadBranch,
+		TotalMessages: summary.NumChatMessages,
+		IsSidechain:   summary.SessionKind == "subagent",
+	}
+	if s.SessionID == "" {
+		s.SessionID = filepath.Base(sessionDir)
+	}
+	if s.CWD == "" {
+		s.CWD = decodeGrokDirName(filepath.Base(filepath.Dir(sessionDir)))
+	}
+	if summary.ChatFormatVersion > 0 {
+		s.Version = strconv.Itoa(summary.ChatFormatVersion)
+	}
+
+	// Timestamps. updated_at == last_active_at in every observed sample;
+	// fall back across both, then created_at.
+	s.LastActivity = parseGrokTime(firstNonEmpty(summary.LastActiveAt, summary.UpdatedAt, summary.CreatedAt))
+	s.LastSummaryAt = parseGrokTime(firstNonEmpty(summary.UpdatedAt, summary.LastActiveAt))
+
+	// Transcript: counts, recent messages/tools, status.
+	chat := parseGrokChatHistory(filepath.Join(sessionDir, "chat_history.jsonl"))
+	s.RecentMessages = chat.recentMessages
+	s.RecentTools = chat.recentTools
+	s.Status, s.CurrentTool = grokStatus(chat.lastEntry)
+
+	// Message counts: prefer signals.json, fall back to counting the transcript.
+	if signals, ok := readGrokSignals(filepath.Join(sessionDir, "signals.json")); ok {
+		s.UserMessages = signals.UserMessageCount
+		s.AssistantMessages = signals.AssistantMessageCount
+	} else {
+		s.UserMessages = chat.userCount
+		s.AssistantMessages = chat.assistantCount
+	}
+	if s.TotalMessages == 0 {
+		s.TotalMessages = s.UserMessages + s.AssistantMessages
+	}
+
+	// Title: generated_title → session_summary → first user message.
+	s.Name = firstNonEmpty(summary.GeneratedTitle, summary.SessionSummary, chat.firstUserText)
+
+	// Activity sparkline timestamps from the bounded tail of updates.jsonl.
+	s.EntryTimestamps = readGrokUpdatesTail(filepath.Join(sessionDir, "updates.jsonl"))
+
+	return s, nil
+}
+
+// decodeGrokDirName reverses Grok's cwd encoding (standard URL percent-encoding;
+// in practice only "/" is escaped as %2F).
+func decodeGrokDirName(name string) string {
+	if decoded, err := url.PathUnescape(name); err == nil {
+		return decoded
+	}
+	return name
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func parseGrokTime(s string) time.Time {
+	t, _ := time.Parse(time.RFC3339Nano, s)
+	return t
+}
+
+func readGrokSummary(path string) (*grokSummary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var sum grokSummary
+	if err := json.Unmarshal(data, &sum); err != nil {
+		return nil, fmt.Errorf("grok: parse summary.json: %w", err)
+	}
+	return &sum, nil
+}
+
+// readGrokSignals returns (signals, true) when signals.json exists and parses.
+func readGrokSignals(path string) (grokSignals, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return grokSignals{}, false
+	}
+	var sig grokSignals
+	if err := json.Unmarshal(data, &sig); err != nil {
+		return grokSignals{}, false
+	}
+	return sig, true
+}
+
+// grokChatResult is what parseGrokChatHistory extracts from chat_history.jsonl.
+type grokChatResult struct {
+	recentMessages []model.ConversationMessage
+	recentTools    []model.ToolCall
+	lastEntry      *grokChatEntry
+	userCount      int
+	assistantCount int
+	firstUserText  string
+}
+
+// parseGrokChatHistory scans chat_history.jsonl. A missing or unreadable file
+// yields a zero-value result — the session is still valid from summary.json.
+func parseGrokChatHistory(path string) grokChatResult {
+	var res grokChatResult
+	f, err := os.Open(path)
+	if err != nil {
+		return res
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		var e grokChatEntry
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue
+		}
+		switch e.Type {
+		case "user":
+			res.userCount++
+			res.lastEntry = copyGrokEntry(&e)
+			text := grokEntryText(e.Content)
+			if res.firstUserText == "" && text != "" {
+				res.firstUserText = model.Truncate(text, 300)
+			}
+			if text != "" {
+				res.recentMessages = append(res.recentMessages, model.ConversationMessage{
+					Role: "user", Text: model.Truncate(text, 300),
+				})
+			}
+		case "assistant":
+			res.assistantCount++
+			res.lastEntry = copyGrokEntry(&e)
+			for _, tc := range e.ToolCalls {
+				res.recentTools = append(res.recentTools, model.ToolCall{
+					Name: normalizeGrokToolName(tc.Name),
+				})
+			}
+			if text := grokEntryText(e.Content); text != "" {
+				res.recentMessages = append(res.recentMessages, model.ConversationMessage{
+					Role: "assistant", Text: model.Truncate(text, 300),
+				})
+			}
+		case "tool_result":
+			res.lastEntry = copyGrokEntry(&e)
+		}
+	}
+
+	if len(res.recentMessages) > maxRecentMessages {
+		res.recentMessages = res.recentMessages[len(res.recentMessages)-maxRecentMessages:]
+	}
+	if len(res.recentTools) > maxRecentTools {
+		res.recentTools = res.recentTools[len(res.recentTools)-maxRecentTools:]
+	}
+	return res
+}
+
+func copyGrokEntry(e *grokChatEntry) *grokChatEntry {
+	cp := *e
+	return &cp
+}
+
+// grokEntryText extracts the first human-readable text from a chat entry's
+// content: a plain string for system/assistant/tool_result entries, an array
+// of {type,text} blocks for user entries.
+func grokEntryText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	switch raw[0] {
+	case '"':
+		var s string
+		_ = json.Unmarshal(raw, &s)
+		return s
+	case '[':
+		var blocks []grokContentBlock
+		if json.Unmarshal(raw, &blocks) != nil {
+			return ""
+		}
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				return b.Text
+			}
+		}
+		for _, b := range blocks {
+			if b.Text != "" {
+				return b.Text
+			}
+		}
+	}
+	return ""
+}
+
+// normalizeGrokToolName upper-cases the first letter so Grok tool names render
+// consistently with the other providers' activity labels.
+func normalizeGrokToolName(name string) string {
+	if name == "" {
+		return name
+	}
+	return strings.ToUpper(name[:1]) + name[1:]
+}
+
+// grokStatus infers session status from the last transcript entry.
+func grokStatus(e *grokChatEntry) (model.SessionStatus, string) {
+	if e == nil {
+		return model.StatusUnknown, ""
+	}
+	switch e.Type {
+	case "assistant":
+		if len(e.ToolCalls) > 0 {
+			return model.StatusExecutingTool, normalizeGrokToolName(e.ToolCalls[len(e.ToolCalls)-1].Name)
+		}
+		return model.StatusWaitingForUser, ""
+	case "user":
+		return model.StatusThinking, ""
+	case "tool_result":
+		return model.StatusProcessingResult, ""
+	}
+	return model.StatusUnknown, ""
+}
+
+// readGrokUpdatesTail reads the trailing maxUpdatesTailBytes of updates.jsonl
+// and returns the event timestamps it finds, for the activity sparkline.
+// updates.jsonl is the largest file in a session, so only the tail is read.
+func readGrokUpdatesTail(path string) []time.Time {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil
+	}
+	var start int64
+	if info.Size() > maxUpdatesTailBytes {
+		start = info.Size() - maxUpdatesTailBytes
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	// Seeking into the middle of the file lands mid-line; discard the first
+	// (almost certainly partial) line.
+	if start > 0 && scanner.Scan() {
+		_ = scanner.Bytes()
+	}
+
+	var stamps []time.Time
+	for scanner.Scan() {
+		var u grokUpdate
+		if json.Unmarshal(scanner.Bytes(), &u) != nil || u.Timestamp <= 0 {
+			continue
+		}
+		sec := int64(u.Timestamp)
+		nsec := int64((u.Timestamp - float64(sec)) * 1e9)
+		stamps = append(stamps, time.Unix(sec, nsec))
+	}
+	if len(stamps) > maxEntryTimestamps {
+		stamps = stamps[len(stamps)-maxEntryTimestamps:]
+	}
+	return stamps
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./internal/grok/...`
+Expected: PASS — all `TestParseGrokSession_*` and `TestDecodeGrokDirName` green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/grok/types.go internal/grok/parse.go internal/grok/parse_test.go
+git commit -m "feat(grok): add session directory parser"
+```
+
+---
+
+### Task 2: `internal/grok` discovery
+
+**Files:**
+- Create: `internal/grok/process.go`
+- Test: `internal/grok/process_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/grok/process_test.go`:
+
+```go
+package grok
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestGrokSessionsDir(t *testing.T) {
+	dir := GrokSessionsDir()
+	if dir == "" {
+		t.Fatal("GrokSessionsDir() returned empty string")
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".grok", "sessions")
+	if dir != want {
+		t.Errorf("GrokSessionsDir() = %q, want %q", dir, want)
+	}
+}
+
+func TestDiscoverSessions_MissingDir(t *testing.T) {
+	sessions, err := discoverSessionsFromDir("/nonexistent/grok/sessions", model.NewSessionCache())
+	if err != nil {
+		t.Fatalf("missing dir must not error: %v", err)
+	}
+	if sessions != nil {
+		t.Errorf("got %v, want nil", sessions)
+	}
+}
+
+func TestDiscoverSessions_PrimaryAndSubagent(t *testing.T) {
+	root := t.TempDir()
+	writeSession(t, root, "%2FUsers%2Falice%2Fproject", "019e0000-0000-7000-8000-000000000001", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat, "signals.json": primarySignals,
+	})
+	subSummary := `{"info":{"id":"sub","cwd":"/tmp/wt"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z","session_kind":"subagent"}`
+	writeSession(t, root, "%2Ftmp%2Fwt", "sub", map[string]string{
+		"summary.json": subSummary, "chat_history.jsonl": "",
+	})
+
+	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+	var primary, sub *model.Session
+	for _, s := range sessions {
+		if s.IsSidechain {
+			sub = s
+		} else {
+			primary = s
+		}
+	}
+	if primary == nil || sub == nil {
+		t.Fatal("expected one primary and one subagent session")
+	}
+	if primary.Agent != "grok" {
+		t.Errorf("Agent = %q", primary.Agent)
+	}
+}
+
+func TestDiscoverSessions_SkipsNonSessionEntries(t *testing.T) {
+	root := t.TempDir()
+	cwdDir := filepath.Join(root, "%2Ftmp%2Fp")
+	if err := os.MkdirAll(cwdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A cwd-level file and a root-level file must both be ignored.
+	if err := os.WriteFile(filepath.Join(cwdDir, "prompt_history.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "session_search.sqlite"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, root, "%2Ftmp%2Fp", "real", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+
+	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1 (sqlite + prompt_history must be skipped)", len(sessions))
+	}
+}
+
+func TestDiscoverSessions_MalformedSummarySkipped(t *testing.T) {
+	root := t.TempDir()
+	writeSession(t, root, "%2Ftmp%2Fp", "bad", map[string]string{
+		"summary.json": "{not json", "chat_history.jsonl": "",
+	})
+	writeSession(t, root, "%2Ftmp%2Fp", "good", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
+	if err != nil {
+		t.Fatalf("one bad session must not abort the scan: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+}
+
+func TestDiscoverSessions_CacheHit(t *testing.T) {
+	root := t.TempDir()
+	writeSession(t, root, "%2Ftmp%2Fp", "c", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+	cache := model.NewSessionCache()
+	first, err := discoverSessionsFromDir(root, cache)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first discover: %v, n=%d", err, len(first))
+	}
+	second, err := discoverSessionsFromDir(root, cache)
+	if err != nil || len(second) != 1 {
+		t.Fatalf("second discover: %v, n=%d", err, len(second))
+	}
+	if first[0] != second[0] {
+		t.Error("unchanged session should be served from cache (same pointer)")
+	}
+}
+
+func TestSessionDirsAndDiskBytes(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "s", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+		"terminal/cmd-1.log": "some output",
+	})
+	dirs := walkSessionDirs(root)
+	if len(dirs) != 1 || dirs[0] != dir {
+		t.Fatalf("walkSessionDirs = %v, want [%s]", dirs, dir)
+	}
+	if got := SessionDiskBytes(dir); got <= 0 {
+		t.Errorf("SessionDiskBytes = %d, want > 0", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/grok/...`
+Expected: FAIL — `undefined: GrokSessionsDir`, `discoverSessionsFromDir`, `walkSessionDirs`, `SessionDiskBytes`.
+
+- [ ] **Step 3: Create `internal/grok/process.go`**
+
+```go
+// Package grok discovers xAI Grok CLI sessions from ~/.grok/sessions.
+//
+// Grok stores one directory per session, exactly two levels deep:
+//
+//	~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/
+//
+// Each session directory carries a summary.json (metadata) and a
+// chat_history.jsonl (transcript). This package walks that tree, parses each
+// session into a model.Session, and integrates with model.SessionCache so
+// unchanged sessions are not re-parsed.
+package grok
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/claude"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// GrokSessionsDir returns the path to ~/.grok/sessions.
+func GrokSessionsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".grok", "sessions")
+}
+
+// DiscoverSessions scans ~/.grok/sessions for Grok session directories.
+func DiscoverSessions(cache *model.SessionCache) ([]*model.Session, error) {
+	return discoverSessionsFromDir(GrokSessionsDir(), cache)
+}
+
+// SessionDirs returns every Grok session directory on disk. Used by the
+// search indexer and maintenance commands that need the raw directory list.
+func SessionDirs() []string {
+	return walkSessionDirs(GrokSessionsDir())
+}
+
+// SessionDiskBytes returns the total size in bytes of every file inside a
+// Grok session directory. Best-effort: unreadable entries contribute zero.
+func SessionDiskBytes(dir string) int64 {
+	var total int64
+	_ = filepath.WalkDir(dir, func(_ string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if info, err := d.Info(); err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+type wtInfo struct {
+	isWorktree bool
+	mainRepo   string
+}
+
+type parseJob struct {
+	sessionDir string
+	cacheKey   string // chat_history.jsonl path — the cache invalidation key
+	mtime      time.Time
+}
+
+type parseResult struct {
+	session  *model.Session
+	cacheKey string
+	mtime    time.Time
+}
+
+// walkSessionDirs returns every session directory under sessionsDir: every
+// depth-2 directory that contains a summary.json. Files at the root
+// (session_search.sqlite) and at cwd level (prompt_history.jsonl) are skipped
+// because only directories are descended into.
+func walkSessionDirs(sessionsDir string) []string {
+	if sessionsDir == "" {
+		return nil
+	}
+	cwdEntries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for _, cwdEntry := range cwdEntries {
+		if !cwdEntry.IsDir() {
+			continue
+		}
+		cwdPath := filepath.Join(sessionsDir, cwdEntry.Name())
+		sessEntries, err := os.ReadDir(cwdPath)
+		if err != nil {
+			continue
+		}
+		for _, sessEntry := range sessEntries {
+			if !sessEntry.IsDir() {
+				continue
+			}
+			sessionDir := filepath.Join(cwdPath, sessEntry.Name())
+			if _, err := os.Stat(filepath.Join(sessionDir, "summary.json")); err != nil {
+				continue // not a session directory
+			}
+			dirs = append(dirs, sessionDir)
+		}
+	}
+	return dirs
+}
+
+// discoverSessionsFromDir scans a Grok sessions root and returns parsed
+// sessions. A missing root is not an error (Grok not installed → nil, nil).
+func discoverSessionsFromDir(sessionsDir string, cache *model.SessionCache) ([]*model.Session, error) {
+	if sessionsDir == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(sessionsDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // Grok not installed — not an error.
+		}
+		return nil, fmt.Errorf("could not read grok sessions dir: %w", err)
+	}
+
+	wtCache := make(map[string]wtInfo)
+	seen := make(map[string]struct{})
+	var sessions []*model.Session
+	var jobs []parseJob
+
+	// Phase 1: classify each session as cache-hit or needs-parse.
+	for _, sessionDir := range walkSessionDirs(sessionsDir) {
+		cacheKey := filepath.Join(sessionDir, "chat_history.jsonl")
+		seen[cacheKey] = struct{}{}
+		cached, offset, mtime := cache.GetIncremental(cacheKey)
+		// A full cache hit (file unchanged) reuses the parsed session. Any
+		// change — including the offset>0 "file grew" case — triggers a full
+		// re-parse, because Grok parsing reads summary.json + the whole
+		// chat_history.jsonl rather than appending incrementally.
+		if cached != nil && offset == 0 {
+			sessions = append(sessions, cached)
+			continue
+		}
+		jobs = append(jobs, parseJob{sessionDir: sessionDir, cacheKey: cacheKey, mtime: mtime})
+	}
+
+	if len(jobs) > 0 {
+		// Phase 2: parse sessions in parallel.
+		workers := runtime.GOMAXPROCS(0)
+		if workers > len(jobs) {
+			workers = len(jobs)
+		}
+		results := make([]parseResult, len(jobs))
+		var wg sync.WaitGroup
+		jobCh := make(chan int, len(jobs))
+		for i := range jobs {
+			jobCh <- i
+		}
+		close(jobCh)
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for idx := range jobCh {
+					j := &jobs[idx]
+					session, err := ParseGrokSession(j.sessionDir)
+					if err != nil {
+						continue // skip malformed / unsupported session
+					}
+					results[idx] = parseResult{session: session, cacheKey: j.cacheKey, mtime: j.mtime}
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Phase 3: enrich worktree info and update the cache (sequential).
+		for _, r := range results {
+			if r.session == nil {
+				continue
+			}
+			if r.session.CWD != "" {
+				if _, ok := wtCache[r.session.CWD]; !ok {
+					isWT, mainRepo := claude.IsWorktree(r.session.CWD)
+					wtCache[r.session.CWD] = wtInfo{isWorktree: isWT, mainRepo: mainRepo}
+				}
+				wt := wtCache[r.session.CWD]
+				r.session.IsWorktree = wt.isWorktree
+				r.session.MainRepo = wt.mainRepo
+			}
+			// size 0 forces a full re-parse on any future mtime change.
+			cache.Put(r.cacheKey, r.mtime, 0, r.session)
+			sessions = append(sessions, r.session)
+		}
+	}
+
+	cache.Prune(seen)
+	return sessions, nil
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/grok/...`
+Expected: PASS — all discovery tests green.
+
+- [ ] **Step 5: Run the full build**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/grok/process.go internal/grok/process_test.go
+git commit -m "feat(grok): add session discovery with cache + parallel parse"
+```
+
+---
+
+### Task 3: Provider wiring + config default
+
+**Files:**
+- Modify: `internal/core/provider.go`
+- Modify: `internal/core/config.go:50-57`
+- Test: `internal/core/provider_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create (or append to) `internal/core/provider_test.go`:
+
+```go
+package core
+
+import "testing"
+
+func TestBuildProvider_Grok(t *testing.T) {
+	p := BuildProvider("grok", DefaultConfig())
+	if _, ok := p.(*GrokProvider); !ok {
+		t.Fatalf("BuildProvider(\"grok\") = %T, want *GrokProvider", p)
+	}
+}
+
+func TestDefaultConfig_GrokEnabled(t *testing.T) {
+	cfg := DefaultConfig()
+	if !cfg.AgentEnabled("grok") {
+		t.Error("grok must be enabled by default")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/core/ -run 'Grok'`
+Expected: FAIL — `undefined: GrokProvider`.
+
+- [ ] **Step 3: Add `"grok": true` to `DefaultConfig().Agents`**
+
+In `internal/core/config.go`, change the `Agents` map literal in `DefaultConfig()` (lines 50-57) to:
+
+```go
+		Agents: map[string]bool{
+			"claude":   true,
+			"pi":       true,
+			"opencode": true,
+			"cursor":   true,
+			"codex":    true,
+			"amp":      true,
+			"grok":     true,
+		},
+```
+
+(`LoadConfig` already backfills missing keys for existing config files via its loop over `defaults.Agents`, so older installs pick `grok` up automatically.)
+
+- [ ] **Step 4: Add the `GrokProvider` to `internal/core/provider.go`**
+
+Add `"github.com/illegalstudio/lazyagent/internal/grok"` to the import block (keep imports alphabetically ordered — it goes after `cursor`, before `model`).
+
+Add the provider type after `AmpProvider` (after line 156), modeled exactly on `PiProvider`:
+
+```go
+// GrokProvider discovers xAI Grok CLI sessions from disk.
+type GrokProvider struct {
+	cache *model.SessionCache
+}
+
+// NewGrokProvider creates a GrokProvider with an mtime-based cache.
+func NewGrokProvider() *GrokProvider {
+	return &GrokProvider{cache: model.NewSessionCache()}
+}
+
+func (p *GrokProvider) DiscoverSessions() ([]*model.Session, error) {
+	return grok.DiscoverSessions(p.cache)
+}
+
+func (p *GrokProvider) UseWatcher() bool               { return true }
+func (p *GrokProvider) RefreshInterval() time.Duration { return 0 }
+func (p *GrokProvider) WatchDirs() []string            { return []string{grok.GrokSessionsDir()} }
+```
+
+In `BuildProvider`, add a case after `case "amp":` (line 174):
+
+```go
+	case "grok":
+		return NewGrokProvider()
+```
+
+In the `default: // "all"` branch, add after the `amp` block (after line 194):
+
+```go
+		if cfg.AgentEnabled("grok") {
+			providers = append(providers, NewGrokProvider())
+		}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `go test ./internal/core/ -run 'Grok'`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full build + test**
+
+Run: `go build ./... && go test ./internal/core/... ./internal/grok/...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/core/provider.go internal/core/config.go internal/core/provider_test.go
+git commit -m "feat(grok): wire GrokProvider into BuildProvider and config"
+```
+
+---
+
+### Task 4: CLI flag + TUI prefix
+
+**Files:**
+- Modify: `main.go:57`, `main.go:63-70`, `main.go:121`, `main.go:124`
+- Modify: `internal/ui/app.go:828-837`
+
+- [ ] **Step 1: Update the `--agent` flag in `main.go`**
+
+Change the flag definition (line 57):
+
+```go
+	agentMode := flag.String("agent", "all", "Which agent sessions to show: claude, pi, opencode, cursor, codex, amp, grok, all (default: all)")
+```
+
+Add a usage example line in the help block — after the `amp` line (line 69), before the `all` line:
+
+```
+  lazyagent --agent grok        Monitor only Grok CLI sessions
+```
+
+Change the validation switch (line 121):
+
+```go
+		case "claude", "pi", "opencode", "cursor", "codex", "amp", "grok", "all":
+```
+
+Change the error message (line 124):
+
+```go
+			fmt.Fprintf(os.Stderr, "Error: unknown --agent value %q (use claude, pi, opencode, cursor, codex, amp, grok, or all)\n", *agentMode)
+```
+
+- [ ] **Step 2: Add the `G` prefix in `internal/ui/app.go`**
+
+In the agent-prefix chain (lines 828-837), add a `grok` branch after the `cursor` branch:
+
+```go
+	agentPrefix := ""
+	if s.Agent == "pi" {
+		agentPrefix = "π "
+	} else if s.Agent == "opencode" {
+		agentPrefix = "O "
+	} else if s.Agent == "cursor" {
+		agentPrefix = "C "
+	} else if s.Agent == "grok" {
+		agentPrefix = "G "
+	} else if s.Desktop != nil {
+		agentPrefix = "D "
+	}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `go build ./... && go vet ./...`
+Expected: no errors.
+
+Run: `./lazyagent --agent grok` (after `go build -o lazyagent .`) — if Grok is installed, Grok sessions appear with a `G ` prefix; if not, an empty list (no error). Run `./lazyagent --agent bogus` and confirm the error message now lists `grok`.
+
+- [ ] **Step 4: Verify the GUI panel**
+
+The macOS GUI panel and the HTTP API consume `model.Session` generically via `SessionManager`, so a Grok session surfaces with no GUI-specific change. Grep for agent-badge logic in `internal/tray/` and `internal/assets/`:
+
+Run: `grep -rn '"pi"\|"codex"\|agentPrefix\|Agent ==' internal/tray internal/assets`
+
+If a GUI-side agent-badge map exists, add a `grok → "G"` entry there. If none exists (expected), no change — note it in the commit body.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add main.go internal/ui/app.go
+git commit -m "feat(grok): add --agent grok flag and TUI G prefix"
+```
+
+---
+
+## Phase 2 — Search
+
+Outcome: `lazyagent search` indexes and finds Grok transcripts. Depends on Phase 1.
+
+### Task 5: `search` Grok support
+
+**Files:**
+- Modify: `internal/search/types.go:5`
+- Modify: `internal/search/extractors.go`
+- Modify: `internal/search/run.go:32`, `run.go:39-44`
+- Test: `internal/search/extractors_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/search/extractors_test.go`:
+
+```go
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractGrok(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "%2Ftmp%2Fp", "sess-1")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := `{"info":{"id":"sess-1","cwd":"/tmp/p"},"generated_title":"Parser work"}`
+	chat := `{"type":"system","content":"ignore me"}
+{"type":"user","content":[{"type":"text","text":"find the parser bug"}]}
+{"type":"assistant","content":"looking into the parser now"}
+{"type":"tool_result","content":"grep matched parser.go"}
+`
+	if err := os.WriteFile(filepath.Join(sessionDir, "summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chatPath := filepath.Join(sessionDir, "chat_history.jsonl")
+	if err := os.WriteFile(chatPath, []byte(chat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src, ok := fileSource("grok", "sess-1", chatPath)
+	if !ok {
+		t.Fatal("fileSource failed")
+	}
+	chunks, err := extractGrok(src)
+	if err != nil {
+		t.Fatalf("extractGrok: %v", err)
+	}
+	// user + assistant + tool_result = 3 chunks; system is skipped.
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks, want 3", len(chunks))
+	}
+	for _, c := range chunks {
+		if c.SessionID != "sess-1" {
+			t.Errorf("SessionID = %q", c.SessionID)
+		}
+		if c.CWD != "/tmp/p" {
+			t.Errorf("CWD = %q", c.CWD)
+		}
+		if c.Name != "Parser work" {
+			t.Errorf("Name = %q", c.Name)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/search/ -run TestExtractGrok`
+Expected: FAIL — `undefined: extractGrok`.
+
+- [ ] **Step 3: Add `"grok"` to `supportedAgents`**
+
+In `internal/search/types.go`, change line 5:
+
+```go
+var supportedAgents = []string{"claude", "codex", "pi", "amp", "grok"}
+```
+
+- [ ] **Step 4: Add `listGrokSources`, `extractGrok`, and the switch cases**
+
+In `internal/search/extractors.go`, add `"github.com/illegalstudio/lazyagent/internal/grok"` to the import block (alphabetical — after `core`, before `pi`).
+
+Add a `grok` case to `listSources` (after the `amp` case, line 100):
+
+```go
+	case "grok":
+		return listGrokSources(), nil
+```
+
+Add a `grok` case to `extractChunks` (after the `amp` case, line 149):
+
+```go
+	case "grok":
+		return extractGrok(src)
+```
+
+Add these functions at the end of `extractors.go`:
+
+```go
+// grokSummaryLite is the subset of a Grok summary.json the indexer needs.
+type grokSummaryLite struct {
+	Info struct {
+		ID  string `json:"id"`
+		CWD string `json:"cwd"`
+	} `json:"info"`
+	GeneratedTitle string `json:"generated_title"`
+	SessionSummary string `json:"session_summary"`
+}
+
+type grokChatLine struct {
+	Type    string          `json:"type"`
+	Content json.RawMessage `json:"content"`
+}
+
+// listGrokSources returns one source per Grok session, keyed on its
+// chat_history.jsonl file (the transcript the indexer scans).
+func listGrokSources() []sourceState {
+	var out []sourceState
+	for _, dir := range grok.SessionDirs() {
+		path := filepath.Join(dir, "chat_history.jsonl")
+		if src, ok := fileSource("grok", filepath.Base(dir), path); ok {
+			out = append(out, src)
+		}
+	}
+	return out
+}
+
+// extractGrok turns one Grok session's chat_history.jsonl into search chunks.
+// CWD, title and the canonical session ID come from the sibling summary.json.
+func extractGrok(src sourceState) ([]chunk, error) {
+	sessionDir := filepath.Dir(src.Path)
+	sessionID := src.ID
+	var cwd, name string
+	if data, err := os.ReadFile(filepath.Join(sessionDir, "summary.json")); err == nil {
+		var sum grokSummaryLite
+		if json.Unmarshal(data, &sum) == nil {
+			if sum.Info.ID != "" {
+				sessionID = sum.Info.ID
+			}
+			cwd = sum.Info.CWD
+			name = sum.GeneratedTitle
+			if name == "" {
+				name = sum.SessionSummary
+			}
+		}
+	}
+	allowed := map[string]bool{"text": true}
+	var chunks []chunk
+	err := scanJSONL(src.Path, func(line []byte) {
+		var e grokChatLine
+		if json.Unmarshal(line, &e) != nil {
+			return
+		}
+		if e.Type != "user" && e.Type != "assistant" && e.Type != "tool_result" {
+			return
+		}
+		// contentText handles both the user array form and the plain-string
+		// form used by assistant/tool_result entries.
+		text := contentText(e.Content, allowed)
+		chunks = appendChunk(chunks, src, sessionID, cwd, name, e.Type, time.Time{}, text)
+	})
+	return chunks, err
+}
+```
+
+- [ ] **Step 5: Update the `search --agent` help text**
+
+In `internal/search/run.go`, change the flag (line 32):
+
+```go
+	fs.StringVar(&opts.agent, "agent", "all", "Agent to search: claude,codex,pi,amp,grok,all")
+```
+
+And the usage example block (around line 43) — add a line after the `--agent codex` example:
+
+```
+  lazyagent search --agent grok "parser bug"
+```
+
+- [ ] **Step 6: Run the test + build**
+
+Run: `go test ./internal/search/... && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/search/types.go internal/search/extractors.go internal/search/run.go internal/search/extractors_test.go
+git commit -m "feat(grok): add Grok transcript indexing to search"
+```
+
+---
+
+## Phase 3 — Prune
+
+Outcome: `lazyagent prune` can delete Grok sessions (directory-aware). Depends on Phase 1.
+
+### Task 6: `prune` Grok support
+
+**Files:**
+- Modify: `internal/prune/prune.go:1-8` (package doc), `prune.go:24`
+- Modify: `internal/prune/delete.go`
+- Modify: `internal/prune/report.go:141-154`
+- Test: `internal/prune/delete_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/prune/delete_test.go`:
+
+```go
+package prune
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestDeleteGrokSession(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "%2Ftmp%2Fp", "sess-1")
+	if err := os.MkdirAll(filepath.Join(sessionDir, "terminal"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"summary.json", "chat_history.jsonl", "updates.jsonl", "terminal/cmd-1.log"} {
+		if err := os.WriteFile(filepath.Join(sessionDir, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := &model.Session{Agent: "grok", JSONLPath: sessionDir}
+	if err := deleteGrokSession(s, root); err != nil {
+		t.Fatalf("deleteGrokSession: %v", err)
+	}
+	if _, err := os.Stat(sessionDir); !os.IsNotExist(err) {
+		t.Error("session directory should be gone")
+	}
+}
+
+func TestDeleteGrokSession_RejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir() // a different root
+	s := &model.Session{Agent: "grok", JSONLPath: outside}
+	if err := deleteGrokSession(s, root); err == nil {
+		t.Error("expected error deleting a directory outside the grok root")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/prune/ -run Grok`
+Expected: FAIL — `undefined: deleteGrokSession`.
+
+- [ ] **Step 3: Add `"grok"` to `SupportedAgents` and update the package doc**
+
+In `internal/prune/prune.go`, change line 24:
+
+```go
+var SupportedAgents = []string{"claude", "pi", "codex", "grok"}
+```
+
+Update the package doc comment (lines 1-8) so the supported set is accurate:
+
+```go
+// Package prune implements the `lazyagent prune` subcommand, which deletes
+// old or orphaned chat sessions from supported coding agents.
+//
+// Supported agents (v1): claude, pi, codex, grok. Amp is skipped because local
+// thread files are re-synced from the remote. Cursor and OpenCode store
+// sessions inside SQLite databases owned by third-party apps; deleting rows
+// there is deferred to a future version.
+package prune
+```
+
+- [ ] **Step 4: Add directory-aware deletion in `internal/prune/delete.go`**
+
+Add `"github.com/illegalstudio/lazyagent/internal/grok"` to the import block (alphabetical — after `core`, before `model`).
+
+In `executeDelete`, add `grokRoot` next to the other roots (after line 27):
+
+```go
+	grokRoot := grok.GrokSessionsDir()
+```
+
+Add a `grok` case to the per-session switch (after the `codex` case, line 54):
+
+```go
+		case "grok":
+			err = deleteGrokSession(s, grokRoot)
+			if err == nil && s.JSONLPath != "" {
+				dirsToGC[filepath.Dir(s.JSONLPath)] = struct{}{}
+			}
+```
+
+Add the deletion function after `deleteCodexSession` (after line 113):
+
+```go
+// deleteGrokSession removes an entire Grok session directory. A Grok session
+// is a directory tree (summary.json, chat_history.jsonl, updates.jsonl,
+// terminal/, …), so it is deleted recursively rather than as a single file.
+func deleteGrokSession(s *model.Session, root string) error {
+	if root == "" {
+		return fmt.Errorf("grok sessions directory not found")
+	}
+	if err := chatops.EnsureWithin(s.JSONLPath, []string{root}); err != nil {
+		return err
+	}
+	return os.RemoveAll(s.JSONLPath)
+}
+```
+
+Update `removeEmptyDirs` to accept and consider the Grok root. Change its signature and body (lines 214-238):
+
+```go
+// removeEmptyDirs deletes any project directory in dirs that is now empty.
+// Only directories that sit directly inside one of the known agent roots are
+// removed, never the roots themselves.
+func removeEmptyDirs(dirs map[string]struct{}, claudeRoots []string, piRoot, codexRoot, grokRoot string) {
+	roots := make([]string, 0, len(claudeRoots)+3)
+	roots = append(roots, claudeRoots...)
+	for _, r := range []string{piRoot, codexRoot, grokRoot} {
+		if r != "" {
+			roots = append(roots, r)
+		}
+	}
+
+	for dir := range dirs {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		if !chatops.IsBelowAny(absDir, roots) {
+			continue
+		}
+		entries, err := os.ReadDir(absDir)
+		if err != nil || len(entries) > 0 {
+			continue
+		}
+		_ = os.Remove(absDir)
+	}
+}
+```
+
+Update the call site in `executeDelete` (line 75):
+
+```go
+	removeEmptyDirs(dirsToGC, claudeRoots, piRoot, codexRoot, grokRoot)
+```
+
+> **Note:** a Grok `<encoded-cwd>/` directory also holds a cwd-level
+> `prompt_history.jsonl`, so it will not be empty after its last session is
+> pruned and `removeEmptyDirs` will (correctly) leave it. `prompt_history.jsonl`
+> is shared cwd state, not per-session, so prune never deletes it. This matches
+> the spec's "cosmetic, match existing behavior" stance (risk #7).
+
+- [ ] **Step 5: Make the prune report directory-aware**
+
+In `internal/prune/report.go`, add `"github.com/illegalstudio/lazyagent/internal/grok"` to the import block (alphabetical — after `chatops`). Change `totalBytes` (lines 141-154):
+
+```go
+// totalBytes sums each candidate's on-disk size. For Grok the candidate is a
+// directory, so its whole tree is measured; for the JSONL-per-session agents
+// a single file is stat-ed. Missing or unreadable paths contribute zero.
+func totalBytes(candidates []Candidate) int64 {
+	var total int64
+	for _, c := range candidates {
+		if c.Session.JSONLPath == "" {
+			continue
+		}
+		if c.Session.Agent == "grok" {
+			total += grok.SessionDiskBytes(c.Session.JSONLPath)
+			continue
+		}
+		info, err := os.Stat(c.Session.JSONLPath)
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	return total
+}
+```
+
+- [ ] **Step 6: Run the test + build**
+
+Run: `go test ./internal/prune/... && go build ./...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/prune/prune.go internal/prune/delete.go internal/prune/report.go internal/prune/delete_test.go
+git commit -m "feat(grok): add directory-aware Grok pruning"
+```
+
+---
+
+## Phase 4 — Compact
+
+Outcome: `lazyagent compact` shrinks Grok sessions. Depends on Phase 1. **Internally gated on Task 7 (Phase 0).**
+
+### Task 7: Phase 0 — empirical resume verification
+
+This task writes **no production code**. It determines which files inside a Grok
+session can be truncated without breaking `grok` resume. Its output is a
+findings note that Task 8 depends on. **Do not start Task 8 until this note
+exists and records a clear verdict.**
+
+**File:**
+- Create: `docs/superpowers/plans/2026-05-20-grok-compact-phase0-findings.md`
+
+- [ ] **Step 1: Confirm Grok is installed with at least one disposable session**
+
+Run: `ls ~/.grok/sessions` and confirm at least one `<encoded-cwd>/<uuid>/` session directory exists. If Grok is not installed or there is no disposable session, **stop** — this task requires a live Grok install. Record "blocked: no Grok install" in the findings note and escalate; Task 8 cannot proceed safely.
+
+- [ ] **Step 2: Pick a disposable session and snapshot it**
+
+Choose a closed, non-important session directory. Copy the whole `~/.grok/sessions/<encoded-cwd>/` tree to a scratch location so the original is recoverable.
+
+- [ ] **Step 3: Baseline — resume the untouched copy**
+
+From the session's `cwd`, run the Grok CLI's resume command for that session ID (consult `grok --help`; the limits code confirms the binary is `grok`). Confirm the session loads and shows prior context. Record the exact resume command used.
+
+- [ ] **Step 4: Test truncating `updates.jsonl`**
+
+On a fresh copy, replace large string values in `updates.jsonl` with short markers (or delete the file's bulk entirely). Resume again. Record: does the session still load and continue coherently? Hypothesis: yes — `updates.jsonl` is a render/telemetry stream not replayed on resume.
+
+- [ ] **Step 5: Test truncating `chat_history.jsonl` `tool_result.content`**
+
+On a fresh copy, truncate the `content` strings of `tool_result` lines in `chat_history.jsonl` (keep every line, keep `tool_call_id`). Resume. Record: does it load? Hypothesis: yes — this is the model-facing transcript; truncating tool output changes what the model sees, exactly like Claude compact, which is the intended behavior.
+
+- [ ] **Step 6: Test truncating `terminal/*.log` and `rewind_points.jsonl`**
+
+On fresh copies, truncate `terminal/*.log` files and the embedded file snapshots in `rewind_points.jsonl`. Resume each. Record results. Note explicitly that gutting `rewind_points.jsonl` disables Grok's rewind feature for that session.
+
+- [ ] **Step 7: Write the findings note**
+
+Create `docs/superpowers/plans/2026-05-20-grok-compact-phase0-findings.md` with, for each of the four files (`updates.jsonl`, `chat_history.jsonl` tool_result, `terminal/*.log`, `rewind_points.jsonl`): **SAFE to truncate** / **UNSAFE** / **SAFE with caveat**, plus the resume command used and any surprising cross-references observed.
+
+The verdict drives Task 8:
+- Each file marked **SAFE** → keep its handling in Task 8.
+- A file marked **UNSAFE** → remove it from `grokBulkJSONL` (or skip the terminal-log handling) in Task 8 and note the narrowed scope.
+- If resume turns out to cross-reference `updates.jsonl` and `chat_history.jsonl` for consistency → narrow Task 8 to whatever is provably safe, even if that means only `terminal/*.log`. A smaller, correct compact beats a broad, corrupting one.
+
+- [ ] **Step 8: Commit the findings note**
+
+```bash
+git add docs/superpowers/plans/2026-05-20-grok-compact-phase0-findings.md
+git commit -m "docs(grok): record compact Phase 0 resume-verification findings"
+```
+
+---
+
+### Task 8: `compact` Grok rewriter
+
+Implement the directory-aware Grok compactor. **The `grokBulkJSONL` list and the
+terminal-log handling below assume all four files from Task 7 came back SAFE.
+Before writing code, open the Phase 0 findings note and remove any file marked
+UNSAFE.**
+
+**Files:**
+- Create: `internal/compact/grok.go`
+- Modify: `internal/compact/compact.go:24-28`, `compact.go:264-271`
+- Modify: `internal/compact/rewrite.go` (`guardPath`, `estimateRewrite`, `estimateSizes`, `executeCompact`)
+- Test: `internal/compact/grok_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/compact/grok_test.go`:
+
+```go
+package compact
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeGrokSessionForCompact builds a Grok session directory with an
+// oversized tool-output payload in updates.jsonl.
+func writeGrokSessionForCompact(t *testing.T, big string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "sess-1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"summary.json":       `{"info":{"id":"sess-1","cwd":"/tmp/p"},"chat_format_version":1}`,
+		"chat_history.jsonl": `{"type":"tool_result","content":` + jsonString(big) + `,"tool_call_id":"call-1"}` + "\n",
+		"updates.jsonl": `{"timestamp":1,"method":"x","params":{"text":` + jsonString(big) + `}}` + "\n" +
+			`{"timestamp":2,"method":"y","params":{"small":"ok"}}` + "\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func countLines(t *testing.T, path string) int {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	n := 0
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+	for sc.Scan() {
+		n++
+		var v any
+		if err := json.Unmarshal(sc.Bytes(), &v); err != nil {
+			t.Fatalf("line %d of %s is not valid JSON: %v", n, path, err)
+		}
+	}
+	return n
+}
+
+func TestCompactGrokSession(t *testing.T) {
+	big := strings.Repeat("A", 50*1024) // 50 KiB — well above the 10 KiB threshold
+	dir := writeGrokSessionForCompact(t, big)
+
+	before := grokDirSize(t, dir)
+	newSize, err := compactGrokSession(dir, 10*1024, true)
+	if err != nil {
+		t.Fatalf("compactGrokSession: %v", err)
+	}
+	if newSize >= before {
+		t.Errorf("size did not shrink: before=%d after=%d", before, newSize)
+	}
+	// Every rewritten JSONL file must stay valid and keep its line count.
+	if n := countLines(t, filepath.Join(dir, "updates.jsonl")); n != 2 {
+		t.Errorf("updates.jsonl line count = %d, want 2", n)
+	}
+	if n := countLines(t, filepath.Join(dir, "chat_history.jsonl")); n != 1 {
+		t.Errorf("chat_history.jsonl line count = %d, want 1", n)
+	}
+	// tool_call_id linkage must survive truncation.
+	data, _ := os.ReadFile(filepath.Join(dir, "chat_history.jsonl"))
+	if !strings.Contains(string(data), `"tool_call_id":"call-1"`) {
+		t.Error("tool_call_id linkage was lost")
+	}
+	// Backups were requested.
+	if _, err := os.Stat(filepath.Join(dir, "updates.jsonl.bak")); err != nil {
+		t.Error("expected updates.jsonl.bak backup")
+	}
+}
+
+func grokDirSize(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if info, err := e.Info(); err == nil && !e.IsDir() {
+			total += info.Size()
+		}
+	}
+	return total
+}
+
+func TestEstimateGrokSession(t *testing.T) {
+	big := strings.Repeat("B", 50*1024)
+	dir := writeGrokSessionForCompact(t, big)
+	before := grokDirSize(t, dir)
+	after, err := estimateGrokSession(dir, 10*1024)
+	if err != nil {
+		t.Fatalf("estimateGrokSession: %v", err)
+	}
+	if after >= before {
+		t.Errorf("estimate did not shrink: before=%d after=%d", before, after)
+	}
+	// Estimation must not modify any file.
+	if grokDirSize(t, dir) != before {
+		t.Error("estimateGrokSession modified the session on disk")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/compact/ -run Grok`
+Expected: FAIL — `undefined: compactGrokSession`, `estimateGrokSession`.
+
+- [ ] **Step 3: Extract a reusable `estimateJSONL` in `internal/compact/rewrite.go`**
+
+`estimateRewrite` currently bakes in `mutatorFor(agent)`. Grok needs a different mutator per file, so factor the scan loop out. Replace `estimateRewrite` (lines 153-186) with:
+
+```go
+// estimateRewrite runs the agent's mutator in memory without writing anything
+// and returns the projected post-rewrite file size. Used by --dry-run.
+func estimateRewrite(path, agent string, threshold int64) (int64, error) {
+	return estimateJSONL(path, mutatorFor(agent), threshold)
+}
+
+// estimateJSONL simulates a per-line rewrite with the given mutator and
+// returns the projected file size, writing nothing.
+func estimateJSONL(path string, mutator lineMutator, threshold int64) (int64, error) {
+	in, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer in.Close()
+
+	var total int64
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+
+	for scanner.Scan() {
+		raw := scanner.Bytes()
+		var entry map[string]any
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			total += int64(len(raw)) + 1
+			continue
+		}
+		mutator(entry, threshold)
+		encoded, err := json.Marshal(entry)
+		if err != nil {
+			total += int64(len(raw)) + 1
+			continue
+		}
+		total += int64(len(encoded)) + 1
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+```
+
+- [ ] **Step 4: Add the Grok root to `guardPath`**
+
+In `internal/compact/rewrite.go`, add `"github.com/illegalstudio/lazyagent/internal/grok"` to the import block (alphabetical — after `core`, before `pi`). In `guardPath` (lines 202-214), add the Grok root:
+
+```go
+// guardPath blocks compacting anything outside the known agent roots.
+func guardPath(path string) error {
+	cfg := core.LoadConfig()
+	var roots []string
+	roots = append(roots, claude.ClaudeProjectsDirs(cfg.ClaudeDirs)...)
+	if d := pi.PiSessionsDir(); d != "" {
+		roots = append(roots, d)
+	}
+	if d := codex.SessionsDir(); d != "" {
+		roots = append(roots, d)
+	}
+	if d := grok.GrokSessionsDir(); d != "" {
+		roots = append(roots, d)
+	}
+	return chatops.EnsureWithin(path, roots)
+}
+```
+
+- [ ] **Step 5: Create `internal/compact/grok.go`**
+
+> **Phase 0 gate:** `grokBulkJSONL` and the `terminal/*.log` block below assume
+> Task 7 returned all four files SAFE. Remove any file the findings note marked
+> UNSAFE before continuing.
+
+```go
+package compact
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/illegalstudio/lazyagent/internal/grok"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// grokBulkJSONL lists the JSONL files inside a Grok session directory whose
+// oversized payloads compact truncates. Phase 0 resume-verification confirmed
+// these are safe to shrink (see 2026-05-20-grok-compact-phase0-findings.md):
+//
+//   - updates.jsonl       — ACP render/telemetry stream, ~70% of session size,
+//                           not replayed on resume → deep string truncation.
+//   - chat_history.jsonl  — model-facing transcript; only tool_result.content
+//                           is truncated (same trade-off as Claude compact).
+//   - rewind_points.jsonl — checkpoint snapshots; truncating disables Grok's
+//                           rewind feature for the session.
+var grokBulkJSONL = []string{"updates.jsonl", "chat_history.jsonl", "rewind_points.jsonl"}
+
+// sessionSizeBytes returns the on-disk size of a session: a directory total
+// for Grok, a single file size for the JSONL-per-session agents.
+func sessionSizeBytes(s *model.Session) int64 {
+	if s.Agent == "grok" {
+		return grok.SessionDiskBytes(s.JSONLPath)
+	}
+	info, err := os.Stat(s.JSONLPath)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+// grokFileMutator returns the per-line mutator for a Grok session file.
+func grokFileMutator(name string) lineMutator {
+	if name == "chat_history.jsonl" {
+		return compactGrokChatLine
+	}
+	// updates.jsonl, rewind_points.jsonl: not replayed on resume, so every
+	// oversized string leaf can be truncated.
+	return func(entry map[string]any, threshold int64) int64 {
+		return truncateGrokDeep(entry, threshold)
+	}
+}
+
+// compactGrokChatLine truncates the content of a tool_result entry. The
+// tool_call_id ↔ tool_calls[].id linkage is untouched so the transcript stays
+// internally consistent and resumable.
+func compactGrokChatLine(entry map[string]any, threshold int64) int64 {
+	if entry["type"] != "tool_result" {
+		return 0
+	}
+	s, ok := entry["content"].(string)
+	if !ok {
+		return 0
+	}
+	if newVal, delta := truncateString(s, threshold); delta > 0 {
+		entry["content"] = newVal
+		return delta
+	}
+	return 0
+}
+
+// truncateGrokDeep recursively truncates every oversized string value in a
+// decoded JSON structure. Used for files Grok does not replay on resume.
+func truncateGrokDeep(v any, threshold int64) int64 {
+	var saved int64
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if s, ok := child.(string); ok {
+				if newVal, delta := truncateString(s, threshold); delta > 0 {
+					t[k] = newVal
+					saved += delta
+				}
+				continue
+			}
+			saved += truncateGrokDeep(child, threshold)
+		}
+	case []any:
+		for _, child := range t {
+			saved += truncateGrokDeep(child, threshold)
+		}
+	}
+	return saved
+}
+
+// grokTerminalLogs returns the terminal/*.log paths inside a session dir.
+func grokTerminalLogs(dir string) []string {
+	logs, _ := filepath.Glob(filepath.Join(dir, "terminal", "*.log"))
+	return logs
+}
+
+// compactGrokSession truncates oversized payloads across the bulky files of a
+// Grok session directory and returns the directory's new total size.
+func compactGrokSession(dir string, threshold int64, backup bool) (int64, error) {
+	if err := guardPath(dir); err != nil {
+		return 0, err
+	}
+	for _, name := range grokBulkJSONL {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); err != nil {
+			continue // file absent for this session
+		}
+		if _, err := rewriteFile(path, grokFileMutator(name), threshold, backup); err != nil {
+			return 0, fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	for _, log := range grokTerminalLogs(dir) {
+		if err := compactGrokTerminalLog(log, threshold, backup); err != nil {
+			return 0, fmt.Errorf("%s: %w", filepath.Base(log), err)
+		}
+	}
+	return grok.SessionDiskBytes(dir), nil
+}
+
+// compactGrokTerminalLog truncates a raw (non-JSON) terminal capture log.
+func compactGrokTerminalLog(path string, threshold int64, backup bool) error {
+	if err := guardPath(path); err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Size() <= threshold {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	newVal, delta := truncateString(string(data), threshold)
+	if delta <= 0 {
+		return nil
+	}
+	if backup {
+		if err := copyFile(path, path+".bak"); err != nil {
+			return fmt.Errorf("backup: %w", err)
+		}
+	}
+	return os.WriteFile(path, []byte(newVal), info.Mode())
+}
+
+// estimateGrokSession simulates the rewrite of every bulky file and returns
+// the directory's projected post-compaction total size. It writes nothing.
+func estimateGrokSession(dir string, threshold int64) (int64, error) {
+	total := grok.SessionDiskBytes(dir)
+	for _, name := range grokBulkJSONL {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		after, err := estimateJSONL(path, grokFileMutator(name), threshold)
+		if err != nil {
+			continue
+		}
+		total -= info.Size() - after
+	}
+	for _, log := range grokTerminalLogs(dir) {
+		info, err := os.Stat(log)
+		if err != nil || info.Size() <= threshold {
+			continue
+		}
+		data, err := os.ReadFile(log)
+		if err != nil {
+			continue
+		}
+		if newVal, delta := truncateString(string(data), threshold); delta > 0 {
+			total -= info.Size() - int64(len(newVal))
+		}
+	}
+	return total, nil
+}
+```
+
+- [ ] **Step 6: Register Grok in `compact.go` and branch on the directory model**
+
+In `internal/compact/compact.go`, add the agent to `supportedAgents` (lines 24-28). The colour `#89B4FA` (blue) is distinct from claude `#E7A15E`, pi `#F38BA8`, and codex `#A6E3A1`:
+
+```go
+var supportedAgents = []chatops.Agent{
+	{Key: "claude", Label: "Claude Code", Color: "#E7A15E"},
+	{Key: "pi", Label: "pi coding agent", Color: "#F38BA8"},
+	{Key: "codex", Label: "Codex CLI", Color: "#A6E3A1"},
+	{Key: "grok", Label: "Grok", Color: "#89B4FA"},
+}
+```
+
+In `collectCandidates` (lines 264-271), replace the single-file stat with `sessionSizeBytes` so a Grok session directory is measured as a whole:
+
+```go
+			size := sessionSizeBytes(s)
+			if size < opts.minSize {
+				continue
+			}
+			all = append(all, Candidate{Session: s, SizeBefore: size})
+```
+
+(Delete the old `info, err := os.Stat(s.JSONLPath)` / `if err != nil { continue }` / `if info.Size() < opts.minSize` lines it replaces. The `os` import stays — it is still used elsewhere in the file.)
+
+- [ ] **Step 7: Branch `estimateSizes` and `executeCompact` on Grok**
+
+In `internal/compact/rewrite.go`, replace `estimateSizes` (lines 188-200):
+
+```go
+// estimateSizes fills SizeAfter for every candidate based on a dry-run
+// simulation. Best-effort: on error the after-size equals the before-size.
+func estimateSizes(candidates []Candidate, threshold int64) {
+	for i := range candidates {
+		c := &candidates[i]
+		var after int64
+		var err error
+		if c.Session.Agent == "grok" {
+			after, err = estimateGrokSession(c.Session.JSONLPath, threshold)
+		} else {
+			after, err = estimateRewrite(c.Session.JSONLPath, c.Session.Agent, threshold)
+		}
+		if err != nil {
+			c.SizeAfter = c.SizeBefore
+			continue
+		}
+		c.SizeAfter = after
+	}
+}
+```
+
+Replace the loop body of `executeCompact` (lines 251-265) so Grok uses the directory compactor:
+
+```go
+	for i := range candidates {
+		c := &candidates[i]
+		var newSize int64
+		var err error
+		if c.Session.Agent == "grok" {
+			newSize, err = compactGrokSession(c.Session.JSONLPath, opts.threshold, opts.backup)
+		} else {
+			newSize, err = rewriteFile(c.Session.JSONLPath, mutatorFor(c.Session.Agent), opts.threshold, opts.backup)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed: %s — %v\n", filepath.Base(c.Session.JSONLPath), err)
+			failed++
+			continue
+		}
+		c.SizeAfter = newSize
+		if newSize < c.SizeBefore {
+			saved += c.SizeBefore - newSize
+		}
+		processed++
+	}
+```
+
+- [ ] **Step 8: Run the test + full build + full suite**
+
+Run: `go test ./internal/compact/... && go build ./... && go test ./...`
+Expected: PASS — `TestCompactGrokSession` and `TestEstimateGrokSession` green, whole suite green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/compact/grok.go internal/compact/compact.go internal/compact/rewrite.go internal/compact/grok_test.go
+git commit -m "feat(grok): add directory-aware Grok compaction"
+```
+
+---
+
+## Phase 5 — Documentation
+
+Outcome: docs describe Grok everywhere the supported-agent set is listed.
+
+### Task 9: Documentation updates
+
+**Files:**
+- Modify: `docs/concepts/supported-agents.md`
+- Modify: `docs/maintenance/prune.md`, `docs/maintenance/compact.md`, `docs/maintenance/search.md`
+- Modify: `docs/usage/cli.md`
+
+- [ ] **Step 1: Update `docs/concepts/supported-agents.md`**
+
+Change the opening line "lazyagent supports seven agents" to "lazyagent supports eight agents".
+
+Add a table row after the `pi` / `OpenCode` rows (keep the existing column layout):
+
+```
+| [Grok CLI](https://github.com/xai-org/grok-cli) | `~/.grok/sessions/<encoded-cwd>/<uuid>/` | Directory per session (JSONL + JSON) | `G` |
+```
+
+Add a per-agent note after the "OpenCode" subsection, before "What's not supported (yet)":
+
+```markdown
+### Grok CLI
+
+Grok writes one *directory* per session, two levels deep under
+`~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/`. Each session directory
+holds a `summary.json` (metadata), a `chat_history.jsonl` (transcript), an
+`updates.jsonl` stream, and several smaller files. lazyagent reads
+`summary.json` plus `chat_history.jsonl` and decodes the cwd from the standard
+URL percent-encoding of the parent directory name.
+
+**No per-session cost.** Grok's on-disk data does not expose an
+input/output/cache token split, so Grok sessions show no per-session token or
+cost figures in any interface — those fields are honestly left at zero. (The
+separate `lazyagent limits` command still reports Grok's monthly billing
+window; that uses Grok's billing API, not on-disk session data.)
+
+**Subagent sessions** (`session_kind: "subagent"` in `summary.json`) are
+treated as sidechains and hidden from the default list, the same as Claude's
+sub-agent sessions.
+```
+
+- [ ] **Step 2: Update `docs/concepts/supported-agents.md` selecting-a-subset block**
+
+Add a line to the `--agent` code block (after `lazyagent --agent opencode`):
+
+```
+lazyagent --agent grok
+```
+
+- [ ] **Step 3: Update the maintenance docs**
+
+In `docs/maintenance/prune.md`, find where the supported agents are listed (`claude, pi, codex`) and add `grok`. Add a sentence: "Grok sessions are directories, so pruning a Grok session deletes the whole session directory recursively."
+
+In `docs/maintenance/compact.md`, change the `--agent LIST` table row (line 28) subset hint from `claude,pi,codex` to `claude,pi,codex,grok`, and the line 78 example `--agent claude,codex,pi` to include `grok`. Add a sentence to the field-paths section (around line 82): "For Grok, compact rewrites the bulky files inside the session directory — `updates.jsonl`, oversized `tool_result` payloads in `chat_history.jsonl`, `rewind_points.jsonl`, and `terminal/*.log`. Truncating `rewind_points.jsonl` disables Grok's rewind feature for that session."
+
+In `docs/maintenance/search.md`: line 10, add **Grok** to the list of plain-text-transcript agents; line 26, change the `--agent LIST` subset to `claude,codex,pi,amp,grok`; lines 104-107, add a bullet `- **grok** — Grok CLI (~/.grok/sessions/)`. The resume-command table (lines 73-76) gets no Grok row — `search` has no Grok resume command (out of scope); opening a Grok result prints a graceful "no resume command" message.
+
+- [ ] **Step 4: Update `docs/usage/cli.md`**
+
+Add a row to the `--agent` value table (after the `amp` row, lines 96-99):
+
+```
+| `grok` | Grok CLI |
+```
+
+Update the `search` paragraph (line 156): change "(Claude, Codex, pi, Amp)" to "(Claude, Codex, pi, Amp, Grok)".
+
+- [ ] **Step 5: Verify the docs build / links**
+
+Run: `grep -rn "seven agents\|claude,pi,codex\b" docs/` and confirm no stale "seven agents" or incomplete agent lists remain where Grok belongs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(grok): document Grok as a supported agent"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the whole suite green**
+
+Run: `go build ./... && go vet ./... && go test ./...`
+Expected: all packages build, vet clean, all tests pass.
+
+- [ ] **Smoke-test the binary** (if Grok is installed locally)
+
+Run: `go build -o lazyagent . && ./lazyagent --agent grok` — Grok sessions list with the `G ` prefix, subagent sessions hidden. Then `./lazyagent search --agent grok "<a word from a known session>"`, `./lazyagent prune --agent grok --dry-run`, and `./lazyagent compact --agent grok --dry-run` — each lists Grok sessions without error.
+
+---
+
+## Self-review (completed by plan author)
+
+**1. Spec coverage** — every spec section maps to a task:
+- §4 provider package → Tasks 1-3. §4.1 discovery strategy → Task 2. §4.2 data mapping → Task 1 (`ParseGrokSession`). §4.2 token-gap → zero fields asserted in Task 1's test, documented in Task 9. §4.3 provider wiring → Task 3.
+- §5 integration file list → Tasks 3 (provider, config), 4 (main, ui), 5 (search), 6 (prune), 8 (compact), 9 (docs).
+- §6 subagents/`IsSidechain` → Task 1 (set flag) + Tasks 1/2 tests; downstream filtering verified in "Design decisions" #4.
+- §7.1 search → Task 5. §7.2 prune (directory-aware) → Task 6. §7.3 compact Phase 0 → Task 7; Rewriter → Task 8.
+- §8 phasing → Phases 1-5 mirror the spec. §9 testing → tests in every code task. §10 error handling → missing-dir/malformed-summary/format-version/missing-signals all covered by Task 1-2 tests. §11 risks → #1 Task 7, #2 Task 6, #3 Design decision #4, #4 Task 1+9, #5 `supportedChatFormatVersion`, #6 bounded `updates.jsonl` tail (Design decision #3), #7 Task 6 note. §13 → Phase 4 starts with the Phase 0 task before any Rewriter code.
+
+**2. Placeholder scan** — no `TBD`/`TODO`/"add error handling"/"similar to Task N". Task 7 is intentionally a verification procedure (no production code); Task 8 is fully concrete and carries explicit Phase 0 gate instructions for narrowing scope — this is a documented gate, not a placeholder.
+
+**3. Type consistency** — `ParseGrokSession`, `discoverSessionsFromDir`, `walkSessionDirs`, `SessionDirs`, `SessionDiskBytes`, `GrokSessionsDir` used consistently across grok/search/prune/compact. `grokFileMutator` returns the existing `lineMutator` type. `estimateJSONL` is introduced in Task 8 step 3 and consumed in step 5. `sessionSizeBytes`/`grokBulkJSONL`/`grokTerminalLogs` defined in `grok.go`, used in `compact.go`/`rewrite.go`. `removeEmptyDirs` signature change (added `grokRoot`) is applied at its one call site in the same task.

--- a/docs/superpowers/plans/2026-05-20-grok-compact-phase0-findings.md
+++ b/docs/superpowers/plans/2026-05-20-grok-compact-phase0-findings.md
@@ -1,0 +1,90 @@
+# Grok Compact — Phase 0 Resume-Verification Findings
+
+> **Date:** 2026-05-20
+> **Status:** COMPLETE — all four candidate files verified SAFE. Task 8 may proceed at full scope.
+> Companion to `2026-05-20-grok-agent-integration.md` Task 7.
+
+## Question
+
+`lazyagent compact` truncates bulky payloads in a session while keeping it
+resumable by the originating agent. Before writing the Grok rewriter, we must
+know **which files inside a Grok session directory can be truncated without
+breaking `grok` resume.**
+
+## Method
+
+The verification ran against a real local Grok install (`~/.grok`, Grok Build
+TUI). Originals were never touched — all work was on a disposable session.
+
+1. **Created a disposable session.** Ran `grok -p "<task>" --cwd /tmp/grok-phase0`
+   with a task that exercised every relevant file type: a shell command (→
+   `terminal/*.log`, a `tool_result`), creating a file (→ `rewind_points.jsonl`
+   file snapshot), editing it (→ another snapshot, `hunk_records.jsonl`), and a
+   codeword (`MANGO-7731`) planted in the conversation as a coherence probe.
+   Resulting session: `chat_history.jsonl` 39 KiB (5 `tool_result` entries),
+   `updates.jsonl` 142 KiB (33 lines), one `terminal/*.log`, a
+   `rewind_points.jsonl` with embedded file snapshots.
+2. **Snapshotted** the pristine session directory for restore between runs.
+3. **Baseline resume** of the unmodified session.
+4. **Run B** — restored the snapshot, then truncated all four candidate files,
+   and resumed again.
+
+Resume command (headless, single-turn):
+
+```
+grok --resume <SESSION_ID> --cwd <cwd> \
+     -p "What codeword did I ask you to remember earlier? Reply with just the codeword." \
+     --output-format plain --no-alt-screen --disable-web-search
+```
+
+**SAFE criterion:** resume exits 0 and the model coherently recalls the
+codeword (proves the session loaded and the conversation continued).
+
+## Results
+
+| Run | Mutation | Outcome |
+|-----|----------|---------|
+| Baseline | none (unmodified session) | exit 0, recalled `MANGO-7731` |
+| Run B | **all four files truncated at once** | exit 0, recalled `MANGO-7731` |
+
+Run B mutations:
+- `updates.jsonl` — deep string truncation (every string value >200 chars cut to a marker), 142 KiB → 120 KiB, line count preserved (33).
+- `chat_history.jsonl` — **every** `tool_result.content` replaced with `"[phase0-truncated tool output]"`, line count preserved (17). `tool_call_id` linkage untouched.
+- `terminal/*.log` — truncated to 12 bytes.
+- `rewind_points.jsonl` — embedded `file_snapshots`/`after_snapshots` `content` values replaced with a marker.
+
+All rewritten files remained valid JSONL (every line independently parseable).
+
+## Verdict
+
+Because the **combined** truncation of all four files was tolerated, every
+subset is necessarily tolerated too — no bisection was needed.
+
+| File | Verdict | Notes |
+|------|---------|-------|
+| `updates.jsonl` | **SAFE** | ACP render/telemetry stream; deep string truncation tolerated, resume coherent. Highest-value target (~70% of session size in large sessions). |
+| `chat_history.jsonl` → `tool_result.content` | **SAFE** | Resume coherent with all tool outputs gutted. This changes what the model sees on resume — the intended, accepted `compact` behavior, identical to Claude compact. Only `tool_result.content` is truncated; `user`/`assistant` text and `tool_call_id` linkage are left intact. |
+| `terminal/*.log` | **SAFE** | Raw command-output capture; not consulted on resume. |
+| `rewind_points.jsonl` (embedded snapshots) | **SAFE — with caveat** | Resume coherent. Caveat: gutting the embedded file snapshots disables Grok's *rewind* feature for that session. Acceptable and must be documented. |
+
+## Caveats
+
+- One session of moderate size was tested (`updates.jsonl` 142 KiB). Truncation
+  tolerance is a structural property — whether Grok reads the file on resume —
+  not size-dependent, so the result generalizes to the ~18 MB sessions seen in
+  the wild.
+- `stderr` showed unrelated `MCP`/`SSE` worker errors (`127.0.0.1:.../sse`
+  connection refused) in **both** the baseline and Run B — a side MCP server,
+  not caused by truncation.
+- The test session was fully removed afterwards (directory, encoded-cwd parent,
+  `session_search.sqlite` row, `worktrees.db` row).
+
+## Decision for Task 8
+
+Proceed at **full scope**, no narrowing:
+
+- `grokBulkJSONL = ["updates.jsonl", "chat_history.jsonl", "rewind_points.jsonl"]`
+- plus `terminal/*.log` raw-log truncation.
+- `updates.jsonl` and `rewind_points.jsonl`: deep string truncation.
+- `chat_history.jsonl`: truncate `tool_result.content` only; preserve line count and `tool_call_id` linkage.
+- Document the `rewind_points.jsonl` caveat (rewind disabled for compacted sessions) in `docs/maintenance/compact.md`.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -97,6 +97,7 @@ Restrict monitoring to one agent. Valid values:
 | `pi` | pi coding agent |
 | `codex` | Codex CLI |
 | `amp` | Amp CLI |
+| `grok` | Grok CLI |
 | `cursor` | Cursor IDE |
 | `opencode` | OpenCode |
 | `all` | Every enabled agent (default) |
@@ -153,7 +154,7 @@ See [`prune`](../maintenance/prune.md), [`compact`](../maintenance/compact.md), 
 
 ### `search`
 
-`search` runs full-text search over local agent transcripts (Claude, Codex, pi, Amp) using an incremental SQLite FTS5 index under the user cache directory. Cursor and OpenCode are excluded because their history lives in third-party SQLite databases.
+`search` runs full-text search over local agent transcripts (Claude, Codex, pi, Amp, Grok) using an incremental SQLite FTS5 index under the user cache directory. Cursor and OpenCode are excluded because their history lives in third-party SQLite databases.
 
 ```bash
 lazyagent search "race condition"

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -430,15 +430,15 @@ type SessionFull struct {
 
 // ToolItem represents a recent tool call.
 type ToolItem struct {
-	Name      string    `json:"name"`
-	Timestamp time.Time `json:"timestamp"`
+	Name      string     `json:"name"`
+	Timestamp *time.Time `json:"timestamp,omitempty"`
 }
 
 // ConversationItem represents a conversation message.
 type ConversationItem struct {
-	Role      string    `json:"role"`
-	Text      string    `json:"text"`
-	Timestamp time.Time `json:"timestamp"`
+	Role      string     `json:"role"`
+	Text      string     `json:"text"`
+	Timestamp *time.Time `json:"timestamp,omitempty"`
 }
 
 // StatsResponse is returned by GET /api/stats and included in SSE frames.
@@ -489,13 +489,24 @@ func (s *Server) buildSessionItem(sess *model.Session, activity core.ActivityKin
 	}
 }
 
+// optTime returns a pointer to t, or nil when t is the zero value, so an
+// unknown timestamp is omitted from the JSON response instead of being
+// serialized as the year-1 zero time. (Grok records a per-item timestamp
+// only for the most recent tool/message.)
+func optTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
 func (s *Server) buildSessionFull(detail *core.SessionDetailView) SessionFull {
 	sess := &detail.Session
 	tools := make([]ToolItem, 0, len(sess.RecentTools))
 	for _, t := range sess.RecentTools {
 		tools = append(tools, ToolItem{
 			Name:      t.Name,
-			Timestamp: t.Timestamp,
+			Timestamp: optTime(t.Timestamp),
 		})
 	}
 	msgs := make([]ConversationItem, 0, len(sess.RecentMessages))
@@ -503,7 +514,7 @@ func (s *Server) buildSessionFull(detail *core.SessionDetailView) SessionFull {
 		msgs = append(msgs, ConversationItem{
 			Role:      m.Role,
 			Text:      m.Text,
-			Timestamp: m.Timestamp,
+			Timestamp: optTime(m.Timestamp),
 		})
 	}
 	return SessionFull{

--- a/internal/compact/compact.go
+++ b/internal/compact/compact.go
@@ -25,6 +25,7 @@ var supportedAgents = []chatops.Agent{
 	{Key: "claude", Label: "Claude Code", Color: "#E7A15E"},
 	{Key: "pi", Label: "pi coding agent", Color: "#F38BA8"},
 	{Key: "codex", Label: "Codex CLI", Color: "#A6E3A1"},
+	{Key: "grok", Label: "Grok", Color: "#89B4FA"},
 }
 
 // defaultThresholdBytes is the maximum length (in bytes) of a single JSON
@@ -261,14 +262,11 @@ func collectCandidates(agents []string, opts options) ([]Candidate, []error) {
 			if opts.daysSet && !s.LastActivity.IsZero() && s.LastActivity.After(cutoff) {
 				continue
 			}
-			info, err := os.Stat(s.JSONLPath)
-			if err != nil {
+			size := sessionSizeBytes(s)
+			if size < opts.minSize {
 				continue
 			}
-			if info.Size() < opts.minSize {
-				continue
-			}
-			all = append(all, Candidate{Session: s, SizeBefore: info.Size()})
+			all = append(all, Candidate{Session: s, SizeBefore: size})
 		}
 	}
 

--- a/internal/compact/grok.go
+++ b/internal/compact/grok.go
@@ -1,0 +1,200 @@
+package compact
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// grokBulkJSONL lists the JSONL files inside a Grok session directory whose
+// oversized payloads compact truncates. Phase 0 resume-verification confirmed
+// these are safe to shrink (see 2026-05-20-grok-compact-phase0-findings.md):
+//
+//   - updates.jsonl       — ACP render/telemetry stream, ~70% of session size,
+//                           not replayed on resume → deep string truncation.
+//   - chat_history.jsonl  — model-facing transcript; only tool_result.content
+//                           is truncated (same trade-off as Claude compact).
+//   - rewind_points.jsonl — checkpoint snapshots; truncating disables Grok's
+//                           rewind feature for the session.
+var grokBulkJSONL = []string{"updates.jsonl", "chat_history.jsonl", "rewind_points.jsonl"}
+
+// sessionSizeBytes returns the on-disk size of a session: the live directory
+// total (excluding .bak sidecars) for Grok, a single file size for the
+// JSONL-per-session agents.
+func sessionSizeBytes(s *model.Session) int64 {
+	if s.Agent == "grok" {
+		return grokLiveDirBytes(s.JSONLPath)
+	}
+	info, err := os.Stat(s.JSONLPath)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+// grokFileMutator returns the per-line mutator for a Grok session file.
+func grokFileMutator(name string) lineMutator {
+	if name == "chat_history.jsonl" {
+		return compactGrokChatLine
+	}
+	// updates.jsonl, rewind_points.jsonl: not replayed on resume, so every
+	// oversized string leaf can be truncated.
+	return func(entry map[string]any, threshold int64) int64 {
+		return truncateGrokDeep(entry, threshold)
+	}
+}
+
+// compactGrokChatLine truncates the content of a tool_result entry. The
+// tool_call_id ↔ tool_calls[].id linkage is untouched so the transcript stays
+// internally consistent and resumable.
+func compactGrokChatLine(entry map[string]any, threshold int64) int64 {
+	if entry["type"] != "tool_result" {
+		return 0
+	}
+	s, ok := entry["content"].(string)
+	if !ok {
+		return 0
+	}
+	if newVal, delta := truncateString(s, threshold); delta > 0 {
+		entry["content"] = newVal
+		return delta
+	}
+	return 0
+}
+
+// truncateGrokDeep recursively truncates every oversized string value in a
+// decoded JSON structure. Used for files Grok does not replay on resume.
+func truncateGrokDeep(v any, threshold int64) int64 {
+	var saved int64
+	switch t := v.(type) {
+	case map[string]any:
+		for k, child := range t {
+			if s, ok := child.(string); ok {
+				if newVal, delta := truncateString(s, threshold); delta > 0 {
+					t[k] = newVal
+					saved += delta
+				}
+				continue
+			}
+			saved += truncateGrokDeep(child, threshold)
+		}
+	case []any:
+		for _, child := range t {
+			saved += truncateGrokDeep(child, threshold)
+		}
+	}
+	return saved
+}
+
+// grokTerminalLogs returns the terminal/*.log paths inside a session dir.
+func grokTerminalLogs(dir string) []string {
+	logs, _ := filepath.Glob(filepath.Join(dir, "terminal", "*.log"))
+	return logs
+}
+
+// grokLiveDirBytes returns the total on-disk size of a Grok session directory,
+// excluding .bak sidecar files created by compact. This gives the "live"
+// session size that callers compare against the pre-compaction baseline.
+func grokLiveDirBytes(dir string) int64 {
+	var total int64
+	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(p) == ".bak" {
+			return nil
+		}
+		if info, err := d.Info(); err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// compactGrokSession truncates oversized payloads across the bulky files of a
+// Grok session directory and returns the directory's new total size (excluding
+// .bak sidecar files so the caller can compare against the pre-compact size).
+func compactGrokSession(dir string, threshold int64, backup bool) (int64, error) {
+	if err := guardPath(dir); err != nil {
+		return 0, err
+	}
+	for _, name := range grokBulkJSONL {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); err != nil {
+			continue // file absent for this session
+		}
+		if _, err := rewriteFile(path, grokFileMutator(name), threshold, backup); err != nil {
+			return 0, fmt.Errorf("%s: %w", name, err)
+		}
+	}
+	for _, log := range grokTerminalLogs(dir) {
+		if err := compactGrokTerminalLog(log, threshold, backup); err != nil {
+			return 0, fmt.Errorf("%s: %w", filepath.Base(log), err)
+		}
+	}
+	return grokLiveDirBytes(dir), nil
+}
+
+// compactGrokTerminalLog truncates a raw (non-JSON) terminal capture log.
+func compactGrokTerminalLog(path string, threshold int64, backup bool) error {
+	if err := guardPath(path); err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Size() <= threshold {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	newVal, delta := truncateString(string(data), threshold)
+	if delta <= 0 {
+		return nil
+	}
+	if backup {
+		if err := copyFile(path, path+".bak"); err != nil {
+			return fmt.Errorf("backup: %w", err)
+		}
+	}
+	return os.WriteFile(path, []byte(newVal), info.Mode())
+}
+
+// estimateGrokSession simulates the rewrite of every bulky file and returns
+// the directory's projected post-compaction total size. It writes nothing.
+// The returned size excludes .bak sidecars to match compactGrokSession output.
+func estimateGrokSession(dir string, threshold int64) (int64, error) {
+	total := grokLiveDirBytes(dir)
+	for _, name := range grokBulkJSONL {
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		after, err := estimateJSONL(path, grokFileMutator(name), threshold)
+		if err != nil {
+			continue
+		}
+		total -= info.Size() - after
+	}
+	for _, log := range grokTerminalLogs(dir) {
+		info, err := os.Stat(log)
+		if err != nil || info.Size() <= threshold {
+			continue
+		}
+		data, err := os.ReadFile(log)
+		if err != nil {
+			continue
+		}
+		if newVal, delta := truncateString(string(data), threshold); delta > 0 {
+			total -= info.Size() - int64(len(newVal))
+		}
+	}
+	return total, nil
+}

--- a/internal/compact/grok.go
+++ b/internal/compact/grok.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
@@ -81,7 +82,14 @@ func truncateGrokDeep(v any, threshold int64) int64 {
 			saved += truncateGrokDeep(child, threshold)
 		}
 	case []any:
-		for _, child := range t {
+		for i, child := range t {
+			if s, ok := child.(string); ok {
+				if newVal, delta := truncateString(s, threshold); delta > 0 {
+					t[i] = newVal
+					saved += delta
+				}
+				continue
+			}
 			saved += truncateGrokDeep(child, threshold)
 		}
 	}
@@ -103,7 +111,8 @@ func grokLiveDirBytes(dir string) int64 {
 		if err != nil || d.IsDir() {
 			return nil
 		}
-		if filepath.Ext(p) == ".bak" {
+		name := d.Name()
+		if filepath.Ext(name) == ".bak" || strings.HasSuffix(name, ".compact.tmp") {
 			return nil
 		}
 		if info, err := d.Info(); err == nil {

--- a/internal/compact/grok_test.go
+++ b/internal/compact/grok_test.go
@@ -1,0 +1,126 @@
+package compact
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMain sets testGuardRoots to the OS temp directory so that
+// compactGrokSession can write to temp dirs created by t.TempDir().
+func TestMain(m *testing.M) {
+	testGuardRoots = []string{os.TempDir()}
+	os.Exit(m.Run())
+}
+
+// writeGrokSessionForCompact builds a Grok session directory with an
+// oversized tool-output payload in updates.jsonl.
+func writeGrokSessionForCompact(t *testing.T, big string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "sess-1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string]string{
+		"summary.json":       `{"info":{"id":"sess-1","cwd":"/tmp/p"},"chat_format_version":1}`,
+		"chat_history.jsonl": `{"type":"tool_result","content":` + jsonString(big) + `,"tool_call_id":"call-1"}` + "\n",
+		"updates.jsonl": `{"timestamp":1,"method":"x","params":{"text":` + jsonString(big) + `}}` + "\n" +
+			`{"timestamp":2,"method":"y","params":{"small":"ok"}}` + "\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func countLines(t *testing.T, path string) int {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	n := 0
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+	for sc.Scan() {
+		n++
+		var v any
+		if err := json.Unmarshal(sc.Bytes(), &v); err != nil {
+			t.Fatalf("line %d of %s is not valid JSON: %v", n, path, err)
+		}
+	}
+	return n
+}
+
+func TestCompactGrokSession(t *testing.T) {
+	big := strings.Repeat("A", 50*1024) // 50 KiB — well above the 10 KiB threshold
+	dir := writeGrokSessionForCompact(t, big)
+
+	before := grokDirSize(t, dir)
+	newSize, err := compactGrokSession(dir, 10*1024, true)
+	if err != nil {
+		t.Fatalf("compactGrokSession: %v", err)
+	}
+	if newSize >= before {
+		t.Errorf("size did not shrink: before=%d after=%d", before, newSize)
+	}
+	// Every rewritten JSONL file must stay valid and keep its line count.
+	if n := countLines(t, filepath.Join(dir, "updates.jsonl")); n != 2 {
+		t.Errorf("updates.jsonl line count = %d, want 2", n)
+	}
+	if n := countLines(t, filepath.Join(dir, "chat_history.jsonl")); n != 1 {
+		t.Errorf("chat_history.jsonl line count = %d, want 1", n)
+	}
+	// tool_call_id linkage must survive truncation.
+	data, _ := os.ReadFile(filepath.Join(dir, "chat_history.jsonl"))
+	if !strings.Contains(string(data), `"tool_call_id":"call-1"`) {
+		t.Error("tool_call_id linkage was lost")
+	}
+	// Backups were requested.
+	if _, err := os.Stat(filepath.Join(dir, "updates.jsonl.bak")); err != nil {
+		t.Error("expected updates.jsonl.bak backup")
+	}
+}
+
+func grokDirSize(t *testing.T, dir string) int64 {
+	t.Helper()
+	var total int64
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if info, err := e.Info(); err == nil && !e.IsDir() {
+			total += info.Size()
+		}
+	}
+	return total
+}
+
+func TestEstimateGrokSession(t *testing.T) {
+	big := strings.Repeat("B", 50*1024)
+	dir := writeGrokSessionForCompact(t, big)
+	before := grokDirSize(t, dir)
+	after, err := estimateGrokSession(dir, 10*1024)
+	if err != nil {
+		t.Fatalf("estimateGrokSession: %v", err)
+	}
+	if after >= before {
+		t.Errorf("estimate did not shrink: before=%d after=%d", before, after)
+	}
+	// Estimation must not modify any file.
+	if grokDirSize(t, dir) != before {
+		t.Error("estimateGrokSession modified the session on disk")
+	}
+}

--- a/internal/compact/grok_test.go
+++ b/internal/compact/grok_test.go
@@ -95,17 +95,7 @@ func TestCompactGrokSession(t *testing.T) {
 
 func grokDirSize(t *testing.T, dir string) int64 {
 	t.Helper()
-	var total int64
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if info, err := e.Info(); err == nil && !e.IsDir() {
-			total += info.Size()
-		}
-	}
-	return total
+	return grokLiveDirBytes(dir)
 }
 
 func TestEstimateGrokSession(t *testing.T) {
@@ -122,5 +112,32 @@ func TestEstimateGrokSession(t *testing.T) {
 	// Estimation must not modify any file.
 	if grokDirSize(t, dir) != before {
 		t.Error("estimateGrokSession modified the session on disk")
+	}
+}
+
+func TestCompactGrokSession_TerminalLog(t *testing.T) {
+	dir := writeGrokSessionForCompact(t, "small payload") // chat/updates stay tiny
+	logDir := filepath.Join(dir, "terminal")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(logDir, "call-1.log")
+	big := strings.Repeat("C", 50*1024) // 50 KiB raw log, above the 10 KiB threshold
+	if err := os.WriteFile(logPath, []byte(big), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := compactGrokSession(dir, 10*1024, true); err != nil {
+		t.Fatalf("compactGrokSession: %v", err)
+	}
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() >= int64(len(big)) {
+		t.Errorf("terminal log did not shrink: size=%d, was %d", info.Size(), len(big))
+	}
+	if _, err := os.Stat(logPath + ".bak"); err != nil {
+		t.Error("expected a .bak backup of the terminal log")
 	}
 }

--- a/internal/compact/rewrite.go
+++ b/internal/compact/rewrite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/claude"
 	"github.com/illegalstudio/lazyagent/internal/codex"
 	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/grok"
 	"github.com/illegalstudio/lazyagent/internal/pi"
 )
 
@@ -149,16 +150,20 @@ func rewriteFile(path string, mutator lineMutator, threshold int64, backup bool)
 	return info.Size(), nil
 }
 
-// estimateRewrite runs the mutator in memory without writing anything, and
-// returns what the post-rewrite file size would be. Used by --dry-run.
+// estimateRewrite runs the agent's mutator in memory without writing anything
+// and returns the projected post-rewrite file size. Used by --dry-run.
 func estimateRewrite(path, agent string, threshold int64) (int64, error) {
+	return estimateJSONL(path, mutatorFor(agent), threshold)
+}
+
+// estimateJSONL simulates a per-line rewrite with the given mutator and
+// returns the projected file size, writing nothing.
+func estimateJSONL(path string, mutator lineMutator, threshold int64) (int64, error) {
 	in, err := os.Open(path)
 	if err != nil {
 		return 0, err
 	}
 	defer in.Close()
-
-	mutator := mutatorFor(agent)
 
 	var total int64
 	scanner := bufio.NewScanner(in)
@@ -190,7 +195,13 @@ func estimateRewrite(path, agent string, threshold int64) (int64, error) {
 func estimateSizes(candidates []Candidate, threshold int64) {
 	for i := range candidates {
 		c := &candidates[i]
-		after, err := estimateRewrite(c.Session.JSONLPath, c.Session.Agent, threshold)
+		var after int64
+		var err error
+		if c.Session.Agent == "grok" {
+			after, err = estimateGrokSession(c.Session.JSONLPath, threshold)
+		} else {
+			after, err = estimateRewrite(c.Session.JSONLPath, c.Session.Agent, threshold)
+		}
 		if err != nil {
 			c.SizeAfter = c.SizeBefore
 			continue
@@ -199,8 +210,16 @@ func estimateSizes(candidates []Candidate, threshold int64) {
 	}
 }
 
+// testGuardRoots holds extra root directories injected by tests. When
+// non-empty the normal root list is replaced entirely so tests can write to
+// their own temp directories without relaxing the real guard.
+var testGuardRoots []string
+
 // guardPath blocks compacting anything outside the known agent roots.
 func guardPath(path string) error {
+	if len(testGuardRoots) > 0 {
+		return chatops.EnsureWithin(path, testGuardRoots)
+	}
 	cfg := core.LoadConfig()
 	var roots []string
 	roots = append(roots, claude.ClaudeProjectsDirs(cfg.ClaudeDirs)...)
@@ -208,6 +227,9 @@ func guardPath(path string) error {
 		roots = append(roots, d)
 	}
 	if d := codex.SessionsDir(); d != "" {
+		roots = append(roots, d)
+	}
+	if d := grok.GrokSessionsDir(); d != "" {
 		roots = append(roots, d)
 	}
 	return chatops.EnsureWithin(path, roots)
@@ -250,8 +272,13 @@ func executeCompact(candidates []Candidate, opts options) (int, int, int64) {
 	var saved int64
 	for i := range candidates {
 		c := &candidates[i]
-		mutator := mutatorFor(c.Session.Agent)
-		newSize, err := rewriteFile(c.Session.JSONLPath, mutator, opts.threshold, opts.backup)
+		var newSize int64
+		var err error
+		if c.Session.Agent == "grok" {
+			newSize, err = compactGrokSession(c.Session.JSONLPath, opts.threshold, opts.backup)
+		} else {
+			newSize, err = rewriteFile(c.Session.JSONLPath, mutatorFor(c.Session.Agent), opts.threshold, opts.backup)
+		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed: %s — %v\n", filepath.Base(c.Session.JSONLPath), err)
 			failed++

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -54,6 +54,7 @@ func DefaultConfig() Config {
 			"cursor":   true,
 			"codex":    true,
 			"amp":      true,
+			"grok":     true,
 		},
 		ExcludeCWDSubstrings: []string{},
 		TUI:                  TUIConfig{Theme: "dark"},

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/claude"
 	"github.com/illegalstudio/lazyagent/internal/codex"
 	"github.com/illegalstudio/lazyagent/internal/cursor"
+	"github.com/illegalstudio/lazyagent/internal/grok"
 	"github.com/illegalstudio/lazyagent/internal/model"
 	"github.com/illegalstudio/lazyagent/internal/opencode"
 	"github.com/illegalstudio/lazyagent/internal/pi"
@@ -155,6 +156,24 @@ func (p *AmpProvider) WatchDirs() []string {
 	return nil
 }
 
+// GrokProvider discovers xAI Grok CLI sessions from disk.
+type GrokProvider struct {
+	cache *model.SessionCache
+}
+
+// NewGrokProvider creates a GrokProvider with an mtime-based cache.
+func NewGrokProvider() *GrokProvider {
+	return &GrokProvider{cache: model.NewSessionCache()}
+}
+
+func (p *GrokProvider) DiscoverSessions() ([]*model.Session, error) {
+	return grok.DiscoverSessions(p.cache)
+}
+
+func (p *GrokProvider) UseWatcher() bool               { return true }
+func (p *GrokProvider) RefreshInterval() time.Duration { return 0 }
+func (p *GrokProvider) WatchDirs() []string            { return []string{grok.GrokSessionsDir()} }
+
 // BuildProvider creates a SessionProvider based on agent mode and config.
 // When agentMode is "all", it reads the agents config to decide which providers
 // to include. A specific agentMode (e.g. "claude") overrides the config.
@@ -172,6 +191,8 @@ func BuildProvider(agentMode string, cfg Config) SessionProvider {
 		return NewCodexProvider()
 	case "amp":
 		return NewAmpProvider()
+	case "grok":
+		return NewGrokProvider()
 	default: // "all"
 		var providers []SessionProvider
 		if cfg.AgentEnabled("claude") {
@@ -191,6 +212,9 @@ func BuildProvider(agentMode string, cfg Config) SessionProvider {
 		}
 		if cfg.AgentEnabled("amp") {
 			providers = append(providers, NewAmpProvider())
+		}
+		if cfg.AgentEnabled("grok") {
+			providers = append(providers, NewGrokProvider())
 		}
 		if len(providers) == 0 {
 			// All disabled — return a no-op provider.

--- a/internal/core/provider_test.go
+++ b/internal/core/provider_test.go
@@ -96,6 +96,20 @@ func TestMultiProvider_RefreshInterval(t *testing.T) {
 	}
 }
 
+func TestBuildProvider_Grok(t *testing.T) {
+	p := BuildProvider("grok", DefaultConfig())
+	if _, ok := p.(*GrokProvider); !ok {
+		t.Fatalf("BuildProvider(\"grok\") = %T, want *GrokProvider", p)
+	}
+}
+
+func TestDefaultConfig_GrokEnabled(t *testing.T) {
+	cfg := DefaultConfig()
+	if !cfg.AgentEnabled("grok") {
+		t.Error("grok must be enabled by default")
+	}
+}
+
 var errTest = errorString("test error")
 
 type errorString string

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -248,6 +248,13 @@ func (m *SessionManager) filterSessionsLocked(search string, filter ActivityKind
 		if s.IsSidechain || !s.LastActivity.After(cutoff) {
 			continue
 		}
+		// Grok creates a session directory the moment `grok` is launched,
+		// before any message is sent. Hide such never-used sessions from the
+		// list. They are still returned by the provider, so `prune` and
+		// `compact` can reach very old empty sessions.
+		if s.Agent == "grok" && s.UserMessages == 0 {
+			continue
+		}
 		if filter != "" && m.tracker.Get(s.SessionID) != filter {
 			continue
 		}

--- a/internal/core/session_test.go
+++ b/internal/core/session_test.go
@@ -102,6 +102,45 @@ func TestFilterSessionsLocked_ExcludesCWDSubstrings(t *testing.T) {
 	}
 }
 
+func TestFilterSessionsLocked_HidesEmptyGrokSessions(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	provider := fakeProvider{
+		sessions: []*model.Session{
+			{SessionID: "grok-active", Agent: "grok", CWD: "/p", LastActivity: now, UserMessages: 3},
+			{SessionID: "grok-empty", Agent: "grok", CWD: "/p", LastActivity: now, UserMessages: 0},
+			{SessionID: "claude-zero", Agent: "claude", CWD: "/p", LastActivity: now, UserMessages: 0},
+		},
+	}
+
+	mgr := NewSessionManager(60, provider)
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+
+	// Discovery keeps every session so prune can reach old never-used ones.
+	if len(mgr.Sessions()) != 3 {
+		t.Errorf("Sessions() = %d, want 3 (raw discovery keeps empty Grok sessions)", len(mgr.Sessions()))
+	}
+
+	// The rendering filter (backing TUI, GUI and API) hides the empty Grok
+	// session — and only Grok: a non-Grok session with no user messages is
+	// left untouched.
+	check := func(name string, got []*model.Session) {
+		for _, s := range got {
+			if s.SessionID == "grok-empty" {
+				t.Errorf("%s must not contain the never-used Grok session", name)
+			}
+		}
+		if len(got) != 2 {
+			t.Errorf("%s = %d sessions, want 2 (grok-active + claude-zero)", name, len(got))
+		}
+	}
+	check("VisibleSessions", mgr.VisibleSessions()) // TUI + GUI/tray
+	check("QuerySessions", mgr.QuerySessions("", "")) // HTTP API
+}
+
 func TestFilterSessionsLocked_NoExcludePatterns(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 

--- a/internal/grok/parse.go
+++ b/internal/grok/parse.go
@@ -9,8 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
@@ -237,11 +238,6 @@ func grokEntryText(raw json.RawMessage) string {
 				return b.Text
 			}
 		}
-		for _, b := range blocks {
-			if b.Text != "" {
-				return b.Text
-			}
-		}
 	}
 	return ""
 }
@@ -252,7 +248,8 @@ func normalizeGrokToolName(name string) string {
 	if name == "" {
 		return name
 	}
-	return strings.ToUpper(name[:1]) + name[1:]
+	r, size := utf8.DecodeRuneInString(name)
+	return string(unicode.ToUpper(r)) + name[size:]
 }
 
 // grokStatus infers session status from the last transcript entry.

--- a/internal/grok/parse.go
+++ b/internal/grok/parse.go
@@ -79,6 +79,18 @@ func ParseGrokSession(sessionDir string) (*model.Session, error) {
 	s.RecentTools = chat.recentTools
 	s.Status, s.CurrentTool = grokStatus(chat.lastEntry)
 
+	// chat_history.jsonl carries no per-message timestamps. Stamp tools and
+	// messages with the session's last-activity time so the UI shows a sane
+	// relative age — a zero time.Time renders as a time.Duration overflow
+	// ("106751d ago") and would never satisfy the activity-tracker freshness
+	// check. It also lets a recently active session surface its tool activity.
+	for i := range s.RecentTools {
+		s.RecentTools[i].Timestamp = s.LastActivity
+	}
+	for i := range s.RecentMessages {
+		s.RecentMessages[i].Timestamp = s.LastActivity
+	}
+
 	// Message counts: prefer signals.json, fall back to counting the transcript.
 	if signals, ok := readGrokSignals(filepath.Join(sessionDir, "signals.json")); ok {
 		s.UserMessages = signals.UserMessageCount

--- a/internal/grok/parse.go
+++ b/internal/grok/parse.go
@@ -67,7 +67,11 @@ func ParseGrokSession(sessionDir string) (*model.Session, error) {
 	// Timestamps. updated_at == last_active_at in every observed sample;
 	// fall back across both, then created_at.
 	s.LastActivity = parseGrokTime(firstNonEmpty(summary.LastActiveAt, summary.UpdatedAt, summary.CreatedAt))
-	s.LastSummaryAt = parseGrokTime(firstNonEmpty(summary.UpdatedAt, summary.LastActiveAt))
+	// LastSummaryAt is intentionally left zero: it drives the "compacting"
+	// activity (core.ResolveActivity), and Grok exposes no compaction-summary
+	// marker on disk — not in summary.json, chat_history.jsonl, or events.jsonl.
+	// Mapping it to updated_at (as an earlier draft did) made every recently
+	// active session falsely render as "compacting".
 
 	// Transcript: counts, recent messages/tools, status.
 	chat := parseGrokChatHistory(filepath.Join(sessionDir, "chat_history.jsonl"))

--- a/internal/grok/parse.go
+++ b/internal/grok/parse.go
@@ -231,6 +231,8 @@ func UserMessageText(content json.RawMessage) (string, bool) {
 	if inner, ok := extractGrokTag(text, "user_query"); ok {
 		return strings.TrimSpace(inner), true
 	}
+	// text is already TrimSpace'd above, so HasPrefix reliably catches
+	// injected blocks even when the raw entry had leading whitespace.
 	if strings.HasPrefix(text, "<system-reminder>") || strings.HasPrefix(text, "<user_info>") {
 		return "", false
 	}

--- a/internal/grok/parse.go
+++ b/internal/grok/parse.go
@@ -79,16 +79,18 @@ func ParseGrokSession(sessionDir string) (*model.Session, error) {
 	s.RecentTools = chat.recentTools
 	s.Status, s.CurrentTool = grokStatus(chat.lastEntry)
 
-	// chat_history.jsonl carries no per-message timestamps. Stamp tools and
-	// messages with the session's last-activity time so the UI shows a sane
-	// relative age — a zero time.Time renders as a time.Duration overflow
-	// ("106751d ago") and would never satisfy the activity-tracker freshness
-	// check. It also lets a recently active session surface its tool activity.
-	for i := range s.RecentTools {
-		s.RecentTools[i].Timestamp = s.LastActivity
+	// chat_history.jsonl carries no per-message timestamps. Stamp only the
+	// most recent tool and message with the session's last-activity time —
+	// the best timestamp available. Earlier entries keep a zero Timestamp;
+	// renderers omit their relative age rather than show a fabricated one.
+	// (A zero time.Time otherwise renders as a time.Duration overflow,
+	// "106751d ago".) Stamping the last tool also lets a recently active
+	// session satisfy the activity-tracker freshness check.
+	if n := len(s.RecentTools); n > 0 {
+		s.RecentTools[n-1].Timestamp = s.LastActivity
 	}
-	for i := range s.RecentMessages {
-		s.RecentMessages[i].Timestamp = s.LastActivity
+	if n := len(s.RecentMessages); n > 0 {
+		s.RecentMessages[n-1].Timestamp = s.LastActivity
 	}
 
 	// Message counts: prefer signals.json, fall back to counting the transcript.

--- a/internal/grok/parse.go
+++ b/internal/grok/parse.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -173,17 +174,18 @@ func parseGrokChatHistory(path string) grokChatResult {
 		}
 		switch e.Type {
 		case "user":
+			msgText, isReal := UserMessageText(e.Content)
+			if !isReal {
+				continue // injected <user_info>/<system-reminder> context, not a message
+			}
 			res.userCount++
 			res.lastEntry = copyGrokEntry(&e)
-			text := grokEntryText(e.Content)
-			if res.firstUserText == "" && text != "" {
-				res.firstUserText = model.Truncate(text, 300)
+			if res.firstUserText == "" {
+				res.firstUserText = model.Truncate(msgText, 300)
 			}
-			if text != "" {
-				res.recentMessages = append(res.recentMessages, model.ConversationMessage{
-					Role: "user", Text: model.Truncate(text, 300),
-				})
-			}
+			res.recentMessages = append(res.recentMessages, model.ConversationMessage{
+				Role: "user", Text: model.Truncate(msgText, 300),
+			})
 		case "assistant":
 			res.assistantCount++
 			res.lastEntry = copyGrokEntry(&e)
@@ -214,6 +216,39 @@ func parseGrokChatHistory(path string) grokChatResult {
 func copyGrokEntry(e *grokChatEntry) *grokChatEntry {
 	cp := *e
 	return &cp
+}
+
+// UserMessageText extracts the human-authored text of a chat_history "user"
+// entry. Grok injects <user_info> and <system-reminder> blocks as their own
+// type:"user" entries; those are context, not messages. The real prompt is
+// wrapped in <user_query>...</user_query>. It returns (text, true) for a real
+// user message and ("", false) for an injected-context entry.
+func UserMessageText(content json.RawMessage) (string, bool) {
+	text := strings.TrimSpace(grokEntryText(content))
+	if text == "" {
+		return "", false
+	}
+	if inner, ok := extractGrokTag(text, "user_query"); ok {
+		return strings.TrimSpace(inner), true
+	}
+	if strings.HasPrefix(text, "<system-reminder>") || strings.HasPrefix(text, "<user_info>") {
+		return "", false
+	}
+	return text, true
+}
+
+// extractGrokTag returns the text between <tag> and </tag> in s.
+func extractGrokTag(s, tag string) (string, bool) {
+	open := "<" + tag + ">"
+	i := strings.Index(s, open)
+	if i < 0 {
+		return "", false
+	}
+	rest := s[i+len(open):]
+	if j := strings.Index(rest, "</"+tag+">"); j >= 0 {
+		return rest[:j], true
+	}
+	return rest, true // unterminated tag — take the remainder
 }
 
 // grokEntryText extracts the first human-readable text from a chat entry's

--- a/internal/grok/parse.go
+++ b/internal/grok/parse.go
@@ -1,0 +1,321 @@
+package grok
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// supportedChatFormatVersion is the highest summary.json chat_format_version
+// this parser understands. A session declaring a newer version is skipped so
+// a future Grok upgrade cannot crash discovery.
+const supportedChatFormatVersion = 1
+
+const (
+	maxRecentMessages  = 10
+	maxRecentTools     = 20
+	maxEntryTimestamps = 500
+	// maxUpdatesTailBytes bounds how much of updates.jsonl is read for the
+	// activity sparkline. updates.jsonl can reach ~18 MB; only the recent
+	// tail matters for the (short) sparkline window.
+	maxUpdatesTailBytes = 512 * 1024
+)
+
+// ParseGrokSession reads one Grok session directory into a model.Session.
+// It returns an error when summary.json is missing/unreadable or declares an
+// unsupported chat_format_version; callers skip such sessions.
+func ParseGrokSession(sessionDir string) (*model.Session, error) {
+	summary, err := readGrokSummary(filepath.Join(sessionDir, "summary.json"))
+	if err != nil {
+		return nil, err
+	}
+	if summary.ChatFormatVersion > supportedChatFormatVersion {
+		return nil, fmt.Errorf("grok: unsupported chat_format_version %d", summary.ChatFormatVersion)
+	}
+
+	s := &model.Session{
+		Agent:         "grok",
+		SessionID:     summary.Info.ID,
+		JSONLPath:     sessionDir,
+		CWD:           summary.Info.CWD,
+		Model:         summary.CurrentModelID,
+		GitBranch:     summary.HeadBranch,
+		TotalMessages: summary.NumChatMessages,
+		IsSidechain:   summary.SessionKind == "subagent",
+	}
+	if s.SessionID == "" {
+		s.SessionID = filepath.Base(sessionDir)
+	}
+	if s.CWD == "" {
+		s.CWD = decodeGrokDirName(filepath.Base(filepath.Dir(sessionDir)))
+	}
+	if summary.ChatFormatVersion > 0 {
+		s.Version = strconv.Itoa(summary.ChatFormatVersion)
+	}
+
+	// Timestamps. updated_at == last_active_at in every observed sample;
+	// fall back across both, then created_at.
+	s.LastActivity = parseGrokTime(firstNonEmpty(summary.LastActiveAt, summary.UpdatedAt, summary.CreatedAt))
+	s.LastSummaryAt = parseGrokTime(firstNonEmpty(summary.UpdatedAt, summary.LastActiveAt))
+
+	// Transcript: counts, recent messages/tools, status.
+	chat := parseGrokChatHistory(filepath.Join(sessionDir, "chat_history.jsonl"))
+	s.RecentMessages = chat.recentMessages
+	s.RecentTools = chat.recentTools
+	s.Status, s.CurrentTool = grokStatus(chat.lastEntry)
+
+	// Message counts: prefer signals.json, fall back to counting the transcript.
+	if signals, ok := readGrokSignals(filepath.Join(sessionDir, "signals.json")); ok {
+		s.UserMessages = signals.UserMessageCount
+		s.AssistantMessages = signals.AssistantMessageCount
+	} else {
+		s.UserMessages = chat.userCount
+		s.AssistantMessages = chat.assistantCount
+	}
+	if s.TotalMessages == 0 {
+		s.TotalMessages = s.UserMessages + s.AssistantMessages
+	}
+
+	// Title: generated_title → session_summary → first user message.
+	s.Name = firstNonEmpty(summary.GeneratedTitle, summary.SessionSummary, chat.firstUserText)
+
+	// Activity sparkline timestamps from the bounded tail of updates.jsonl.
+	s.EntryTimestamps = readGrokUpdatesTail(filepath.Join(sessionDir, "updates.jsonl"))
+
+	return s, nil
+}
+
+// decodeGrokDirName reverses Grok's cwd encoding (standard URL percent-encoding;
+// in practice only "/" is escaped as %2F).
+func decodeGrokDirName(name string) string {
+	if decoded, err := url.PathUnescape(name); err == nil {
+		return decoded
+	}
+	return name
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func parseGrokTime(s string) time.Time {
+	t, _ := time.Parse(time.RFC3339Nano, s)
+	return t
+}
+
+func readGrokSummary(path string) (*grokSummary, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var sum grokSummary
+	if err := json.Unmarshal(data, &sum); err != nil {
+		return nil, fmt.Errorf("grok: parse summary.json: %w", err)
+	}
+	return &sum, nil
+}
+
+// readGrokSignals returns (signals, true) when signals.json exists and parses.
+func readGrokSignals(path string) (grokSignals, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return grokSignals{}, false
+	}
+	var sig grokSignals
+	if err := json.Unmarshal(data, &sig); err != nil {
+		return grokSignals{}, false
+	}
+	return sig, true
+}
+
+// grokChatResult is what parseGrokChatHistory extracts from chat_history.jsonl.
+type grokChatResult struct {
+	recentMessages []model.ConversationMessage
+	recentTools    []model.ToolCall
+	lastEntry      *grokChatEntry
+	userCount      int
+	assistantCount int
+	firstUserText  string
+}
+
+// parseGrokChatHistory scans chat_history.jsonl. A missing or unreadable file
+// yields a zero-value result — the session is still valid from summary.json.
+func parseGrokChatHistory(path string) grokChatResult {
+	var res grokChatResult
+	f, err := os.Open(path)
+	if err != nil {
+		return res
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	for scanner.Scan() {
+		var e grokChatEntry
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue
+		}
+		switch e.Type {
+		case "user":
+			res.userCount++
+			res.lastEntry = copyGrokEntry(&e)
+			text := grokEntryText(e.Content)
+			if res.firstUserText == "" && text != "" {
+				res.firstUserText = model.Truncate(text, 300)
+			}
+			if text != "" {
+				res.recentMessages = append(res.recentMessages, model.ConversationMessage{
+					Role: "user", Text: model.Truncate(text, 300),
+				})
+			}
+		case "assistant":
+			res.assistantCount++
+			res.lastEntry = copyGrokEntry(&e)
+			for _, tc := range e.ToolCalls {
+				res.recentTools = append(res.recentTools, model.ToolCall{
+					Name: normalizeGrokToolName(tc.Name),
+				})
+			}
+			if text := grokEntryText(e.Content); text != "" {
+				res.recentMessages = append(res.recentMessages, model.ConversationMessage{
+					Role: "assistant", Text: model.Truncate(text, 300),
+				})
+			}
+		case "tool_result":
+			res.lastEntry = copyGrokEntry(&e)
+		}
+	}
+
+	if len(res.recentMessages) > maxRecentMessages {
+		res.recentMessages = res.recentMessages[len(res.recentMessages)-maxRecentMessages:]
+	}
+	if len(res.recentTools) > maxRecentTools {
+		res.recentTools = res.recentTools[len(res.recentTools)-maxRecentTools:]
+	}
+	return res
+}
+
+func copyGrokEntry(e *grokChatEntry) *grokChatEntry {
+	cp := *e
+	return &cp
+}
+
+// grokEntryText extracts the first human-readable text from a chat entry's
+// content: a plain string for system/assistant/tool_result entries, an array
+// of {type,text} blocks for user entries.
+func grokEntryText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	switch raw[0] {
+	case '"':
+		var s string
+		_ = json.Unmarshal(raw, &s)
+		return s
+	case '[':
+		var blocks []grokContentBlock
+		if json.Unmarshal(raw, &blocks) != nil {
+			return ""
+		}
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				return b.Text
+			}
+		}
+		for _, b := range blocks {
+			if b.Text != "" {
+				return b.Text
+			}
+		}
+	}
+	return ""
+}
+
+// normalizeGrokToolName upper-cases the first letter so Grok tool names render
+// consistently with the other providers' activity labels.
+func normalizeGrokToolName(name string) string {
+	if name == "" {
+		return name
+	}
+	return strings.ToUpper(name[:1]) + name[1:]
+}
+
+// grokStatus infers session status from the last transcript entry.
+func grokStatus(e *grokChatEntry) (model.SessionStatus, string) {
+	if e == nil {
+		return model.StatusUnknown, ""
+	}
+	switch e.Type {
+	case "assistant":
+		if len(e.ToolCalls) > 0 {
+			return model.StatusExecutingTool, normalizeGrokToolName(e.ToolCalls[len(e.ToolCalls)-1].Name)
+		}
+		return model.StatusWaitingForUser, ""
+	case "user":
+		return model.StatusThinking, ""
+	case "tool_result":
+		return model.StatusProcessingResult, ""
+	}
+	return model.StatusUnknown, ""
+}
+
+// readGrokUpdatesTail reads the trailing maxUpdatesTailBytes of updates.jsonl
+// and returns the event timestamps it finds, for the activity sparkline.
+// updates.jsonl is the largest file in a session, so only the tail is read.
+func readGrokUpdatesTail(path string) []time.Time {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return nil
+	}
+	var start int64
+	if info.Size() > maxUpdatesTailBytes {
+		start = info.Size() - maxUpdatesTailBytes
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return nil
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	// Seeking into the middle of the file lands mid-line; discard the first
+	// (almost certainly partial) line.
+	if start > 0 && scanner.Scan() {
+		_ = scanner.Bytes()
+	}
+
+	var stamps []time.Time
+	for scanner.Scan() {
+		var u grokUpdate
+		if json.Unmarshal(scanner.Bytes(), &u) != nil || u.Timestamp <= 0 {
+			continue
+		}
+		sec := int64(u.Timestamp)
+		nsec := int64((u.Timestamp - float64(sec)) * 1e9)
+		stamps = append(stamps, time.Unix(sec, nsec))
+	}
+	if len(stamps) > maxEntryTimestamps {
+		stamps = stamps[len(stamps)-maxEntryTimestamps:]
+	}
+	return stamps
+}

--- a/internal/grok/parse_test.go
+++ b/internal/grok/parse_test.go
@@ -112,6 +112,24 @@ func TestParseGrokSession_Fields(t *testing.T) {
 	if s.Status != model.StatusWaitingForUser {
 		t.Errorf("Status = %v, want WaitingForUser (last entry is assistant with no tool_calls)", s.Status)
 	}
+	// Tools and messages must carry a non-zero timestamp — a zero time.Time
+	// renders as a duration overflow ("106751d ago") in the UI.
+	if len(s.RecentTools) == 0 {
+		t.Fatal("expected at least one tool in RecentTools")
+	}
+	for _, tc := range s.RecentTools {
+		if tc.Timestamp.IsZero() {
+			t.Errorf("tool %q has a zero Timestamp", tc.Name)
+		}
+		if !tc.Timestamp.Equal(s.LastActivity) {
+			t.Errorf("tool %q Timestamp = %v, want LastActivity %v", tc.Name, tc.Timestamp, s.LastActivity)
+		}
+	}
+	for _, msg := range s.RecentMessages {
+		if msg.Timestamp.IsZero() {
+			t.Errorf("%s message has a zero Timestamp", msg.Role)
+		}
+	}
 }
 
 func TestParseGrokSession_TitleFallback(t *testing.T) {

--- a/internal/grok/parse_test.go
+++ b/internal/grok/parse_test.go
@@ -3,6 +3,7 @@ package grok
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
@@ -42,12 +43,15 @@ const primarySummary = `{
 }`
 
 const primaryChat = `{"type":"system","content":"system prompt"}
-{"type":"user","content":[{"type":"text","text":"Hello Grok"}]}
-{"type":"assistant","content":"Working on it","tool_calls":[{"id":"call-1","name":"bash","arguments":"{}"}],"model_id":"grok-build"}
+{"type":"user","content":[{"type":"text","text":"<user_info>\nOS Version: macos\n</user_info>"}]}
+{"type":"user","content":[{"type":"text","text":"\n\n<system-reminder>\nThe following skills are available\n</system-reminder>"}]}
+{"type":"user","content":[{"type":"text","text":"<user_query>\nHello Grok\n</user_query>"}]}
+{"type":"assistant","content":"","reasoning":{"text":"Let me look into it","encrypted":"abc","id":"r1"},"tool_calls":[{"id":"call-1","name":"bash","arguments":"{}"}],"model_id":"grok-build"}
 {"type":"tool_result","content":"command output","tool_call_id":"call-1"}
+{"type":"assistant","content":"Here is the result","reasoning":{"text":"done","encrypted":"def","id":"r2"},"model_id":"grok-build"}
 `
 
-const primarySignals = `{"userMessageCount":1,"assistantMessageCount":1,"contextTokensUsed":1234}`
+const primarySignals = `{"userMessageCount":1,"assistantMessageCount":2,"contextTokensUsed":1234}`
 
 func TestParseGrokSession_Fields(t *testing.T) {
 	root := t.TempDir()
@@ -85,8 +89,8 @@ func TestParseGrokSession_Fields(t *testing.T) {
 	if s.TotalMessages != 4 {
 		t.Errorf("TotalMessages = %d, want 4", s.TotalMessages)
 	}
-	if s.UserMessages != 1 || s.AssistantMessages != 1 {
-		t.Errorf("counts = (%d,%d), want (1,1)", s.UserMessages, s.AssistantMessages)
+	if s.UserMessages != 1 || s.AssistantMessages != 2 {
+		t.Errorf("counts = (%d,%d), want (1,2)", s.UserMessages, s.AssistantMessages)
 	}
 	if s.LastActivity.IsZero() {
 		t.Error("LastActivity is zero")
@@ -99,8 +103,8 @@ func TestParseGrokSession_Fields(t *testing.T) {
 		s.CacheCreationTokens != 0 || s.CostUSD != 0 {
 		t.Error("token/cost fields must stay zero for Grok")
 	}
-	if s.Status != model.StatusProcessingResult {
-		t.Errorf("Status = %v, want ProcessingResult (last entry is tool_result)", s.Status)
+	if s.Status != model.StatusWaitingForUser {
+		t.Errorf("Status = %v, want WaitingForUser (last entry is assistant with no tool_calls)", s.Status)
 	}
 }
 
@@ -109,7 +113,7 @@ func TestParseGrokSession_TitleFallback(t *testing.T) {
 	// No generated_title, no session_summary → fall back to first user message.
 	summary := `{"info":{"id":"x","cwd":"/tmp/p"},"chat_format_version":1,
 		"updated_at":"2026-05-17T11:00:00Z"}`
-	chat := `{"type":"user","content":[{"type":"text","text":"Please refactor auth"}]}` + "\n"
+	chat := `{"type":"user","content":[{"type":"text","text":"<user_query>Please refactor auth</user_query>"}]}` + "\n"
 	dir := writeSession(t, root, "%2Ftmp%2Fp", "x", map[string]string{
 		"summary.json": summary, "chat_history.jsonl": chat,
 	})
@@ -133,8 +137,8 @@ func TestParseGrokSession_CountsFromTranscriptWhenNoSignals(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s.UserMessages != 1 || s.AssistantMessages != 1 {
-		t.Errorf("counts from transcript = (%d,%d), want (1,1)", s.UserMessages, s.AssistantMessages)
+	if s.UserMessages != 1 || s.AssistantMessages != 2 {
+		t.Errorf("counts from transcript = (%d,%d), want (1,2)", s.UserMessages, s.AssistantMessages)
 	}
 }
 
@@ -182,7 +186,7 @@ func TestParseGrokSession_StatusExecutingTool(t *testing.T) {
 		"updated_at":"2026-05-17T11:00:00Z"}`
 	// Chat ends on an assistant entry with a pending tool call.
 	chat := `{"type":"user","content":[{"type":"text","text":"run the tests"}]}
-{"type":"assistant","content":"running","tool_calls":[{"id":"call-9","name":"bash","arguments":"{}"}]}
+{"type":"assistant","content":"running","reasoning":{"text":"running tests","encrypted":"x","id":"r1"},"tool_calls":[{"id":"call-9","name":"bash","arguments":"{}"}]}
 `
 	dir := writeSession(t, root, "%2Ftmp%2Fp", "t", map[string]string{
 		"summary.json": summary, "chat_history.jsonl": chat,
@@ -226,5 +230,62 @@ func TestDecodeGrokDirName(t *testing.T) {
 		if got := decodeGrokDirName(tt.in); got != tt.want {
 			t.Errorf("decodeGrokDirName(%q) = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestParseGrokSession_FiltersSyntheticUserEntries(t *testing.T) {
+	// primaryChat has 3 user entries: <user_info>, <system-reminder>, and the
+	// real <user_query>. Only the last is a message.
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "f", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userMsgs := 0
+	for _, m := range s.RecentMessages {
+		if strings.Contains(m.Text, "<system-reminder>") || strings.Contains(m.Text, "<user_info>") {
+			t.Errorf("synthetic entry leaked into RecentMessages: %q", m.Text)
+		}
+		if m.Role == "user" {
+			userMsgs++
+			if strings.Contains(m.Text, "<user_query>") {
+				t.Errorf("user message not unwrapped: %q", m.Text)
+			}
+			if m.Text != "Hello Grok" {
+				t.Errorf("user message = %q, want %q", m.Text, "Hello Grok")
+			}
+		}
+	}
+	if userMsgs != 1 {
+		t.Errorf("got %d user messages in RecentMessages, want 1", userMsgs)
+	}
+}
+
+func TestParseGrokSession_AssistantEntriesParsed(t *testing.T) {
+	// Regression: Grok assistant entries carry `reasoning` as an OBJECT. A
+	// mistyped struct field made json.Unmarshal fail and silently drop every
+	// assistant entry.
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "a", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	asstMsgs := 0
+	for _, m := range s.RecentMessages {
+		if m.Role == "assistant" {
+			asstMsgs++
+		}
+	}
+	if asstMsgs == 0 {
+		t.Fatal("no assistant messages in RecentMessages — assistant entries were dropped")
+	}
+	if len(s.RecentTools) == 0 {
+		t.Error("no tools captured — assistant tool_calls were dropped")
 	}
 }

--- a/internal/grok/parse_test.go
+++ b/internal/grok/parse_test.go
@@ -1,6 +1,7 @@
 package grok
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -282,10 +283,42 @@ func TestParseGrokSession_AssistantEntriesParsed(t *testing.T) {
 			asstMsgs++
 		}
 	}
-	if asstMsgs == 0 {
-		t.Fatal("no assistant messages in RecentMessages — assistant entries were dropped")
+	// primaryChat has 2 assistant entries: a tool-call turn (empty content,
+	// no message row) and a final answer (content → one message row).
+	if asstMsgs != 1 {
+		t.Errorf("assistant messages in RecentMessages = %d, want 1", asstMsgs)
+	}
+	if s.AssistantMessages != 2 {
+		t.Errorf("AssistantMessages = %d, want 2 (both entries counted)", s.AssistantMessages)
 	}
 	if len(s.RecentTools) == 0 {
 		t.Error("no tools captured — assistant tool_calls were dropped")
+	}
+}
+
+func TestUserMessageText(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string // raw JSON for the entry's content field
+		want    string
+		wantOK  bool
+	}{
+		{"user_query at start", `[{"type":"text","text":"<user_query>hi there</user_query>"}]`, "hi there", true},
+		{"user_query mid-string", `[{"type":"text","text":"prefix <user_query>real</user_query>"}]`, "real", true},
+		{"user_query unterminated", `[{"type":"text","text":"<user_query>tail only"}]`, "tail only", true},
+		{"system-reminder", `[{"type":"text","text":"<system-reminder>ctx</system-reminder>"}]`, "", false},
+		{"system-reminder leading whitespace", `[{"type":"text","text":"\n\n<system-reminder>ctx</system-reminder>"}]`, "", false},
+		{"user_info", `[{"type":"text","text":"<user_info>os</user_info>"}]`, "", false},
+		{"plain text", `[{"type":"text","text":"just a message"}]`, "just a message", true},
+		{"empty", `[{"type":"text","text":""}]`, "", false},
+		{"plain string content", `"plain string"`, "plain string", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := UserMessageText(json.RawMessage(tt.content))
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("UserMessageText(%s) = (%q,%v), want (%q,%v)", tt.content, got, ok, tt.want, tt.wantOK)
+			}
+		})
 	}
 }

--- a/internal/grok/parse_test.go
+++ b/internal/grok/parse_test.go
@@ -112,23 +112,55 @@ func TestParseGrokSession_Fields(t *testing.T) {
 	if s.Status != model.StatusWaitingForUser {
 		t.Errorf("Status = %v, want WaitingForUser (last entry is assistant with no tool_calls)", s.Status)
 	}
-	// Tools and messages must carry a non-zero timestamp — a zero time.Time
-	// renders as a duration overflow ("106751d ago") in the UI.
-	if len(s.RecentTools) == 0 {
-		t.Fatal("expected at least one tool in RecentTools")
+	// Only the most recent tool/message is stamped (chat_history has no
+	// per-item time); earlier entries keep a zero Timestamp.
+	if n := len(s.RecentTools); n > 0 {
+		if !s.RecentTools[n-1].Timestamp.Equal(s.LastActivity) {
+			t.Errorf("last tool Timestamp = %v, want LastActivity %v", s.RecentTools[n-1].Timestamp, s.LastActivity)
+		}
+		for _, tc := range s.RecentTools[:n-1] {
+			if !tc.Timestamp.IsZero() {
+				t.Errorf("non-last tool %q has Timestamp %v, want zero", tc.Name, tc.Timestamp)
+			}
+		}
 	}
-	for _, tc := range s.RecentTools {
-		if tc.Timestamp.IsZero() {
-			t.Errorf("tool %q has a zero Timestamp", tc.Name)
+	if n := len(s.RecentMessages); n > 0 {
+		if !s.RecentMessages[n-1].Timestamp.Equal(s.LastActivity) {
+			t.Errorf("last message Timestamp = %v, want LastActivity %v", s.RecentMessages[n-1].Timestamp, s.LastActivity)
 		}
-		if !tc.Timestamp.Equal(s.LastActivity) {
-			t.Errorf("tool %q Timestamp = %v, want LastActivity %v", tc.Name, tc.Timestamp, s.LastActivity)
+		for _, msg := range s.RecentMessages[:n-1] {
+			if !msg.Timestamp.IsZero() {
+				t.Errorf("non-last %s message has Timestamp %v, want zero", msg.Role, msg.Timestamp)
+			}
 		}
 	}
-	for _, msg := range s.RecentMessages {
-		if msg.Timestamp.IsZero() {
-			t.Errorf("%s message has a zero Timestamp", msg.Role)
-		}
+}
+
+func TestParseGrokSession_OnlyLastToolHasTimestamp(t *testing.T) {
+	root := t.TempDir()
+	summary := `{"info":{"id":"m","cwd":"/tmp/p"},"chat_format_version":1,"updated_at":"2026-05-17T11:00:00Z"}`
+	chat := `{"type":"user","content":[{"type":"text","text":"<user_query>go</user_query>"}]}
+{"type":"assistant","content":"","reasoning":{"text":"a","encrypted":"x","id":"r1"},"tool_calls":[{"id":"c1","name":"read","arguments":"{}"}]}
+{"type":"tool_result","content":"r1","tool_call_id":"c1"}
+{"type":"assistant","content":"","reasoning":{"text":"b","encrypted":"y","id":"r2"},"tool_calls":[{"id":"c2","name":"bash","arguments":"{}"}]}
+{"type":"tool_result","content":"r2","tool_call_id":"c2"}
+{"type":"assistant","content":"done","reasoning":{"text":"c","encrypted":"z","id":"r3"}}
+`
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "m", map[string]string{
+		"summary.json": summary, "chat_history.jsonl": chat,
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s.RecentTools) != 2 {
+		t.Fatalf("RecentTools = %d, want 2", len(s.RecentTools))
+	}
+	if !s.RecentTools[0].Timestamp.IsZero() {
+		t.Errorf("earlier tool must keep a zero Timestamp, got %v", s.RecentTools[0].Timestamp)
+	}
+	if s.RecentTools[1].Timestamp.IsZero() {
+		t.Error("the most recent tool must be stamped")
 	}
 }
 

--- a/internal/grok/parse_test.go
+++ b/internal/grok/parse_test.go
@@ -176,6 +176,46 @@ func TestParseGrokSession_MissingSummary(t *testing.T) {
 	}
 }
 
+func TestParseGrokSession_StatusExecutingTool(t *testing.T) {
+	root := t.TempDir()
+	summary := `{"info":{"id":"t","cwd":"/tmp/p"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z"}`
+	// Chat ends on an assistant entry with a pending tool call.
+	chat := `{"type":"user","content":[{"type":"text","text":"run the tests"}]}
+{"type":"assistant","content":"running","tool_calls":[{"id":"call-9","name":"bash","arguments":"{}"}]}
+`
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "t", map[string]string{
+		"summary.json": summary, "chat_history.jsonl": chat,
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Status != model.StatusExecutingTool {
+		t.Errorf("Status = %v, want ExecutingTool", s.Status)
+	}
+	if s.CurrentTool != "Bash" {
+		t.Errorf("CurrentTool = %q, want Bash", s.CurrentTool)
+	}
+}
+
+func TestParseGrokSession_StatusThinking(t *testing.T) {
+	root := t.TempDir()
+	summary := `{"info":{"id":"u","cwd":"/tmp/p"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z"}`
+	chat := `{"type":"user","content":[{"type":"text","text":"hello"}]}` + "\n"
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "u", map[string]string{
+		"summary.json": summary, "chat_history.jsonl": chat,
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Status != model.StatusThinking {
+		t.Errorf("Status = %v, want Thinking", s.Status)
+	}
+}
+
 func TestDecodeGrokDirName(t *testing.T) {
 	tests := []struct{ in, want string }{
 		{"%2FUsers%2Falice%2Fproject", "/Users/alice/project"},

--- a/internal/grok/parse_test.go
+++ b/internal/grok/parse_test.go
@@ -96,6 +96,11 @@ func TestParseGrokSession_Fields(t *testing.T) {
 	if s.LastActivity.IsZero() {
 		t.Error("LastActivity is zero")
 	}
+	// LastSummaryAt must stay zero: Grok has no compaction-summary marker, and
+	// a non-zero value would falsely render the session as "compacting".
+	if !s.LastSummaryAt.IsZero() {
+		t.Errorf("LastSummaryAt = %v, want zero (Grok has no compaction marker)", s.LastSummaryAt)
+	}
 	if s.IsSidechain {
 		t.Error("primary session must not be a sidechain")
 	}

--- a/internal/grok/parse_test.go
+++ b/internal/grok/parse_test.go
@@ -1,0 +1,190 @@
+package grok
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// writeSession creates a session directory at root/encodedCWD/uuid and writes
+// the given files (relative paths → contents) into it. Returns the session dir.
+func writeSession(t *testing.T, root, encodedCWD, uuid string, files map[string]string) string {
+	t.Helper()
+	dir := filepath.Join(root, encodedCWD, uuid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+const primarySummary = `{
+  "info": {"id": "019e0000-0000-7000-8000-000000000001", "cwd": "/Users/alice/project"},
+  "session_summary": "fix the parser",
+  "generated_title": "Fix the JSON parser bug",
+  "created_at": "2026-05-17T10:33:00.260953Z",
+  "updated_at": "2026-05-17T11:33:49.449038Z",
+  "last_active_at": "2026-05-17T11:33:49.449038Z",
+  "num_chat_messages": 4,
+  "current_model_id": "grok-build",
+  "head_branch": "feature/parser",
+  "chat_format_version": 1
+}`
+
+const primaryChat = `{"type":"system","content":"system prompt"}
+{"type":"user","content":[{"type":"text","text":"Hello Grok"}]}
+{"type":"assistant","content":"Working on it","tool_calls":[{"id":"call-1","name":"bash","arguments":"{}"}],"model_id":"grok-build"}
+{"type":"tool_result","content":"command output","tool_call_id":"call-1"}
+`
+
+const primarySignals = `{"userMessageCount":1,"assistantMessageCount":1,"contextTokensUsed":1234}`
+
+func TestParseGrokSession_Fields(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2FUsers%2Falice%2Fproject", "019e0000-0000-7000-8000-000000000001", map[string]string{
+		"summary.json":       primarySummary,
+		"chat_history.jsonl": primaryChat,
+		"signals.json":       primarySignals,
+	})
+
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatalf("ParseGrokSession: %v", err)
+	}
+	if s.Agent != "grok" {
+		t.Errorf("Agent = %q, want grok", s.Agent)
+	}
+	if s.SessionID != "019e0000-0000-7000-8000-000000000001" {
+		t.Errorf("SessionID = %q", s.SessionID)
+	}
+	if s.JSONLPath != dir {
+		t.Errorf("JSONLPath = %q, want %q", s.JSONLPath, dir)
+	}
+	if s.CWD != "/Users/alice/project" {
+		t.Errorf("CWD = %q", s.CWD)
+	}
+	if s.Name != "Fix the JSON parser bug" {
+		t.Errorf("Name = %q, want generated_title", s.Name)
+	}
+	if s.Model != "grok-build" {
+		t.Errorf("Model = %q", s.Model)
+	}
+	if s.GitBranch != "feature/parser" {
+		t.Errorf("GitBranch = %q", s.GitBranch)
+	}
+	if s.TotalMessages != 4 {
+		t.Errorf("TotalMessages = %d, want 4", s.TotalMessages)
+	}
+	if s.UserMessages != 1 || s.AssistantMessages != 1 {
+		t.Errorf("counts = (%d,%d), want (1,1)", s.UserMessages, s.AssistantMessages)
+	}
+	if s.LastActivity.IsZero() {
+		t.Error("LastActivity is zero")
+	}
+	if s.IsSidechain {
+		t.Error("primary session must not be a sidechain")
+	}
+	// Token/cost fields stay zero — Grok exposes no input/output/cache split.
+	if s.InputTokens != 0 || s.OutputTokens != 0 || s.CacheReadTokens != 0 ||
+		s.CacheCreationTokens != 0 || s.CostUSD != 0 {
+		t.Error("token/cost fields must stay zero for Grok")
+	}
+	if s.Status != model.StatusProcessingResult {
+		t.Errorf("Status = %v, want ProcessingResult (last entry is tool_result)", s.Status)
+	}
+}
+
+func TestParseGrokSession_TitleFallback(t *testing.T) {
+	root := t.TempDir()
+	// No generated_title, no session_summary → fall back to first user message.
+	summary := `{"info":{"id":"x","cwd":"/tmp/p"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z"}`
+	chat := `{"type":"user","content":[{"type":"text","text":"Please refactor auth"}]}` + "\n"
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "x", map[string]string{
+		"summary.json": summary, "chat_history.jsonl": chat,
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Name != "Please refactor auth" {
+		t.Errorf("Name = %q, want first user message", s.Name)
+	}
+}
+
+func TestParseGrokSession_CountsFromTranscriptWhenNoSignals(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "y", map[string]string{
+		"summary.json":       primarySummary,
+		"chat_history.jsonl": primaryChat,
+		// signals.json deliberately absent
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.UserMessages != 1 || s.AssistantMessages != 1 {
+		t.Errorf("counts from transcript = (%d,%d), want (1,1)", s.UserMessages, s.AssistantMessages)
+	}
+}
+
+func TestParseGrokSession_Subagent(t *testing.T) {
+	root := t.TempDir()
+	summary := `{"info":{"id":"sub","cwd":"/tmp/wt"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z","session_kind":"subagent"}`
+	dir := writeSession(t, root, "%2Ftmp%2Fwt", "sub", map[string]string{
+		"summary.json": summary, "chat_history.jsonl": "",
+	})
+	s, err := ParseGrokSession(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.IsSidechain {
+		t.Error("subagent session must have IsSidechain = true")
+	}
+}
+
+func TestParseGrokSession_UnsupportedFormatVersion(t *testing.T) {
+	root := t.TempDir()
+	summary := `{"info":{"id":"z","cwd":"/tmp/p"},"chat_format_version":999,
+		"updated_at":"2026-05-17T11:00:00Z"}`
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "z", map[string]string{
+		"summary.json": summary,
+	})
+	if _, err := ParseGrokSession(dir); err == nil {
+		t.Error("expected error for unsupported chat_format_version")
+	}
+}
+
+func TestParseGrokSession_MissingSummary(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "w", map[string]string{
+		"chat_history.jsonl": primaryChat,
+	})
+	if _, err := ParseGrokSession(dir); err == nil {
+		t.Error("expected error when summary.json is missing")
+	}
+}
+
+func TestDecodeGrokDirName(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"%2FUsers%2Falice%2Fproject", "/Users/alice/project"},
+		{"%2Ftmp", "/tmp"},
+		{"plain", "plain"},
+	}
+	for _, tt := range tests {
+		if got := decodeGrokDirName(tt.in); got != tt.want {
+			t.Errorf("decodeGrokDirName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/grok/process.go
+++ b/internal/grok/process.go
@@ -138,6 +138,11 @@ func discoverSessionsFromDir(sessionsDir string, cache *model.SessionCache) ([]*
 		// change — including the offset>0 "file grew" case — triggers a full
 		// re-parse, because Grok parsing reads summary.json + the whole
 		// chat_history.jsonl rather than appending incrementally.
+		// Trade-off: the cache key is chat_history.jsonl only, so a change
+		// to summary.json or updates.jsonl alone (e.g. an asynchronously-
+		// generated title) is not detected until the next chat_history.jsonl
+		// write or a full --reindex. chat_history.jsonl is chosen because it
+		// is always present and grows on every turn.
 		if cached != nil && offset == 0 {
 			sessions = append(sessions, cached)
 			continue

--- a/internal/grok/process.go
+++ b/internal/grok/process.go
@@ -1,0 +1,199 @@
+// Package grok discovers xAI Grok CLI sessions from ~/.grok/sessions.
+//
+// Grok stores one directory per session, exactly two levels deep:
+//
+//	~/.grok/sessions/<url-encoded-cwd>/<session-uuid>/
+//
+// Each session directory carries a summary.json (metadata) and a
+// chat_history.jsonl (transcript). This package walks that tree, parses each
+// session into a model.Session, and integrates with model.SessionCache so
+// unchanged sessions are not re-parsed.
+package grok
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/claude"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// GrokSessionsDir returns the path to ~/.grok/sessions.
+func GrokSessionsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".grok", "sessions")
+}
+
+// DiscoverSessions scans ~/.grok/sessions for Grok session directories.
+func DiscoverSessions(cache *model.SessionCache) ([]*model.Session, error) {
+	return discoverSessionsFromDir(GrokSessionsDir(), cache)
+}
+
+// SessionDirs returns every Grok session directory on disk. Used by the
+// search indexer and maintenance commands that need the raw directory list.
+func SessionDirs() []string {
+	return walkSessionDirs(GrokSessionsDir())
+}
+
+// SessionDiskBytes returns the total size in bytes of every file inside a
+// Grok session directory. Best-effort: unreadable entries contribute zero.
+func SessionDiskBytes(dir string) int64 {
+	var total int64
+	_ = filepath.WalkDir(dir, func(_ string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if info, err := d.Info(); err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+type wtInfo struct {
+	isWorktree bool
+	mainRepo   string
+}
+
+type parseJob struct {
+	sessionDir string
+	cacheKey   string // chat_history.jsonl path — the cache invalidation key
+	mtime      time.Time
+}
+
+type parseResult struct {
+	session  *model.Session
+	cacheKey string
+	mtime    time.Time
+}
+
+// walkSessionDirs returns every session directory under sessionsDir: every
+// depth-2 directory that contains a summary.json. Files at the root
+// (session_search.sqlite) and at cwd level (prompt_history.jsonl) are skipped
+// because only directories are descended into.
+func walkSessionDirs(sessionsDir string) []string {
+	if sessionsDir == "" {
+		return nil
+	}
+	cwdEntries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for _, cwdEntry := range cwdEntries {
+		if !cwdEntry.IsDir() {
+			continue
+		}
+		cwdPath := filepath.Join(sessionsDir, cwdEntry.Name())
+		sessEntries, err := os.ReadDir(cwdPath)
+		if err != nil {
+			continue
+		}
+		for _, sessEntry := range sessEntries {
+			if !sessEntry.IsDir() {
+				continue
+			}
+			sessionDir := filepath.Join(cwdPath, sessEntry.Name())
+			if _, err := os.Stat(filepath.Join(sessionDir, "summary.json")); err != nil {
+				continue // not a session directory
+			}
+			dirs = append(dirs, sessionDir)
+		}
+	}
+	return dirs
+}
+
+// discoverSessionsFromDir scans a Grok sessions root and returns parsed
+// sessions. A missing root is not an error (Grok not installed → nil, nil).
+func discoverSessionsFromDir(sessionsDir string, cache *model.SessionCache) ([]*model.Session, error) {
+	if sessionsDir == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(sessionsDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // Grok not installed — not an error.
+		}
+		return nil, fmt.Errorf("could not read grok sessions dir: %w", err)
+	}
+
+	wtCache := make(map[string]wtInfo)
+	seen := make(map[string]struct{})
+	var sessions []*model.Session
+	var jobs []parseJob
+
+	// Phase 1: classify each session as cache-hit or needs-parse.
+	for _, sessionDir := range walkSessionDirs(sessionsDir) {
+		cacheKey := filepath.Join(sessionDir, "chat_history.jsonl")
+		seen[cacheKey] = struct{}{}
+		cached, offset, mtime := cache.GetIncremental(cacheKey)
+		// A full cache hit (file unchanged) reuses the parsed session. Any
+		// change — including the offset>0 "file grew" case — triggers a full
+		// re-parse, because Grok parsing reads summary.json + the whole
+		// chat_history.jsonl rather than appending incrementally.
+		if cached != nil && offset == 0 {
+			sessions = append(sessions, cached)
+			continue
+		}
+		jobs = append(jobs, parseJob{sessionDir: sessionDir, cacheKey: cacheKey, mtime: mtime})
+	}
+
+	if len(jobs) > 0 {
+		// Phase 2: parse sessions in parallel.
+		workers := runtime.GOMAXPROCS(0)
+		if workers > len(jobs) {
+			workers = len(jobs)
+		}
+		results := make([]parseResult, len(jobs))
+		var wg sync.WaitGroup
+		jobCh := make(chan int, len(jobs))
+		for i := range jobs {
+			jobCh <- i
+		}
+		close(jobCh)
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for idx := range jobCh {
+					j := &jobs[idx]
+					session, err := ParseGrokSession(j.sessionDir)
+					if err != nil {
+						continue // skip malformed / unsupported session
+					}
+					results[idx] = parseResult{session: session, cacheKey: j.cacheKey, mtime: j.mtime}
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Phase 3: enrich worktree info and update the cache (sequential).
+		for _, r := range results {
+			if r.session == nil {
+				continue
+			}
+			if r.session.CWD != "" {
+				if _, ok := wtCache[r.session.CWD]; !ok {
+					isWT, mainRepo := claude.IsWorktree(r.session.CWD)
+					wtCache[r.session.CWD] = wtInfo{isWorktree: isWT, mainRepo: mainRepo}
+				}
+				wt := wtCache[r.session.CWD]
+				r.session.IsWorktree = wt.isWorktree
+				r.session.MainRepo = wt.mainRepo
+			}
+			// size 0 forces a full re-parse on any future mtime change.
+			cache.Put(r.cacheKey, r.mtime, 0, r.session)
+			sessions = append(sessions, r.session)
+		}
+	}
+
+	cache.Prune(seen)
+	return sessions, nil
+}

--- a/internal/grok/process.go
+++ b/internal/grok/process.go
@@ -200,5 +200,20 @@ func discoverSessionsFromDir(sessionsDir string, cache *model.SessionCache) ([]*
 	}
 
 	cache.Prune(seen)
-	return sessions, nil
+
+	// Hide sessions the user has not interacted with yet. Grok creates a
+	// session directory (summary.json, system_prompt.txt, ...) the moment
+	// `grok` is launched — before any message is sent. A session only becomes
+	// a real conversation once the user writes the first message, i.e. once a
+	// <user_query> entry exists in chat_history.jsonl (UserMessages > 0).
+	// Empty sessions stay in the cache (keyed on chat_history.jsonl), so once
+	// the first message lands the file grows, the cache misses, and the
+	// session is re-parsed and surfaces.
+	active := sessions[:0]
+	for _, s := range sessions {
+		if s.UserMessages > 0 {
+			active = append(active, s)
+		}
+	}
+	return active, nil
 }

--- a/internal/grok/process.go
+++ b/internal/grok/process.go
@@ -200,20 +200,10 @@ func discoverSessionsFromDir(sessionsDir string, cache *model.SessionCache) ([]*
 	}
 
 	cache.Prune(seen)
-
-	// Hide sessions the user has not interacted with yet. Grok creates a
-	// session directory (summary.json, system_prompt.txt, ...) the moment
-	// `grok` is launched — before any message is sent. A session only becomes
-	// a real conversation once the user writes the first message, i.e. once a
-	// <user_query> entry exists in chat_history.jsonl (UserMessages > 0).
-	// Empty sessions stay in the cache (keyed on chat_history.jsonl), so once
-	// the first message lands the file grows, the cache misses, and the
-	// session is re-parsed and surfaces.
-	active := sessions[:0]
-	for _, s := range sessions {
-		if s.UserMessages > 0 {
-			active = append(active, s)
-		}
-	}
-	return active, nil
+	// Discovery returns every session, including ones with no user message
+	// yet (a Grok session directory is created the moment `grok` is launched).
+	// Keeping them here lets `prune` reach and delete very old never-used
+	// sessions; hiding them from the TUI/GUI/API list is done at the rendering
+	// layer (core.filterSessionsLocked).
+	return sessions, nil
 }

--- a/internal/grok/process.go
+++ b/internal/grok/process.go
@@ -141,8 +141,8 @@ func discoverSessionsFromDir(sessionsDir string, cache *model.SessionCache) ([]*
 		// Trade-off: the cache key is chat_history.jsonl only, so a change
 		// to summary.json or updates.jsonl alone (e.g. an asynchronously-
 		// generated title) is not detected until the next chat_history.jsonl
-		// write or a full --reindex. chat_history.jsonl is chosen because it
-		// is always present and grows on every turn.
+		// write or the next full re-discovery. chat_history.jsonl is chosen
+		// because it is always present and grows on every turn.
 		if cached != nil && offset == 0 {
 			sessions = append(sessions, cached)
 			continue

--- a/internal/grok/process_test.go
+++ b/internal/grok/process_test.go
@@ -1,0 +1,142 @@
+package grok
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestGrokSessionsDir(t *testing.T) {
+	dir := GrokSessionsDir()
+	if dir == "" {
+		t.Fatal("GrokSessionsDir() returned empty string")
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".grok", "sessions")
+	if dir != want {
+		t.Errorf("GrokSessionsDir() = %q, want %q", dir, want)
+	}
+}
+
+func TestDiscoverSessions_MissingDir(t *testing.T) {
+	sessions, err := discoverSessionsFromDir("/nonexistent/grok/sessions", model.NewSessionCache())
+	if err != nil {
+		t.Fatalf("missing dir must not error: %v", err)
+	}
+	if sessions != nil {
+		t.Errorf("got %v, want nil", sessions)
+	}
+}
+
+func TestDiscoverSessions_PrimaryAndSubagent(t *testing.T) {
+	root := t.TempDir()
+	writeSession(t, root, "%2FUsers%2Falice%2Fproject", "019e0000-0000-7000-8000-000000000001", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat, "signals.json": primarySignals,
+	})
+	subSummary := `{"info":{"id":"sub","cwd":"/tmp/wt"},"chat_format_version":1,
+		"updated_at":"2026-05-17T11:00:00Z","session_kind":"subagent"}`
+	writeSession(t, root, "%2Ftmp%2Fwt", "sub", map[string]string{
+		"summary.json": subSummary, "chat_history.jsonl": "",
+	})
+
+	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+	var primary, sub *model.Session
+	for _, s := range sessions {
+		if s.IsSidechain {
+			sub = s
+		} else {
+			primary = s
+		}
+	}
+	if primary == nil || sub == nil {
+		t.Fatal("expected one primary and one subagent session")
+	}
+	if primary.Agent != "grok" {
+		t.Errorf("Agent = %q", primary.Agent)
+	}
+}
+
+func TestDiscoverSessions_SkipsNonSessionEntries(t *testing.T) {
+	root := t.TempDir()
+	cwdDir := filepath.Join(root, "%2Ftmp%2Fp")
+	if err := os.MkdirAll(cwdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A cwd-level file and a root-level file must both be ignored.
+	if err := os.WriteFile(filepath.Join(cwdDir, "prompt_history.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "session_search.sqlite"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeSession(t, root, "%2Ftmp%2Fp", "real", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+
+	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1 (sqlite + prompt_history must be skipped)", len(sessions))
+	}
+}
+
+func TestDiscoverSessions_MalformedSummarySkipped(t *testing.T) {
+	root := t.TempDir()
+	writeSession(t, root, "%2Ftmp%2Fp", "bad", map[string]string{
+		"summary.json": "{not json", "chat_history.jsonl": "",
+	})
+	writeSession(t, root, "%2Ftmp%2Fp", "good", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
+	if err != nil {
+		t.Fatalf("one bad session must not abort the scan: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+}
+
+func TestDiscoverSessions_CacheHit(t *testing.T) {
+	root := t.TempDir()
+	writeSession(t, root, "%2Ftmp%2Fp", "c", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+	})
+	cache := model.NewSessionCache()
+	first, err := discoverSessionsFromDir(root, cache)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first discover: %v, n=%d", err, len(first))
+	}
+	second, err := discoverSessionsFromDir(root, cache)
+	if err != nil || len(second) != 1 {
+		t.Fatalf("second discover: %v, n=%d", err, len(second))
+	}
+	if first[0] != second[0] {
+		t.Error("unchanged session should be served from cache (same pointer)")
+	}
+}
+
+func TestSessionDirsAndDiskBytes(t *testing.T) {
+	root := t.TempDir()
+	dir := writeSession(t, root, "%2Ftmp%2Fp", "s", map[string]string{
+		"summary.json": primarySummary, "chat_history.jsonl": primaryChat,
+		"terminal/cmd-1.log": "some output",
+	})
+	dirs := walkSessionDirs(root)
+	if len(dirs) != 1 || dirs[0] != dir {
+		t.Fatalf("walkSessionDirs = %v, want [%s]", dirs, dir)
+	}
+	if got := SessionDiskBytes(dir); got <= 0 {
+		t.Errorf("SessionDiskBytes = %d, want > 0", got)
+	}
+}

--- a/internal/grok/process_test.go
+++ b/internal/grok/process_test.go
@@ -38,7 +38,10 @@ func TestDiscoverSessions_PrimaryAndSubagent(t *testing.T) {
 	subSummary := `{"info":{"id":"sub","cwd":"/tmp/wt"},"chat_format_version":1,
 		"updated_at":"2026-05-17T11:00:00Z","session_kind":"subagent"}`
 	writeSession(t, root, "%2Ftmp%2Fwt", "sub", map[string]string{
-		"summary.json": subSummary, "chat_history.jsonl": "",
+		"summary.json": subSummary,
+		// A subagent that did work has a user/task message — without one,
+		// discovery hides it as a never-used session.
+		"chat_history.jsonl": `{"type":"user","content":[{"type":"text","text":"<user_query>do the subtask</user_query>"}]}` + "\n",
 	})
 
 	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
@@ -61,6 +64,34 @@ func TestDiscoverSessions_PrimaryAndSubagent(t *testing.T) {
 	}
 	if primary.Agent != "grok" {
 		t.Errorf("Agent = %q", primary.Agent)
+	}
+}
+
+func TestDiscoverSessions_HidesSessionsWithNoUserMessage(t *testing.T) {
+	root := t.TempDir()
+	freshSummary := `{"info":{"id":"fresh","cwd":"/tmp/p"},"chat_format_version":1,"updated_at":"2026-05-17T11:00:00Z"}`
+	activeSummary := `{"info":{"id":"active","cwd":"/tmp/p"},"chat_format_version":1,"updated_at":"2026-05-17T11:00:00Z"}`
+	// A freshly-opened session: directory exists, but only the system entry —
+	// the user has not written anything yet.
+	writeSession(t, root, "%2Ftmp%2Fp", "fresh", map[string]string{
+		"summary.json":       freshSummary,
+		"chat_history.jsonl": `{"type":"system","content":"system prompt"}` + "\n",
+	})
+	// An active session: the user has written a message.
+	writeSession(t, root, "%2Ftmp%2Fp", "active", map[string]string{
+		"summary.json":       activeSummary,
+		"chat_history.jsonl": primaryChat,
+	})
+
+	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1 (the no-message session must be hidden)", len(sessions))
+	}
+	if sessions[0].SessionID != "active" {
+		t.Errorf("surviving session = %q, want \"active\"", sessions[0].SessionID)
 	}
 }
 

--- a/internal/grok/process_test.go
+++ b/internal/grok/process_test.go
@@ -38,10 +38,7 @@ func TestDiscoverSessions_PrimaryAndSubagent(t *testing.T) {
 	subSummary := `{"info":{"id":"sub","cwd":"/tmp/wt"},"chat_format_version":1,
 		"updated_at":"2026-05-17T11:00:00Z","session_kind":"subagent"}`
 	writeSession(t, root, "%2Ftmp%2Fwt", "sub", map[string]string{
-		"summary.json": subSummary,
-		// A subagent that did work has a user/task message — without one,
-		// discovery hides it as a never-used session.
-		"chat_history.jsonl": `{"type":"user","content":[{"type":"text","text":"<user_query>do the subtask</user_query>"}]}` + "\n",
+		"summary.json": subSummary, "chat_history.jsonl": "",
 	})
 
 	sessions, err := discoverSessionsFromDir(root, model.NewSessionCache())
@@ -67,7 +64,10 @@ func TestDiscoverSessions_PrimaryAndSubagent(t *testing.T) {
 	}
 }
 
-func TestDiscoverSessions_HidesSessionsWithNoUserMessage(t *testing.T) {
+func TestDiscoverSessions_IncludesSessionsWithNoUserMessage(t *testing.T) {
+	// Discovery returns sessions even with no user message yet, so `prune` can
+	// reach and delete very old never-used sessions. Hiding them from the list
+	// is done at the rendering layer (core.filterSessionsLocked), not here.
 	root := t.TempDir()
 	freshSummary := `{"info":{"id":"fresh","cwd":"/tmp/p"},"chat_format_version":1,"updated_at":"2026-05-17T11:00:00Z"}`
 	activeSummary := `{"info":{"id":"active","cwd":"/tmp/p"},"chat_format_version":1,"updated_at":"2026-05-17T11:00:00Z"}`
@@ -87,11 +87,20 @@ func TestDiscoverSessions_HidesSessionsWithNoUserMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 {
-		t.Fatalf("got %d sessions, want 1 (the no-message session must be hidden)", len(sessions))
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2 (discovery must include the no-message session)", len(sessions))
 	}
-	if sessions[0].SessionID != "active" {
-		t.Errorf("surviving session = %q, want \"active\"", sessions[0].SessionID)
+	var fresh *model.Session
+	for _, s := range sessions {
+		if s.SessionID == "fresh" {
+			fresh = s
+		}
+	}
+	if fresh == nil {
+		t.Fatal("the never-used session must still be discovered (so prune can reach it)")
+	}
+	if fresh.UserMessages != 0 {
+		t.Errorf("fresh session UserMessages = %d, want 0", fresh.UserMessages)
 	}
 }
 

--- a/internal/grok/types.go
+++ b/internal/grok/types.go
@@ -1,0 +1,63 @@
+package grok
+
+import "encoding/json"
+
+// grokSummary mirrors the subset of summary.json this package reads.
+// Timestamps are RFC3339 UTC strings with microseconds and a trailing Z.
+type grokSummary struct {
+	Info struct {
+		ID  string `json:"id"`
+		CWD string `json:"cwd"`
+	} `json:"info"`
+	SessionSummary    string `json:"session_summary"`
+	GeneratedTitle    string `json:"generated_title"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+	LastActiveAt      string `json:"last_active_at"`
+	NumChatMessages   int    `json:"num_chat_messages"`
+	CurrentModelID    string `json:"current_model_id"`
+	GitRootDir        string `json:"git_root_dir"`
+	HeadBranch        string `json:"head_branch"`
+	ChatFormatVersion int    `json:"chat_format_version"`
+	// SessionKind is present ONLY on subagent sessions ("subagent").
+	SessionKind string `json:"session_kind"`
+}
+
+// grokChatEntry is one line of chat_history.jsonl. content is a plain string
+// for system/assistant/tool_result entries and an array of blocks for user
+// entries — kept as RawMessage so the caller picks the right decode path.
+type grokChatEntry struct {
+	Type       string          `json:"type"` // system | user | assistant | tool_result
+	Content    json.RawMessage `json:"content"`
+	Reasoning  string          `json:"reasoning"`
+	ToolCalls  []grokToolCall  `json:"tool_calls"`
+	ToolCallID string          `json:"tool_call_id"`
+	ModelID    string          `json:"model_id"`
+}
+
+// grokToolCall is one entry of an assistant message's tool_calls[].
+type grokToolCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // a JSON-encoded string
+}
+
+// grokContentBlock is one block of a user entry's content array.
+type grokContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// grokSignals mirrors the subset of signals.json this package reads.
+// signals.json is absent in ~11% of sessions (very short / aborted ones).
+type grokSignals struct {
+	UserMessageCount      int `json:"userMessageCount"`
+	AssistantMessageCount int `json:"assistantMessageCount"`
+	ContextTokensUsed     int `json:"contextTokensUsed"`
+}
+
+// grokUpdate is the minimal shape of an updates.jsonl line. timestamp is
+// Unix epoch seconds (fractional).
+type grokUpdate struct {
+	Timestamp float64 `json:"timestamp"`
+}

--- a/internal/grok/types.go
+++ b/internal/grok/types.go
@@ -43,7 +43,7 @@ type grokChatEntry struct {
 type grokToolCall struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
-	Arguments string `json:"arguments"` // a JSON-encoded string
+	Arguments string `json:"arguments"` // a JSON-encoded string — NOT an object; keep as string (see the reasoning note above)
 }
 
 // grokContentBlock is one block of a user entry's content array.

--- a/internal/grok/types.go
+++ b/internal/grok/types.go
@@ -29,10 +29,14 @@ type grokSummary struct {
 type grokChatEntry struct {
 	Type       string          `json:"type"` // system | user | assistant | tool_result
 	Content    json.RawMessage `json:"content"`
-	Reasoning  string          `json:"reasoning"`
 	ToolCalls  []grokToolCall  `json:"tool_calls"`
 	ToolCallID string          `json:"tool_call_id"`
 	ModelID    string          `json:"model_id"`
+	// NOTE: assistant entries also carry a `reasoning` OBJECT
+	// ({text,encrypted,id}) and `model_fingerprint`. They are intentionally
+	// NOT modeled: encoding/json silently ignores unknown JSON keys, whereas
+	// a struct field with a mismatched type (e.g. `reasoning` typed as string)
+	// makes json.Unmarshal fail for the whole line and the entry is dropped.
 }
 
 // grokToolCall is one entry of an assistant message's tool_calls[].

--- a/internal/prune/delete.go
+++ b/internal/prune/delete.go
@@ -12,6 +12,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/claude"
 	"github.com/illegalstudio/lazyagent/internal/codex"
 	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/grok"
 	"github.com/illegalstudio/lazyagent/internal/model"
 	"github.com/illegalstudio/lazyagent/internal/pi"
 )
@@ -24,6 +25,7 @@ func executeDelete(candidates []Candidate) (int, int) {
 	claudeRoots := claude.ClaudeProjectsDirs(cfg.ClaudeDirs)
 	piRoot := pi.PiSessionsDir()
 	codexRoot := codex.SessionsDir()
+	grokRoot := grok.GrokSessionsDir()
 	desktopRoot := claude.DesktopSessionsDir()
 
 	// Collect Codex session IDs to strip from the index in a single rewrite.
@@ -52,6 +54,11 @@ func executeDelete(candidates []Candidate) (int, int) {
 				codexIDsToStrip[s.SessionID] = struct{}{}
 				dirsToGC[filepath.Dir(s.JSONLPath)] = struct{}{}
 			}
+		case "grok":
+			err = deleteGrokSession(s, grokRoot)
+			if err == nil && s.JSONLPath != "" {
+				dirsToGC[filepath.Dir(s.JSONLPath)] = struct{}{}
+			}
 		default:
 			err = fmt.Errorf("agent %q is not supported by prune", s.Agent)
 		}
@@ -72,7 +79,7 @@ func executeDelete(candidates []Candidate) (int, int) {
 	}
 
 	// Best-effort: remove any now-empty project directories.
-	removeEmptyDirs(dirsToGC, claudeRoots, piRoot, codexRoot)
+	removeEmptyDirs(dirsToGC, claudeRoots, piRoot, codexRoot, grokRoot)
 
 	return deleted, failed
 }
@@ -110,6 +117,19 @@ func deleteCodexSession(s *model.Session, root string) error {
 		return err
 	}
 	return os.Remove(s.JSONLPath)
+}
+
+// deleteGrokSession removes an entire Grok session directory. A Grok session
+// is a directory tree (summary.json, chat_history.jsonl, updates.jsonl,
+// terminal/, …), so it is deleted recursively rather than as a single file.
+func deleteGrokSession(s *model.Session, root string) error {
+	if root == "" {
+		return fmt.Errorf("grok sessions directory not found")
+	}
+	if err := chatops.EnsureWithin(s.JSONLPath, []string{root}); err != nil {
+		return err
+	}
+	return os.RemoveAll(s.JSONLPath)
 }
 
 // removeDesktopSidecar scans the desktop sessions directory for JSON files
@@ -211,14 +231,13 @@ func removeCodexIndexEntries(indexPath string, ids map[string]struct{}) error {
 // removeEmptyDirs deletes any project directory in dirs that is now empty.
 // Only directories that sit directly inside one of the known agent roots are
 // removed, never the roots themselves.
-func removeEmptyDirs(dirs map[string]struct{}, claudeRoots []string, piRoot, codexRoot string) {
-	roots := make([]string, 0, len(claudeRoots)+2)
+func removeEmptyDirs(dirs map[string]struct{}, claudeRoots []string, piRoot, codexRoot, grokRoot string) {
+	roots := make([]string, 0, len(claudeRoots)+3)
 	roots = append(roots, claudeRoots...)
-	if piRoot != "" {
-		roots = append(roots, piRoot)
-	}
-	if codexRoot != "" {
-		roots = append(roots, codexRoot)
+	for _, r := range []string{piRoot, codexRoot, grokRoot} {
+		if r != "" {
+			roots = append(roots, r)
+		}
 	}
 
 	for dir := range dirs {

--- a/internal/prune/delete_test.go
+++ b/internal/prune/delete_test.go
@@ -1,0 +1,39 @@
+package prune
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestDeleteGrokSession(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "%2Ftmp%2Fp", "sess-1")
+	if err := os.MkdirAll(filepath.Join(sessionDir, "terminal"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range []string{"summary.json", "chat_history.jsonl", "updates.jsonl", "terminal/cmd-1.log"} {
+		if err := os.WriteFile(filepath.Join(sessionDir, f), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := &model.Session{Agent: "grok", JSONLPath: sessionDir}
+	if err := deleteGrokSession(s, root); err != nil {
+		t.Fatalf("deleteGrokSession: %v", err)
+	}
+	if _, err := os.Stat(sessionDir); !os.IsNotExist(err) {
+		t.Error("session directory should be gone")
+	}
+}
+
+func TestDeleteGrokSession_RejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir() // a different root
+	s := &model.Session{Agent: "grok", JSONLPath: outside}
+	if err := deleteGrokSession(s, root); err == nil {
+		t.Error("expected error deleting a directory outside the grok root")
+	}
+}

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -1,7 +1,7 @@
 // Package prune implements the `lazyagent prune` subcommand, which deletes
 // old or orphaned chat sessions from supported coding agents.
 //
-// Supported agents (v1): claude, pi, codex. Amp is skipped because local
+// Supported agents (v1): claude, pi, codex, grok. Amp is skipped because local
 // thread files are re-synced from the remote. Cursor and OpenCode store
 // sessions inside SQLite databases owned by third-party apps; deleting rows
 // there is deferred to a future version.
@@ -21,7 +21,7 @@ import (
 )
 
 // SupportedAgents lists the agent names that prune can safely clean up.
-var SupportedAgents = []string{"claude", "pi", "codex"}
+var SupportedAgents = []string{"claude", "pi", "codex", "grok"}
 
 // activeWindow skips files touched very recently (a live session might be
 // writing to them). Anything younger than this is silently excluded.

--- a/internal/prune/report.go
+++ b/internal/prune/report.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/illegalstudio/lazyagent/internal/chatops"
+	"github.com/illegalstudio/lazyagent/internal/grok"
 )
 
 var reasonStyles = map[string]lipgloss.Style{
@@ -135,13 +136,17 @@ func printVerboseTable(candidates []Candidate) {
 	)))
 }
 
-// totalBytes stats each candidate's JSONL file and sums the sizes. Missing
-// or unreadable files contribute zero — we prefer an underestimate to
-// failing the report.
+// totalBytes sums each candidate's on-disk size. For Grok the candidate is a
+// directory, so its whole tree is measured; for the JSONL-per-session agents
+// a single file is stat-ed. Missing or unreadable paths contribute zero.
 func totalBytes(candidates []Candidate) int64 {
 	var total int64
 	for _, c := range candidates {
 		if c.Session.JSONLPath == "" {
+			continue
+		}
+		if c.Session.Agent == "grok" {
+			total += grok.SessionDiskBytes(c.Session.JSONLPath)
 			continue
 		}
 		info, err := os.Stat(c.Session.JSONLPath)

--- a/internal/search/extractors.go
+++ b/internal/search/extractors.go
@@ -509,13 +509,21 @@ func extractGrok(src sourceState) ([]chunk, error) {
 		if json.Unmarshal(line, &e) != nil {
 			return
 		}
-		if e.Type != "user" && e.Type != "assistant" && e.Type != "tool_result" {
+		var role, text string
+		switch e.Type {
+		case "user":
+			msg, ok := grok.UserMessageText(e.Content)
+			if !ok {
+				return
+			}
+			role, text = "user", msg
+		case "assistant", "tool_result":
+			role = e.Type
+			text = contentText(e.Content, map[string]bool{"text": true})
+		default:
 			return
 		}
-		// contentText handles both the user array form and the plain-string
-		// form used by assistant/tool_result entries.
-		text := contentText(e.Content, map[string]bool{"text": true})
-		chunks = appendChunk(chunks, src, sessionID, cwd, name, e.Type, time.Time{}, text)
+		chunks = appendChunk(chunks, src, sessionID, cwd, name, role, time.Time{}, text)
 	})
 	return chunks, err
 }

--- a/internal/search/extractors.go
+++ b/internal/search/extractors.go
@@ -503,7 +503,6 @@ func extractGrok(src sourceState) ([]chunk, error) {
 			}
 		}
 	}
-	allowed := map[string]bool{"text": true}
 	var chunks []chunk
 	err := scanJSONL(src.Path, func(line []byte) {
 		var e grokChatLine
@@ -515,7 +514,7 @@ func extractGrok(src sourceState) ([]chunk, error) {
 		}
 		// contentText handles both the user array form and the plain-string
 		// form used by assistant/tool_result entries.
-		text := contentText(e.Content, allowed)
+		text := contentText(e.Content, map[string]bool{"text": true})
 		chunks = appendChunk(chunks, src, sessionID, cwd, name, e.Type, time.Time{}, text)
 	})
 	return chunks, err

--- a/internal/search/extractors.go
+++ b/internal/search/extractors.go
@@ -14,6 +14,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/claude"
 	"github.com/illegalstudio/lazyagent/internal/codex"
 	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/grok"
 	"github.com/illegalstudio/lazyagent/internal/pi"
 )
 
@@ -98,6 +99,8 @@ func listSources(agent string, cfg core.Config) ([]sourceState, error) {
 		return walkFiles(agent, pi.PiSessionsDir(), ".jsonl")
 	case "amp":
 		return walkFiles(agent, amp.ThreadsDir(), ".json")
+	case "grok":
+		return listGrokSources(), nil
 	default:
 		return nil, fmt.Errorf("unsupported agent %q", agent)
 	}
@@ -148,6 +151,8 @@ func extractChunks(src sourceState, cfg core.Config) ([]chunk, error) {
 		return extractPi(src)
 	case "amp":
 		return extractAmp(src)
+	case "grok":
+		return extractGrok(src)
 	default:
 		return nil, fmt.Errorf("unsupported agent %q", src.Agent)
 	}
@@ -449,4 +454,69 @@ func extractAmp(src sourceState) ([]chunk, error) {
 		chunks = appendChunk(chunks, src, sessionID, cwd, thread.Title, msg.Role, ts, strings.Join(parts, "\n"))
 	}
 	return chunks, nil
+}
+
+// grokSummaryLite is the subset of a Grok summary.json the indexer needs.
+type grokSummaryLite struct {
+	Info struct {
+		ID  string `json:"id"`
+		CWD string `json:"cwd"`
+	} `json:"info"`
+	GeneratedTitle string `json:"generated_title"`
+	SessionSummary string `json:"session_summary"`
+}
+
+type grokChatLine struct {
+	Type    string          `json:"type"`
+	Content json.RawMessage `json:"content"`
+}
+
+// listGrokSources returns one source per Grok session, keyed on its
+// chat_history.jsonl file (the transcript the indexer scans).
+func listGrokSources() []sourceState {
+	var out []sourceState
+	for _, dir := range grok.SessionDirs() {
+		path := filepath.Join(dir, "chat_history.jsonl")
+		if src, ok := fileSource("grok", filepath.Base(dir), path); ok {
+			out = append(out, src)
+		}
+	}
+	return out
+}
+
+// extractGrok turns one Grok session's chat_history.jsonl into search chunks.
+// CWD, title and the canonical session ID come from the sibling summary.json.
+func extractGrok(src sourceState) ([]chunk, error) {
+	sessionDir := filepath.Dir(src.Path)
+	sessionID := src.ID
+	var cwd, name string
+	if data, err := os.ReadFile(filepath.Join(sessionDir, "summary.json")); err == nil {
+		var sum grokSummaryLite
+		if json.Unmarshal(data, &sum) == nil {
+			if sum.Info.ID != "" {
+				sessionID = sum.Info.ID
+			}
+			cwd = sum.Info.CWD
+			name = sum.GeneratedTitle
+			if name == "" {
+				name = sum.SessionSummary
+			}
+		}
+	}
+	allowed := map[string]bool{"text": true}
+	var chunks []chunk
+	err := scanJSONL(src.Path, func(line []byte) {
+		var e grokChatLine
+		if json.Unmarshal(line, &e) != nil {
+			return
+		}
+		if e.Type != "user" && e.Type != "assistant" && e.Type != "tool_result" {
+			return
+		}
+		// contentText handles both the user array form and the plain-string
+		// form used by assistant/tool_result entries.
+		text := contentText(e.Content, allowed)
+		chunks = appendChunk(chunks, src, sessionID, cwd, name, e.Type, time.Time{}, text)
+	})
+	return chunks, err
 }

--- a/internal/search/extractors_test.go
+++ b/internal/search/extractors_test.go
@@ -1,0 +1,52 @@
+package search
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractGrok(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "%2Ftmp%2Fp", "sess-1")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	summary := `{"info":{"id":"sess-1","cwd":"/tmp/p"},"generated_title":"Parser work"}`
+	chat := `{"type":"system","content":"ignore me"}
+{"type":"user","content":[{"type":"text","text":"find the parser bug"}]}
+{"type":"assistant","content":"looking into the parser now"}
+{"type":"tool_result","content":"grep matched parser.go"}
+`
+	if err := os.WriteFile(filepath.Join(sessionDir, "summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chatPath := filepath.Join(sessionDir, "chat_history.jsonl")
+	if err := os.WriteFile(chatPath, []byte(chat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src, ok := fileSource("grok", "sess-1", chatPath)
+	if !ok {
+		t.Fatal("fileSource failed")
+	}
+	chunks, err := extractGrok(src)
+	if err != nil {
+		t.Fatalf("extractGrok: %v", err)
+	}
+	// user + assistant + tool_result = 3 chunks; system is skipped.
+	if len(chunks) != 3 {
+		t.Fatalf("got %d chunks, want 3", len(chunks))
+	}
+	for _, c := range chunks {
+		if c.SessionID != "sess-1" {
+			t.Errorf("SessionID = %q", c.SessionID)
+		}
+		if c.CWD != "/tmp/p" {
+			t.Errorf("CWD = %q", c.CWD)
+		}
+		if c.Name != "Parser work" {
+			t.Errorf("Name = %q", c.Name)
+		}
+	}
+}

--- a/internal/search/extractors_test.go
+++ b/internal/search/extractors_test.go
@@ -14,7 +14,8 @@ func TestExtractGrok(t *testing.T) {
 	}
 	summary := `{"info":{"id":"sess-1","cwd":"/tmp/p"},"generated_title":"Parser work"}`
 	chat := `{"type":"system","content":"ignore me"}
-{"type":"user","content":[{"type":"text","text":"find the parser bug"}]}
+{"type":"user","content":[{"type":"text","text":"<system-reminder>\nskills available\n</system-reminder>"}]}
+{"type":"user","content":[{"type":"text","text":"<user_query>find the parser bug</user_query>"}]}
 {"type":"assistant","content":"looking into the parser now"}
 {"type":"tool_result","content":"grep matched parser.go"}
 `
@@ -34,7 +35,7 @@ func TestExtractGrok(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extractGrok: %v", err)
 	}
-	// user + assistant + tool_result = 3 chunks; system is skipped.
+	// user + assistant + tool_result = 3 chunks; system and <system-reminder> are skipped.
 	if len(chunks) != 3 {
 		t.Fatalf("got %d chunks, want 3", len(chunks))
 	}
@@ -55,6 +56,10 @@ func TestExtractGrok(t *testing.T) {
 		if gotRoles[i] != wantRoles[i] {
 			t.Errorf("chunk %d Role = %q, want %q", i, gotRoles[i], wantRoles[i])
 		}
+	}
+	// The user chunk must have the unwrapped text — no <user_query> tags, no <system-reminder>.
+	if chunks[0].Text != "find the parser bug" {
+		t.Errorf("user chunk Text = %q, want %q", chunks[0].Text, "find the parser bug")
 	}
 }
 

--- a/internal/search/extractors_test.go
+++ b/internal/search/extractors_test.go
@@ -49,4 +49,41 @@ func TestExtractGrok(t *testing.T) {
 			t.Errorf("Name = %q", c.Name)
 		}
 	}
+	gotRoles := []string{chunks[0].Role, chunks[1].Role, chunks[2].Role}
+	wantRoles := []string{"user", "assistant", "tool_result"}
+	for i := range wantRoles {
+		if gotRoles[i] != wantRoles[i] {
+			t.Errorf("chunk %d Role = %q, want %q", i, gotRoles[i], wantRoles[i])
+		}
+	}
+}
+
+func TestExtractGrok_MissingSummary(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "%2Ftmp%2Fp", "fallback-id")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No summary.json on purpose.
+	chat := `{"type":"user","content":[{"type":"text","text":"hello grok"}]}` + "\n"
+	chatPath := filepath.Join(sessionDir, "chat_history.jsonl")
+	if err := os.WriteFile(chatPath, []byte(chat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src, ok := fileSource("grok", "fallback-id", chatPath)
+	if !ok {
+		t.Fatal("fileSource failed")
+	}
+	chunks, err := extractGrok(src)
+	if err != nil {
+		t.Fatalf("extractGrok must not fail when summary.json is absent: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("got %d chunks, want 1", len(chunks))
+	}
+	// With no summary.json, the session ID falls back to src.ID.
+	if chunks[0].SessionID != "fallback-id" {
+		t.Errorf("SessionID = %q, want fallback-id", chunks[0].SessionID)
+	}
 }

--- a/internal/search/run.go
+++ b/internal/search/run.go
@@ -29,7 +29,7 @@ func Run(args []string) int {
 	fs.SetOutput(os.Stderr)
 
 	var opts options
-	fs.StringVar(&opts.agent, "agent", "all", "Agent to search: claude,codex,pi,amp,all")
+	fs.StringVar(&opts.agent, "agent", "all", "Agent to search: claude,codex,pi,amp,grok,all")
 	fs.IntVar(&opts.limit, "limit", 20, "Maximum chat sessions to show")
 	fs.IntVar(&opts.snippets, "snippets", 2, "Maximum snippets per chat session")
 	fs.BoolVar(&opts.reindex, "reindex", false, "Rebuild the local search index before searching")
@@ -41,6 +41,7 @@ func Run(args []string) int {
 Usage:
   lazyagent search [query] [flags]
   lazyagent search --agent codex "parser bug"
+  lazyagent search --agent grok "parser bug"
 
 If query is omitted, lazyagent prompts for it.
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -2,7 +2,7 @@ package search
 
 import "time"
 
-var supportedAgents = []string{"claude", "codex", "pi", "amp"}
+var supportedAgents = []string{"claude", "codex", "pi", "amp", "grok"}
 
 type sourceState struct {
 	Agent   string

--- a/internal/tray/service.go
+++ b/internal/tray/service.go
@@ -218,10 +218,16 @@ func (s *SessionService) GetSessionDetail(id string) *SessionFull {
 
 	tools := make([]ToolItem, 0, len(sess.RecentTools))
 	for _, t := range sess.RecentTools {
+		ago := ""
+		// Only timestamped tool calls get a relative age — agents like Grok
+		// record a per-tool time only for the most recent call.
+		if !t.Timestamp.IsZero() {
+			ago = core.FormatDuration(time.Since(t.Timestamp))
+		}
 		tools = append(tools, ToolItem{
 			Name:      t.Name,
 			Timestamp: t.Timestamp,
-			Ago:       core.FormatDuration(time.Since(t.Timestamp)),
+			Ago:       ago,
 		})
 	}
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -832,6 +832,8 @@ func (m Model) renderListRow(s *model.Session, nameW, sparkW int, selected bool)
 		agentPrefix = "O "
 	} else if s.Agent == "cursor" {
 		agentPrefix = "C "
+	} else if s.Agent == "grok" {
+		agentPrefix = "G "
 	} else if s.Desktop != nil {
 		agentPrefix = "D "
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1069,9 +1069,13 @@ func (m Model) buildDetailLines(s *model.Session, width int) []string {
 		}
 		for i := len(tools) - 1; i >= 0; i-- {
 			tc := tools[i]
-			ago := core.FormatDuration(time.Since(tc.Timestamp))
-			add(lipgloss.NewStyle().Foreground(m.theme.Primary).Render("  "+tc.Name) +
-				lipgloss.NewStyle().Foreground(m.theme.Muted).Render("  "+ago))
+			line := lipgloss.NewStyle().Foreground(m.theme.Primary).Render("  " + tc.Name)
+			// Only timestamped tool calls get a relative age — agents like
+			// Grok record a per-tool time only for the most recent call.
+			if !tc.Timestamp.IsZero() {
+				line += lipgloss.NewStyle().Foreground(m.theme.Muted).Render("  " + core.FormatDuration(time.Since(tc.Timestamp)))
+			}
+			add(line)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	apiMode := flag.Bool("api", false, "Start the API server")
 	apiHost := flag.String("host", "", "API listen address (e.g. :7421 or 0.0.0.0:7421). Default: 127.0.0.1:7421")
 	demoMode := flag.Bool("demo", false, "Use generated fake data instead of real Claude sessions")
-	agentMode := flag.String("agent", "all", "Which agent sessions to show: claude, pi, opencode, cursor, codex, amp, all (default: all)")
+	agentMode := flag.String("agent", "all", "Which agent sessions to show: claude, pi, opencode, cursor, codex, amp, grok, all (default: all)")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, `%s — monitor all running coding agent sessions
@@ -67,6 +67,7 @@ Usage:
   lazyagent --agent cursor      Monitor only Cursor sessions
   lazyagent --agent codex       Monitor only Codex CLI sessions
   lazyagent --agent amp         Monitor only Amp CLI sessions
+  lazyagent --agent grok        Monitor only Grok CLI sessions
   lazyagent --agent all         Monitor all agents (default)
   lazyagent --api               Start the API server (http://127.0.0.1:7421)
   lazyagent --api --host :7421  Start the API server on custom address
@@ -118,10 +119,10 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 		provider = demo.Provider{}
 	} else {
 		switch *agentMode {
-		case "claude", "pi", "opencode", "cursor", "codex", "amp", "all":
+		case "claude", "pi", "opencode", "cursor", "codex", "amp", "grok", "all":
 			provider = core.BuildProvider(*agentMode, cfg)
 		default:
-			fmt.Fprintf(os.Stderr, "Error: unknown --agent value %q (use claude, pi, opencode, cursor, codex, amp, or all)\n", *agentMode)
+			fmt.Fprintf(os.Stderr, "Error: unknown --agent value %q (use claude, pi, opencode, cursor, codex, amp, grok, or all)\n", *agentMode)
 			os.Exit(1)
 		}
 	}


### PR DESCRIPTION
- **feat(grok): add session directory parser**
- **fix(grok): rune-safe tool name, drop over-broad text fallback, add status tests**
- **feat(grok): add session discovery with cache + parallel parse**
- **feat(grok): wire GrokProvider into BuildProvider and config**
- **feat(grok): add --agent grok flag and TUI G prefix**
- **feat(grok): add Grok transcript indexing to search**
- **test(grok): cover missing-summary fallback; inline allowed map**
- **feat(grok): add directory-aware Grok pruning**
- **docs(grok): record compact Phase 0 resume-verification findings**
- **feat(grok): add directory-aware Grok compaction**
- **test(grok): cover terminal-log compaction; truncate array strings; tidy size accounting**
- **docs(grok): document Grok as a supported agent**
- **docs(grok): match per-agent prose style in supported-agents and compact**
- **docs(grok): add Grok integration implementation plan**
- **docs(grok): note cache-key trade-off and search resume caveat**
- **docs(grok): correct cache trade-off comment wording**
- **fix(grok): show assistant messages, filter injected user-context entries**
- **test(grok): direct UserMessageText coverage; tighten assistant test; guard comments**
- **fix(grok): stop sessions falsely showing 'compacting' status**
- **feat(grok): hide sessions until the user sends the first message**
- **refactor(grok): hide never-used sessions at render layer, keep them prunable**
- **fix(grok): stamp tool/message timestamps so the UI shows a sane age**
- **fix(grok): show tool age only for the last tool, omit unknown timestamps**
