### PR TITLE
feat/sessions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ That said, lazyagent and its API are **fully open source**. If you'd rather not 
 - **[`lazyagent compact`](docs/maintenance/compact.md)** — shrink session files in place by truncating bulky tool outputs, thinking blocks, and embedded images — sessions stay resumable with the originating agent. Supports Claude Code, pi, Codex, Grok, and Kimi.
 - **[`lazyagent search`](docs/maintenance/search.md)** — search transcript-file agents (Claude, Codex, pi, Amp, Grok, Kimi) with highlighted snippets and an incremental local index.
 - **[`lazyagent limits`](docs/maintenance/limits.md)** — on-demand rate-limit / billing summary for Claude Code (5h + 7d), Codex (5h + 7d), Grok (monthly), Kimi Code, and Cursor (monthly API usage), with a detailed pace view available via `--detailed`.
+- **[`lazyagent sessions`](docs/usage/sessions.md)** — list every session recorded for the current directory — across all agents — and reopen one with the originating agent's CLI. Interactive picker, `--json` for scripts.
 - **Outbound webhooks on session state transitions** — send a signed JSON payload to Slack, a custom dashboard, or a CI endpoint whenever a session goes idle, waits for input, or changes state. See [Webhooks](docs/reference/webhooks.md).
 
 Typical savings on a year of daily use: **80+ MiB reclaimed** across a few commands, with every rewrite validated and backed up by default.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Three interfaces ship in a single binary: a terminal UI, a macOS menu bar app, a
 
 - [CLI reference](usage/cli.md) — every `lazyagent` flag, with syntax and examples
 - [Recipes](usage/recipes.md) — end-to-end walkthroughs for common workflows
+- [Sessions for a directory](usage/sessions.md) — list every recorded session for a directory and reopen one, across all agents
 
 ## Maintenance
 

--- a/docs/interfaces/http-api.md
+++ b/docs/interfaces/http-api.md
@@ -200,6 +200,7 @@ List all visible sessions within the configured [time window](../reference/confi
 |-----------|--------|-------------|
 | `search`  | string | Filter by project path (case-insensitive substring match) |
 | `filter`  | string | Filter by activity kind (e.g. `thinking`, `writing`, `idle`) |
+| `dir`     | string | Filter to sessions whose CWD is this directory or a subdirectory of it — the same matching `lazyagent sessions` uses. Must be an **absolute path** (there's no meaningful "current directory" for a remote client). The directory does not need to exist on the machine running the server. |
 
 **Response: `200 OK`**
 
@@ -222,6 +223,19 @@ List all visible sessions within the configured [time window](../reference/confi
 ```
 
 Possible `activity` values: `idle`, `waiting`, `thinking`, `compacting`, `reading`, `writing`, `running`, `searching`, `browsing`, `spawning`. See [Activity states](../concepts/activity-states.md) for meanings.
+
+**Example — sessions under one project:**
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:7421/api/sessions?dir=/Users/me/projects/myapp"
+```
+
+**Response: `400 Bad Request`** — `dir` is not an absolute path:
+
+```json
+{ "error": "dir must be an absolute path" }
+```
 
 ### `GET /api/sessions/{id}`
 

--- a/docs/superpowers/plans/2026-07-20-sessions-list.md
+++ b/docs/superpowers/plans/2026-07-20-sessions-list.md
@@ -1,0 +1,1223 @@
+# `lazyagent sessions` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A `lazyagent sessions` subcommand that lists every session recorded for the current directory (all agents) in an interactive bubbletea picker and reopens the selected one with the originating agent's CLI.
+
+**Architecture:** New self-contained package `internal/sessions` following the existing subcommand pattern (`Run(args []string) int` registered in `main.go`). Discovery reuses `core.BuildProvider`; filtering/sorting are pure functions; the picker is a small bubbletea model whose `Update` is unit-testable; the resume exec happens after the tea program exits. A targeted refactor adds `core.ResumeArgv` as the single source of truth for executable resume commands (dedups `search/run.go`).
+
+**Tech Stack:** Go 1.25, bubbletea + lipgloss (already vendored), stdlib `flag`/`encoding/json`/`path/filepath`.
+
+**Spec:** `docs/superpowers/specs/2026-07-20-sessions-list-design.md`
+
+## Global Constraints
+
+- Executable resume set is exactly: claude, codex, amp, pi, kimi ("openable" ⇔ `ResumeArgv != nil`).
+- Copyable set: any agent where `core.ResumeCommand != ""` (adds opencode, kilo, cursor); grok has neither.
+- Sidechain sessions (`IsSidechain`) are always excluded from the listing.
+- Sort: `LastActivity` descending.
+- Exit codes: 0 success/quit/no-sessions, 1 runtime failure (discovery, exec, clipboard), 2 usage errors.
+- JSON field names (verbatim): `agent`, `session_id`, `name`, `cwd`, `last_activity`, `messages`, `resume_command`. Empty list → `[]`.
+- Picker renders to **stderr** (like `chatops.PickAgents`); JSON goes to **stdout**.
+- All commit messages: no Co-Authored-By lines (user preference).
+- Run package tests with `go test ./internal/<pkg>/`.
+
+---
+
+### Task 1: `core.ResumeArgv` + dedup `search`
+
+**Files:**
+- Modify: `internal/core/resume.go`
+- Modify: `internal/search/run.go` (function `resumeCommand`, ~line 239)
+- Test: `internal/core/resume_test.go`
+
+**Interfaces:**
+- Consumes: existing `core.ResumeCommand(agent, sessionID string) string` (display string, unchanged).
+- Produces: `core.ResumeArgv(agent, sessionID string) []string` — executable argv for claude/codex/amp/pi/kimi, `nil` for every other agent or empty sessionID. Tasks 4 and 5 rely on this exact name and nil-semantics.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/core/resume_test.go` (package `core`; add `"slices"` to imports):
+
+```go
+func TestResumeArgv(t *testing.T) {
+	cases := []struct {
+		agent string
+		want  []string
+	}{
+		{"claude", []string{"claude", "--resume", "abc"}},
+		{"codex", []string{"codex", "resume", "abc"}},
+		{"amp", []string{"amp", "threads", "continue", "abc"}},
+		{"pi", []string{"pi", "--session", "abc"}},
+		{"kimi", []string{"kimi", "--resume", "abc"}},
+		// Display-only agents: copyable via ResumeCommand but not executable.
+		{"opencode", nil},
+		{"kilo", nil},
+		{"cursor", nil},
+		{"grok", nil},
+		{"unknown", nil},
+	}
+	for _, c := range cases {
+		if got := ResumeArgv(c.agent, "abc"); !slices.Equal(got, c.want) {
+			t.Errorf("ResumeArgv(%q) = %v, want %v", c.agent, got, c.want)
+		}
+	}
+	if got := ResumeArgv("claude", ""); got != nil {
+		t.Errorf("empty session ID: want nil, got %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/core/ -run TestResumeArgv -v`
+Expected: FAIL — `undefined: ResumeArgv` (compile error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `internal/core/resume.go`:
+
+```go
+// ResumeArgv returns the executable argv to resume a session, or nil when
+// the agent has no resume command lazyagent is willing to exec (grok has
+// none; opencode/kilo/cursor have a display string only — see ResumeCommand).
+// "Openable" everywhere in the codebase means ResumeArgv != nil.
+func ResumeArgv(agent, sessionID string) []string {
+	if sessionID == "" {
+		return nil
+	}
+	switch agent {
+	case "claude":
+		return []string{"claude", "--resume", sessionID}
+	case "codex":
+		return []string{"codex", "resume", sessionID}
+	case "amp":
+		return []string{"amp", "threads", "continue", sessionID}
+	case "pi":
+		return []string{"pi", "--session", sessionID}
+	case "kimi":
+		return []string{"kimi", "--resume", sessionID}
+	default:
+		return nil
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/core/ -run 'TestResumeArgv|TestResumeCommand' -v`
+Expected: PASS (both).
+
+- [ ] **Step 5: Dedup `search/run.go`**
+
+Replace the whole `resumeCommand` function at the bottom of `internal/search/run.go` (the switch duplicating the agent→argv mapping) with:
+
+```go
+func resumeCommand(agent, sessionID string) (*exec.Cmd, string) {
+	argv := core.ResumeArgv(agent, sessionID)
+	if argv == nil {
+		return nil, ""
+	}
+	return exec.Command(argv[0], argv[1:]...), core.ResumeCommand(agent, sessionID)
+}
+```
+
+- [ ] **Step 6: Run search + core tests**
+
+Run: `go test ./internal/search/ ./internal/core/`
+Expected: PASS (no behavior change: same five agents, same argv).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/core/resume.go internal/core/resume_test.go internal/search/run.go
+git commit -m "refactor(core): add ResumeArgv as single source of resume argv"
+```
+
+---
+
+### Task 2: directory filter (`internal/sessions/filter.go`)
+
+**Files:**
+- Create: `internal/sessions/filter.go`
+- Test: `internal/sessions/filter_test.go`
+
+**Interfaces:**
+- Consumes: `model.Session` fields `CWD`, `IsSidechain`, `LastActivity`.
+- Produces: `FilterByDir(sessions []*model.Session, dir string) ([]*model.Session, error)` — matching sessions, sidechains excluded, sorted `LastActivity` desc. Task 5 calls exactly this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/sessions/filter_test.go`:
+
+```go
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func sess(cwd string, last time.Time, sidechain bool) *model.Session {
+	return &model.Session{SessionID: cwd, CWD: cwd, LastActivity: last, IsSidechain: sidechain}
+}
+
+func TestFilterByDirMatching(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	in := []*model.Session{
+		sess(base, now, false),                // exact match
+		sess(sub, now.Add(-time.Hour), false), // subdirectory
+		sess(base+"extra", now, false),        // false prefix — excluded
+		sess("/somewhere/else", now, false),   // unrelated — excluded
+		sess(base, now, true),                 // sidechain — excluded
+	}
+	got, err := FilterByDir(in, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 sessions, got %d", len(got))
+	}
+	if got[0].CWD != base || got[1].CWD != sub {
+		t.Errorf("wrong contents/order: %s, %s", got[0].CWD, got[1].CWD)
+	}
+}
+
+func TestFilterByDirSymlinkedTarget(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	got, err := FilterByDir([]*model.Session{sess(real, time.Now(), false)}, link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("symlinked target should match resolved CWD, got %d matches", len(got))
+	}
+}
+
+func TestFilterByDirSortsByLastActivityDesc(t *testing.T) {
+	base := t.TempDir()
+	now := time.Now()
+	in := []*model.Session{
+		sess(base, now.Add(-2*time.Hour), false),
+		sess(base, now, false),
+		sess(base, now.Add(-time.Hour), false),
+	}
+	got, err := FilterByDir(in, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got[0].LastActivity.Equal(now) {
+		t.Errorf("most recent must be first, got %v", got[0].LastActivity)
+	}
+	if !got[2].LastActivity.Equal(now.Add(-2 * time.Hour)) {
+		t.Errorf("oldest must be last, got %v", got[2].LastActivity)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/sessions/ -v`
+Expected: FAIL — `undefined: FilterByDir` (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/sessions/filter.go`:
+
+```go
+// Package sessions implements the `lazyagent sessions` subcommand: list the
+// sessions recorded for a directory (all agents) and reopen one.
+package sessions
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// targetVariants normalizes dir for matching: the cleaned absolute path
+// plus, when it differs, the symlink-resolved form — so /tmp also matches
+// sessions recorded under /private/tmp on macOS.
+func targetVariants(dir string) ([]string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	abs = filepath.Clean(abs)
+	variants := []string{abs}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		if resolved = filepath.Clean(resolved); resolved != abs {
+			variants = append(variants, resolved)
+		}
+	}
+	return variants, nil
+}
+
+// matchesDir reports whether cwd equals a target variant or lies beneath one
+// (prefix on a path boundary: /foo/bar must not match /foo/barbaz).
+func matchesDir(cwd string, variants []string) bool {
+	if cwd == "" {
+		return false
+	}
+	cwd = filepath.Clean(cwd)
+	for _, v := range variants {
+		if cwd == v || strings.HasPrefix(cwd, v+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterByDir returns the sessions whose CWD is dir or a subdirectory of it,
+// excluding sidechains, sorted by LastActivity descending.
+func FilterByDir(sessions []*model.Session, dir string) ([]*model.Session, error) {
+	variants, err := targetVariants(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []*model.Session
+	for _, s := range sessions {
+		if s.IsSidechain {
+			continue
+		}
+		if matchesDir(s.CWD, variants) {
+			out = append(out, s)
+		}
+	}
+	slices.SortFunc(out, func(a, b *model.Session) int {
+		return b.LastActivity.Compare(a.LastActivity)
+	})
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/sessions/ -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sessions/filter.go internal/sessions/filter_test.go
+git commit -m "feat(sessions): add directory filter for session listing"
+```
+
+---
+
+### Task 3: JSON output (`internal/sessions/json.go`)
+
+**Files:**
+- Create: `internal/sessions/json.go`
+- Test: `internal/sessions/json_test.go`
+
+**Interfaces:**
+- Consumes: `core.ResumeCommand(agent, sessionID) string` (Task 1 file, pre-existing function).
+- Produces: `writeJSON(w io.Writer, sessions []*model.Session, nameFor func(*model.Session) string) error`. Task 5 calls exactly this; `nameFor` resolves the display name (custom alias or agent-provided) per session.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/sessions/json_test.go`:
+
+```go
+package sessions
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestWriteJSONFields(t *testing.T) {
+	last := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	list := []*model.Session{{
+		Agent: "claude", SessionID: "abc", CWD: "/proj",
+		LastActivity: last, TotalMessages: 5,
+	}}
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, list, func(*model.Session) string { return "my-alias" }); err != nil {
+		t.Fatal(err)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(out))
+	}
+	e := out[0]
+	if e["agent"] != "claude" || e["session_id"] != "abc" || e["cwd"] != "/proj" {
+		t.Errorf("identity fields wrong: %v", e)
+	}
+	if e["name"] != "my-alias" {
+		t.Errorf("name = %v, want my-alias", e["name"])
+	}
+	if e["messages"] != float64(5) {
+		t.Errorf("messages = %v, want 5", e["messages"])
+	}
+	if e["resume_command"] != "claude --resume abc" {
+		t.Errorf("resume_command = %v", e["resume_command"])
+	}
+	if _, ok := e["last_activity"]; !ok {
+		t.Error("missing last_activity")
+	}
+}
+
+func TestWriteJSONEmptyList(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, nil, func(*model.Session) string { return "" }); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Errorf("empty list must encode as [], got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/sessions/ -run TestWriteJSON -v`
+Expected: FAIL — `undefined: writeJSON` (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/sessions/json.go`:
+
+```go
+package sessions
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// sessionJSON is the wire shape of one row in `lazyagent sessions --json`.
+// Field names are part of the CLI contract — do not rename.
+type sessionJSON struct {
+	Agent         string    `json:"agent"`
+	SessionID     string    `json:"session_id"`
+	Name          string    `json:"name,omitempty"`
+	CWD           string    `json:"cwd"`
+	LastActivity  time.Time `json:"last_activity"`
+	Messages      int       `json:"messages"`
+	ResumeCommand string    `json:"resume_command,omitempty"`
+}
+
+// writeJSON emits the filtered sessions as an indented JSON array.
+// nameFor resolves the display name for a session ("" omits the field).
+func writeJSON(w io.Writer, sessions []*model.Session, nameFor func(*model.Session) string) error {
+	out := make([]sessionJSON, 0, len(sessions)) // non-nil so empty encodes as []
+	for _, s := range sessions {
+		out = append(out, sessionJSON{
+			Agent:         s.Agent,
+			SessionID:     s.SessionID,
+			Name:          nameFor(s),
+			CWD:           s.CWD,
+			LastActivity:  s.LastActivity,
+			Messages:      s.TotalMessages,
+			ResumeCommand: core.ResumeCommand(s.Agent, s.SessionID),
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/sessions/ -v`
+Expected: PASS (filter + json tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sessions/json.go internal/sessions/json_test.go
+git commit -m "feat(sessions): add --json output encoder"
+```
+
+---
+
+### Task 4: interactive picker (`internal/sessions/picker.go`)
+
+**Files:**
+- Create: `internal/sessions/picker.go`
+- Test: `internal/sessions/picker_test.go`
+
+**Interfaces:**
+- Consumes: `core.ResumeArgv` (Task 1), `core.ResumeCommand`, `chatops` styles (`StyleMuted`, `StyleFooter`, `StyleTableHeader`, `ColBorderDim`).
+- Produces (Task 5 relies on these exact names):
+  - `type pickerAction int` with constants `actionQuit`, `actionOpen`, `actionCopy`
+  - `runPicker(list []*model.Session, titles []string, dirLabel string) (*model.Session, pickerAction, error)` — nil session ⇔ `actionQuit`
+  - `titleFor(s *model.Session, alias string) string`
+  - `relTime(t, now time.Time) string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/sessions/picker_test.go`:
+
+```go
+package sessions
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func keyRune(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
+func TestPickerNavigationAndOpen(t *testing.T) {
+	m := pickerModel{
+		sessions: []*model.Session{
+			{Agent: "claude", SessionID: "a"},
+			{Agent: "grok", SessionID: "b"},
+		},
+		titles: []string{"one", "two"},
+	}
+
+	next, _ := m.Update(keyRune('j'))
+	m = next.(pickerModel)
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1", m.cursor)
+	}
+	// j at the bottom stays put.
+	next, _ = m.Update(keyRune('j'))
+	m = next.(pickerModel)
+	if m.cursor != 1 {
+		t.Fatalf("cursor moved past end: %d", m.cursor)
+	}
+
+	// enter on grok (no resume at all): stays open, shows a status message.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("picker must stay open on a grok row")
+	}
+	if m.status == "" {
+		t.Fatal("expected a status message for grok")
+	}
+
+	// back up to claude and open.
+	next, _ = m.Update(keyRune('k'))
+	m = next.(pickerModel)
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if m.action != actionOpen {
+		t.Fatalf("action = %v, want actionOpen", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after open")
+	}
+}
+
+func TestPickerEnterFallsBackToCopy(t *testing.T) {
+	// opencode: display command exists, executable argv does not → copy.
+	m := pickerModel{sessions: []*model.Session{{Agent: "opencode", SessionID: "x"}}, titles: []string{"t"}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if m.action != actionCopy {
+		t.Fatalf("action = %v, want actionCopy", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after copy")
+	}
+}
+
+func TestPickerQuitKeys(t *testing.T) {
+	for _, k := range []tea.KeyMsg{{Type: tea.KeyEsc}, {Type: tea.KeyCtrlC}, keyRune('q')} {
+		m := pickerModel{sessions: []*model.Session{{Agent: "claude", SessionID: "a"}}, titles: []string{"t"}}
+		next, cmd := m.Update(k)
+		m = next.(pickerModel)
+		if m.action != actionQuit || cmd == nil {
+			t.Fatalf("key %v: action=%v cmd=%v, want quit", k, m.action, cmd)
+		}
+	}
+}
+
+func TestRelTime(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		in   time.Time
+		want string
+	}{
+		{now.Add(-30 * time.Second), "just now"},
+		{now.Add(-5 * time.Minute), "5m ago"},
+		{now.Add(-2 * time.Hour), "2h ago"},
+		{now.Add(-30 * time.Hour), "yesterday"},
+		{now.Add(-3 * 24 * time.Hour), "3d ago"},
+		{now.Add(-40 * 24 * time.Hour), "2026-06-10"},
+		{time.Time{}, "unknown"},
+	}
+	for _, c := range cases {
+		if got := relTime(c.in, now); got != c.want {
+			t.Errorf("relTime(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTitleFor(t *testing.T) {
+	s := &model.Session{
+		Name: "agent-name",
+		RecentMessages: []model.ConversationMessage{
+			{Role: "assistant", Text: "hi"},
+			{Role: "user", Text: "fix the build\nplease"},
+		},
+	}
+	if got := titleFor(s, "custom"); got != "custom" {
+		t.Errorf("alias must win, got %q", got)
+	}
+	if got := titleFor(s, ""); got != "agent-name" {
+		t.Errorf("agent name second, got %q", got)
+	}
+	s.Name = ""
+	if got := titleFor(s, ""); got != "fix the build please" {
+		t.Errorf("user message preview third, got %q", got)
+	}
+	if got := titleFor(&model.Session{}, ""); got != "(no messages)" {
+		t.Errorf("fallback, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/sessions/ -v`
+Expected: FAIL — `undefined: pickerModel` etc. (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/sessions/picker.go`:
+
+```go
+package sessions
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/illegalstudio/lazyagent/internal/chatops"
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// pickerAction is what the user chose when the picker exited.
+type pickerAction int
+
+const (
+	actionQuit pickerAction = iota
+	actionOpen
+	actionCopy
+)
+
+// agentColors maps agent keys to identity colors. The keys shared with the
+// prune/compact selectors reuse their palette; the rest stay in the family.
+var agentColors = map[string]lipgloss.Color{
+	"claude":   "#E7A15E",
+	"pi":       "#F38BA8",
+	"codex":    "#A6E3A1",
+	"grok":     "#89B4FA",
+	"kimi":     "#CBA6F7",
+	"opencode": "#94E2D5",
+	"kilo":     "#F9E2AF",
+	"cursor":   "#B4BEFE",
+	"amp":      "#EBA0AC",
+}
+
+var (
+	stylePickerBox = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(chatops.ColBorderDim).
+		Padding(0, 1)
+	styleCursor = lipgloss.NewStyle().Foreground(chatops.ColPrimary).Bold(true)
+	styleStatus = lipgloss.NewStyle().Foreground(chatops.ColWarn)
+)
+
+type pickerModel struct {
+	sessions []*model.Session
+	titles   []string // pre-computed row titles, same indexing as sessions
+	cursor   int
+	action   pickerAction
+	status   string
+	dirLabel string
+	now      time.Time
+}
+
+func (m pickerModel) Init() tea.Cmd { return nil }
+
+func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		m.status = ""
+	case "down", "j":
+		if m.cursor < len(m.sessions)-1 {
+			m.cursor++
+		}
+		m.status = ""
+	case "enter":
+		s := m.sessions[m.cursor]
+		switch {
+		case core.ResumeArgv(s.Agent, s.SessionID) != nil:
+			m.action = actionOpen
+			return m, tea.Quit
+		case core.ResumeCommand(s.Agent, s.SessionID) != "":
+			// Not executable from here, but the command exists: copy it.
+			m.action = actionCopy
+			return m, tea.Quit
+		default:
+			m.status = fmt.Sprintf("no resume available for %s sessions", s.Agent)
+		}
+	case "c":
+		s := m.sessions[m.cursor]
+		if core.ResumeCommand(s.Agent, s.SessionID) != "" {
+			m.action = actionCopy
+			return m, tea.Quit
+		}
+		m.status = fmt.Sprintf("no resume command for %s sessions", s.Agent)
+	case "q", "esc", "ctrl+c":
+		m.action = actionQuit
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m pickerModel) View() string {
+	var rows []string
+	for i, s := range m.sessions {
+		marker := "  "
+		if i == m.cursor {
+			marker = styleCursor.Render("▸ ")
+		}
+		agent := lipgloss.NewStyle().Foreground(agentColor(s.Agent)).Render(fmt.Sprintf("%-8s", s.Agent))
+		row := fmt.Sprintf("%s%s %-10s %4d  %s",
+			marker, agent, relTime(s.LastActivity, m.now), s.TotalMessages, m.titles[i])
+		if core.ResumeCommand(s.Agent, s.SessionID) == "" {
+			row += chatops.StyleMuted.Render("  (no resume)")
+		}
+		rows = append(rows, row)
+	}
+	title := chatops.StyleTableHeader.Render(fmt.Sprintf("Sessions in %s (%d)", m.dirLabel, len(m.sessions)))
+	box := stylePickerBox.Render(title + "\n\n" + strings.Join(rows, "\n"))
+	footer := chatops.StyleFooter.Render("  ↑/↓ move · enter open · c copy resume cmd · q quit")
+	if m.status != "" {
+		footer += "\n" + styleStatus.Render("  "+m.status)
+	}
+	return box + "\n" + footer + "\n"
+}
+
+func agentColor(agent string) lipgloss.Color {
+	if c, ok := agentColors[agent]; ok {
+		return c
+	}
+	return chatops.ColTextSubtle
+}
+
+// runPicker shows the interactive list and returns the chosen session and
+// action. A nil session means the user quit without choosing.
+func runPicker(list []*model.Session, titles []string, dirLabel string) (*model.Session, pickerAction, error) {
+	m := pickerModel{sessions: list, titles: titles, dirLabel: dirLabel, now: time.Now()}
+	p := tea.NewProgram(m, tea.WithInput(os.Stdin), tea.WithOutput(os.Stderr))
+	final, err := p.Run()
+	if err != nil {
+		return nil, actionQuit, fmt.Errorf("session picker: %w", err)
+	}
+	res := final.(pickerModel)
+	if res.action == actionQuit {
+		return nil, actionQuit, nil
+	}
+	return res.sessions[res.cursor], res.action, nil
+}
+
+// relTime renders t relative to now, degrading to an absolute date after
+// 30 days. Zero times render as "unknown".
+func relTime(t, now time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 48*time.Hour:
+		return "yesterday"
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+	return t.Format("2006-01-02")
+}
+
+// titleFor picks the row title: user alias, then agent-provided name, then
+// the earliest user message still in the RecentMessages window.
+func titleFor(s *model.Session, alias string) string {
+	if alias != "" {
+		return alias
+	}
+	if s.Name != "" {
+		return s.Name
+	}
+	for _, msg := range s.RecentMessages {
+		if msg.Role == "user" && strings.TrimSpace(msg.Text) != "" {
+			return truncate(msg.Text, 60)
+		}
+	}
+	return "(no messages)"
+}
+
+// truncate collapses whitespace and cuts s to max runes with an ellipsis.
+func truncate(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-1]) + "…"
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/sessions/ -v`
+Expected: PASS (all picker, filter, json tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/sessions/picker.go internal/sessions/picker_test.go
+git commit -m "feat(sessions): add interactive session picker"
+```
+
+---
+
+### Task 5: `Run` wiring + `main.go` registration
+
+**Files:**
+- Create: `internal/sessions/sessions.go`
+- Modify: `main.go` (subcommand switch ~line 40, usage text ~line 88)
+- Test: `internal/sessions/run_test.go`
+
+**Interfaces:**
+- Consumes: `FilterByDir` (Task 2), `writeJSON` (Task 3), `runPicker`/`titleFor`/`actionOpen`/`actionCopy` (Task 4), `core.LoadConfig`, `core.BuildProvider`, `core.NewSessionNames().Get(sessionID)`, `core.CopyToClipboard`, `core.ResumeArgv`, `core.ResumeCommand`.
+- Produces: `sessions.Run(args []string) int` — the subcommand entrypoint `main.go` calls.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/sessions/run_test.go` (only hermetic paths — they must return before any discovery or config I/O):
+
+```go
+package sessions
+
+import "testing"
+
+func TestRunRejectsUnknownAgent(t *testing.T) {
+	if code := Run([]string{"--agent", "nope"}); code != 2 {
+		t.Errorf("unknown agent: exit = %d, want 2", code)
+	}
+}
+
+func TestRunRejectsMissingDir(t *testing.T) {
+	if code := Run([]string{"--dir", "/nonexistent-lazyagent-test-dir"}); code != 2 {
+		t.Errorf("missing dir: exit = %d, want 2", code)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	if code := Run([]string{"--help"}); code != 0 {
+		t.Errorf("--help: exit = %d, want 0", code)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/sessions/ -run TestRun -v`
+Expected: FAIL — `undefined: Run` (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/sessions/sessions.go`:
+
+```go
+package sessions
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/illegalstudio/lazyagent/internal/chatops"
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+	"github.com/mattn/go-isatty"
+)
+
+var validAgents = map[string]bool{
+	"claude": true, "pi": true, "opencode": true, "kilo": true, "cursor": true,
+	"codex": true, "amp": true, "grok": true, "kimi": true, "all": true,
+}
+
+// Run implements `lazyagent sessions`. It lists the sessions recorded for
+// the current (or --dir) directory across agents and reopens the chosen one.
+func Run(args []string) int {
+	fs := flag.NewFlagSet("sessions", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	agent := fs.String("agent", "all", "Agent to list: claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, all")
+	jsonOut := fs.Bool("json", false, "Print the session list as JSON and exit")
+	dirFlag := fs.String("dir", "", "List sessions for this directory instead of the current one")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `lazyagent sessions — list sessions for a directory and reopen one
+
+Lists every recorded session whose working directory is the current
+directory (or --dir) or a subdirectory of it, across all agents.
+Selecting a session resumes it with the originating agent's CLI.
+
+Usage:
+  lazyagent sessions
+  lazyagent sessions --agent claude
+  lazyagent sessions --json
+  lazyagent sessions --dir ~/projects/foo
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	if !validAgents[*agent] {
+		fmt.Fprintf(os.Stderr, "Error: unknown --agent value %q (use claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, or all)\n", *agent)
+		return 2
+	}
+
+	dir := *dirFlag
+	if dir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: cannot determine working directory: %v\n", err)
+			return 2
+		}
+		dir = wd
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "Error: %q is not a directory\n", dir)
+		return 2
+	}
+
+	cfg := core.LoadConfig()
+	provider := core.BuildProvider(*agent, cfg)
+	all, err := provider.DiscoverSessions()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	filtered, err := FilterByDir(all, dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	names := core.NewSessionNames()
+	nameFor := func(s *model.Session) string {
+		if alias := names.Get(s.SessionID); alias != "" {
+			return alias
+		}
+		return s.Name
+	}
+
+	if *jsonOut {
+		if err := writeJSON(os.Stdout, filtered, nameFor); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	if len(filtered) == 0 {
+		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
+		return 0
+	}
+	if !isatty.IsTerminal(os.Stdin.Fd()) {
+		fmt.Fprintln(os.Stderr, "Error: the interactive picker needs a terminal (use --json for scripted output)")
+		return 2
+	}
+
+	titles := make([]string, len(filtered))
+	for i, s := range filtered {
+		titles[i] = titleFor(s, names.Get(s.SessionID))
+	}
+	chosen, action, err := runPicker(filtered, titles, abbreviateHome(dir))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	switch action {
+	case actionOpen:
+		return openSession(chosen)
+	case actionCopy:
+		cmdStr := core.ResumeCommand(chosen.Agent, chosen.SessionID)
+		if err := core.CopyToClipboard(cmdStr); err != nil {
+			fmt.Fprintf(os.Stderr, "Copy failed: %v\nCommand: %s\n", err, cmdStr)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "Copied to clipboard: %s\n", cmdStr)
+	}
+	return 0
+}
+
+// openSession execs the agent's resume command in the current terminal,
+// running from the session's own CWD when it still exists (claude --resume
+// locates sessions by project directory).
+func openSession(s *model.Session) int {
+	argv := core.ResumeArgv(s.Agent, s.SessionID)
+	if argv == nil {
+		fmt.Fprintf(os.Stderr, "No resume command available for %s sessions.\n", s.Agent)
+		return 1
+	}
+	cmd := exec.Command(argv[0], argv[1:]...)
+	if s.CWD != "" {
+		if info, err := os.Stat(s.CWD); err == nil && info.IsDir() {
+			cmd.Dir = s.CWD
+		}
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	fmt.Fprintf(os.Stderr, "%s %s\n", chatops.StyleMuted.Render("Opening:"), core.ResumeCommand(s.Agent, s.SessionID))
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// abbreviateHome shortens a path with the user's home directory to ~/...
+func abbreviateHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" && strings.HasPrefix(path, home) {
+		return "~" + strings.TrimPrefix(path, home)
+	}
+	return path
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/sessions/ -v`
+Expected: PASS (all package tests).
+
+- [ ] **Step 5: Register in `main.go`**
+
+In the subcommand switch at the top of `main()` (after the `"passphrase"` case), add:
+
+```go
+		case "sessions":
+			os.Exit(sessions.Run(os.Args[2:]))
+```
+
+Add the import `"github.com/illegalstudio/lazyagent/internal/sessions"` to the import block.
+
+In `flag.Usage`, under the `Subcommands:` heading, after the `lazyagent search` lines, add:
+
+```
+  lazyagent sessions            List sessions for the current directory and reopen one
+  lazyagent sessions --help     Show sessions options (--agent, --json, --dir)
+```
+
+- [ ] **Step 6: Build and smoke-test**
+
+Run: `go build . && go vet ./... && go test ./internal/...`
+Expected: clean build, vet clean, all tests PASS.
+
+Run: `./lazyagent sessions --json --dir "$(pwd)" | head -20`
+Expected: a JSON array (possibly `[]`) — no picker, exit 0.
+
+Run: `./lazyagent sessions` (in a terminal, from the repo root)
+Expected: the picker renders with this repo's sessions; `q` exits with code 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/sessions/sessions.go internal/sessions/run_test.go main.go
+git commit -m "feat(sessions): add lazyagent sessions subcommand"
+```
+
+---
+
+### Task 6: documentation
+
+**Files:**
+- Create: `docs/usage/sessions.md`
+- Modify: `docs/README.md` (Usage section, ~line 30)
+- Modify: `docs/usage/cli.md` (subcommand list, ~line 10)
+- Modify: `README.md` (News section subcommand list, ~line 40)
+
+**Interfaces:**
+- Consumes: the final CLI behavior from Task 5 (flags, keys, exit codes).
+- Produces: user-facing docs; no code.
+
+- [ ] **Step 1: Write the docs page**
+
+Create `docs/usage/sessions.md`:
+
+````markdown
+---
+title: "Sessions for a directory"
+description: "List every recorded session for the current directory — across all agents — and reopen one."
+sidebar:
+  order: 3
+---
+
+`lazyagent sessions` lists every session whose working directory is the
+current directory (or a subdirectory of it), across all supported agents,
+newest first. Selecting a session resumes it with the originating agent's
+own CLI.
+
+## Synopsis
+
+```
+lazyagent sessions [--agent NAME] [--json] [--dir PATH]
+```
+
+## The picker
+
+```
+┌─ Sessions in ~/projects/foo (12) ───────────────────────────┐
+│ ▸ claude  2h ago      84  fix build embed placeholder       │
+│   codex   yesterday   31  webhook config models             │
+│   grok    3d ago      12  docs limits   (no resume)         │
+└─────────────────────────────────────────────────────────────┘
+  ↑/↓ move · enter open · c copy resume cmd · q quit
+```
+
+Each row shows the agent, relative last-activity time, message count, and a
+title (your custom session name when set, otherwise a preview of the first
+user message).
+
+| Key | Action |
+|-----|--------|
+| `↑`/`k`, `↓`/`j` | Move the cursor |
+| `enter` | Reopen the session in this terminal |
+| `c` | Copy the resume command to the clipboard |
+| `q` / `esc` / `ctrl+c` | Quit without opening |
+
+**Opening** runs the agent's resume command (e.g. `claude --resume <id>`)
+with this terminal attached, from the session's own working directory when
+it still exists. Agents lazyagent can exec directly: Claude Code, Codex,
+Amp, pi, and Kimi. For OpenCode, Kilo, and Cursor the resume command is
+copied to the clipboard instead; Grok has no resume command.
+
+## Flags
+
+| Flag | Type | Default | Summary |
+|------|------|---------|---------|
+| `--agent NAME` | string | `all` | Restrict the listing to one agent |
+| `--json` | bool | `false` | Print the list as JSON on stdout and exit (no picker) |
+| `--dir PATH` | string | current dir | List sessions for another directory |
+
+## JSON output
+
+`--json` emits an array (possibly `[]`), one object per session:
+
+```json
+[
+  {
+    "agent": "claude",
+    "session_id": "abc123",
+    "name": "fix-build",
+    "cwd": "/Users/me/projects/foo",
+    "last_activity": "2026-07-20T09:12:33Z",
+    "messages": 84,
+    "resume_command": "claude --resume abc123"
+  }
+]
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — including quitting the picker or an empty listing |
+| 1 | Runtime failure (discovery, resume exec, clipboard) |
+| 2 | Usage error (unknown `--agent`, `--dir` not a directory, no TTY without `--json`) |
+````
+
+- [ ] **Step 2: Link it from the indexes**
+
+In `docs/README.md`, in the **Usage** section after the Recipes line, add:
+
+```markdown
+- [Sessions for a directory](usage/sessions.md) — list every recorded session for a directory and reopen one, across all agents
+```
+
+In `docs/usage/cli.md`, in the subcommand list at the top, after the `lazyagent limits` line, add:
+
+```markdown
+- [`lazyagent sessions`](sessions.md) — list sessions for the current directory and reopen one
+```
+
+In the root `README.md`, in the **News** subcommand list (after the `lazyagent limits` bullet), add:
+
+```markdown
+- **[`lazyagent sessions`](docs/usage/sessions.md)** — list every session recorded for the current directory — across all agents — and reopen one with the originating agent's CLI. Interactive picker, `--json` for scripts.
+```
+
+- [ ] **Step 3: Verify links and build**
+
+Run: `go build . && go test ./internal/sessions/`
+Expected: still green (docs-only change; build proves no accidental code edits).
+
+Check: every relative link added above resolves to an existing file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/usage/sessions.md docs/README.md docs/usage/cli.md README.md
+git commit -m "docs(sessions): document the sessions subcommand"
+```

--- a/docs/superpowers/specs/2026-07-20-sessions-list-design.md
+++ b/docs/superpowers/specs/2026-07-20-sessions-list-design.md
@@ -1,0 +1,140 @@
+# `lazyagent sessions` — Design
+
+**Date:** 2026-07-20
+**Branch:** `feat/sessions-list`
+
+## Goal
+
+A new subcommand that lists every session that happened in the current
+directory — across all supported coding agents — and lets the user reopen one:
+
+```
+lazyagent sessions [--agent <name>] [--json] [--dir <path>]
+```
+
+The default invocation opens an interactive TUI picker; selecting a session
+resumes it in the current terminal with the originating agent's own CLI.
+
+## Decisions (confirmed)
+
+1. **Interactive picker** (bubbletea), not a numbered-prompt list and not a
+   flag-only list.
+2. **Directory matching: exact CWD + subdirectories.** A session belongs to the
+   listing if its recorded `CWD` equals the target directory or lives beneath
+   it. No whole-git-repo / linked-worktree expansion.
+3. **Show all agents, disable open where unavailable.** Sessions from agents
+   without an executable resume command still appear (it is a historical
+   listing); pressing enter on them shows a footer message and falls back to
+   copying the resume command to the clipboard when one exists.
+4. **Flags from day one:** `--agent`, `--json`, `--dir`.
+
+## Command surface
+
+- **Default:** TUI picker over sessions whose CWD matches the current
+  directory (or `--dir`), all agents, sorted by last activity descending.
+  Sidechain (sub-agent) sessions are excluded — they are noise in a
+  historical listing.
+- **`--agent claude|pi|opencode|kilo|cursor|codex|amp|grok|kimi`** — restrict
+  to one agent. Same validation and error message style as `main.go`'s
+  `--agent` flag. Default: all agents.
+- **`--dir <path>`** — list sessions for that directory instead of
+  `os.Getwd()`.
+- **`--json`** — print the filtered list as JSON on stdout and exit; no
+  picker. Per-session fields: `agent`, `session_id`, `name`, `cwd`,
+  `last_activity`, `messages`, `resume_command`. Empty result → `[]`.
+
+### Directory matching
+
+The target path is normalized with `filepath.Abs` + `filepath.Clean`; a
+symlink-resolved variant (`filepath.EvalSymlinks`) is also computed so that
+e.g. `/tmp` matches sessions recorded under `/private/tmp` on macOS. A session
+matches when its cleaned `CWD` equals either variant or starts with
+`variant + "/"` (prefix on path boundary — `/foo/bar` must not match
+`/foo/barbaz`).
+
+### Picker UX
+
+```
+┌─ Sessions in ~/lazyagent (12) ──────────────────────────────┐
+│ ▸ claude  2h ago      84  fix build embed placeholder       │
+│   codex   yesterday   31  webhook config models             │
+│   grok    3d ago      12  docs limits   (no resume)         │
+└─────────────────────────────────────────────────────────────┘
+  ↑/↓ move · enter open · c copy resume cmd · q quit
+```
+
+- Row = agent, relative last-activity time, message count, title (custom
+  session name when set, otherwise a truncated preview of the first user
+  message).
+- **enter** on an openable session (claude, codex, amp, pi, kimi — the set
+  `search` already executes): quit the picker, then run the resume command in
+  the current terminal with stdin/stdout/stderr attached and `cmd.Dir` set to
+  the session's CWD when that directory still exists (required by e.g.
+  `claude --resume`, which locates sessions by project dir).
+- **enter** on a non-openable session: footer message. If a resume command
+  string exists anyway (opencode, kilo, cursor) it is copied to the clipboard
+  via the existing `core` clipboard helper; for grok: "no resume available".
+- **c** copies the resume command to the clipboard for any row that has one.
+- **↑/↓** and **j/k** move; **q/esc/ctrl+c** quit.
+- No incremental filter/search inside the picker for now (YAGNI).
+
+## Architecture
+
+New package `internal/sessions`, following the existing subcommand pattern
+(`internal/<pkg>.Run(args []string) int` registered in `main.go`'s switch):
+
+```
+internal/sessions/
+  sessions.go   Run(): flag parsing (flag.NewFlagSet), discovery, dispatch
+  filter.go     target-path normalization, CWD matching, sidechain
+                exclusion, LastActivity-desc sorting — pure functions
+  picker.go     bubbletea model; returns (chosen session, action) —
+                open/copy/quit. Exec happens OUTSIDE the tea program,
+                after terminal restore.
+  json.go       JSON serialization of the filtered list
+```
+
+**Data flow:** `Run` → `core.LoadConfig()` → `core.BuildProvider(agent, cfg)`
+→ `DiscoverSessions()` → filter/sort → picker or JSON → on open: exec the
+resume command. Discovery has no recency cutoff, so the listing is the full
+on-disk history.
+
+**Targeted refactor (dedup, not gratuitous):** `search/run.go` currently
+duplicates the agent→resume-command mapping of `core.ResumeCommand` in its own
+switch. Add `core.ResumeArgv(agent, sessionID) []string` and make both
+`search` and `sessions` build their `exec.Cmd` from it. Semantics:
+
+- `ResumeArgv` returns argv **only for the executable set** (claude, codex,
+  amp, pi, kimi) — nil otherwise. "Openable" ⇔ `ResumeArgv != nil`.
+- `ResumeCommand` (display string) stays as-is, covering all agents that have
+  one. "Copyable" ⇔ `ResumeCommand != ""`.
+
+One source of truth for "how a session is reopened".
+
+**Registration:** new `case "sessions":` in `main.go`'s subcommand switch plus
+a line in the usage text.
+
+**No impact** on GUI/tray/API surfaces.
+
+## Error handling
+
+- Nonexistent `--dir` or unknown `--agent` → message on stderr, exit 2.
+- No sessions found → friendly message, exit 0 (`--json`: `[]`, exit 0).
+- Agent binary missing at exec time → error message (as `search` does),
+  exit 1.
+- Quitting the picker without opening → exit 0.
+
+## Testing
+
+- `filter_test.go` — CWD matching (exact, subdirectory, false prefix,
+  symlinked target), sidechain exclusion, sort order.
+- `json_test.go` — output shape, empty list.
+- `core/resume_test.go` — `ResumeArgv` coverage and argv ↔ display-string
+  consistency with `ResumeCommand`.
+- Picker stays thin: the selection→action mapping is a pure function with
+  tests; rendering is not tested.
+
+## Documentation
+
+- New dedicated page `docs/usage/sessions.md`, linked from the docs index.
+- Update the subcommand list in `README.md` and in `main.go`'s usage text.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -11,6 +11,7 @@ This page documents the root `lazyagent` command — the one you run to monitor 
 - [`lazyagent compact`](../maintenance/compact.md) — truncate bulky payloads in place
 - [`lazyagent search`](../maintenance/search.md) — search transcript-file agents with highlighted snippets
 - [`lazyagent limits`](../maintenance/limits.md) — show 5-hour, weekly, and monthly usage summary; add `--detailed` for pace
+- [`lazyagent sessions`](sessions.md) — list sessions for the current directory and reopen one
 
 ## Synopsis
 

--- a/docs/usage/sessions.md
+++ b/docs/usage/sessions.md
@@ -74,6 +74,6 @@ copied to the clipboard instead; Grok has no resume command.
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success — including quitting the picker or an empty listing |
-| 1 | Runtime failure (discovery, resume exec, clipboard) |
-| 2 | Usage error (unknown `--agent`, `--dir` not a directory, no TTY without `--json`) |
+| `0` | Success — including quitting the picker or an empty listing |
+| `1` | Runtime failure (discovery, resume exec, clipboard) |
+| `2` | Usage error (unknown `--agent`, `--dir` not a directory, no TTY without `--json`) |

--- a/docs/usage/sessions.md
+++ b/docs/usage/sessions.md
@@ -70,6 +70,32 @@ copied to the clipboard instead; Grok has no resume command.
 ]
 ```
 
+## Performance
+
+### Progressive picker
+
+When you run `lazyagent sessions`, the picker opens immediately and results stream in as each agent's discovery completes. A footer displays `loading agents… (done/total)` during discovery. Once all agents finish, the footer switches to the normal keybinding hint. If discovery finishes with zero sessions, the command prints "No sessions found in …" and exits.
+
+### Discovery cache
+
+The sessions command maintains persistent discovery caches under your system cache directory:
+
+- **macOS**: `~/Library/Caches/lazyagent/`
+- **Linux**: `~/.cache/lazyagent/`
+- **Other**: per-platform defaults from `$XDG_CACHE_HOME` or equivalent
+
+Cache files follow the pattern `discovery-<agent>.json` and `cwdindex-<agent>.json` (for example, `discovery-claude.json` and `cwdindex-claude.json` for Claude Code). Files are created with permission `0600`; the directory has `0700`.
+
+Cache contents are **advisory**: deleting the cache directory is always safe and won't break anything. On the next run, `lazyagent sessions` simply re-scans the session data and rebuilds the cache.
+
+Repeat runs typically complete in tens of milliseconds when caches are warm; only sessions from files that changed on disk are re-read.
+
+**Privacy note**: cache files may contain short transcript snippets (for example, the first message text for session preview). If you delete your entire cache directory, you also remove these cached snippets from disk.
+
+### Directory-scoped optimization
+
+The listing is optimized to discover sessions for the target directory without reading other directories' data, which speeds up results when your codebase spans multiple large directory hierarchies.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/usage/sessions.md
+++ b/docs/usage/sessions.md
@@ -1,0 +1,79 @@
+---
+title: "Sessions for a directory"
+description: "List every recorded session for the current directory — across all agents — and reopen one."
+sidebar:
+  order: 3
+---
+
+`lazyagent sessions` lists every session whose working directory is the
+current directory (or a subdirectory of it), across all supported agents,
+newest first. Selecting a session resumes it with the originating agent's
+own CLI.
+
+## Synopsis
+
+```
+lazyagent sessions [--agent NAME] [--json] [--dir PATH]
+```
+
+## The picker
+
+```
+┌─ Sessions in ~/projects/foo (12) ───────────────────────────┐
+│ ▸ claude  2h ago      84  fix build embed placeholder       │
+│   codex   yesterday   31  webhook config models             │
+│   grok    3d ago      12  docs limits   (no resume)         │
+└─────────────────────────────────────────────────────────────┘
+  ↑/↓ move · enter open · c copy resume cmd · q quit
+```
+
+Each row shows the agent, relative last-activity time, message count, and a
+title (your custom session name when set, otherwise a preview of the first
+user message).
+
+| Key | Action |
+|-----|--------|
+| `↑`/`k`, `↓`/`j` | Move the cursor |
+| `enter` | Reopen the session in this terminal |
+| `c` | Copy the resume command to the clipboard |
+| `q` / `esc` / `ctrl+c` | Quit without opening |
+
+**Opening** runs the agent's resume command (e.g. `claude --resume <id>`)
+with this terminal attached, from the session's own working directory when
+it still exists. Agents lazyagent can exec directly: Claude Code, Codex,
+Amp, pi, and Kimi. For OpenCode, Kilo, and Cursor the resume command is
+copied to the clipboard instead; Grok has no resume command.
+
+## Flags
+
+| Flag | Type | Default | Summary |
+|------|------|---------|---------|
+| `--agent NAME` | string | `all` | Restrict the listing to one agent |
+| `--json` | bool | `false` | Print the list as JSON on stdout and exit (no picker) |
+| `--dir PATH` | string | current dir | List sessions for another directory |
+
+## JSON output
+
+`--json` emits an array (possibly `[]`), one object per session:
+
+```json
+[
+  {
+    "agent": "claude",
+    "session_id": "abc123",
+    "name": "fix-build",
+    "cwd": "/Users/me/projects/foo",
+    "last_activity": "2026-07-20T09:12:33Z",
+    "messages": 84,
+    "resume_command": "claude --resume abc123"
+  }
+]
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — including quitting the picker or an empty listing |
+| 1 | Runtime failure (discovery, resume exec, clipboard) |
+| 2 | Usage error (unknown `--agent`, `--dir` not a directory, no TTY without `--json`) |

--- a/internal/api/playground.go
+++ b/internal/api/playground.go
@@ -82,8 +82,8 @@ const playgroundHTML = `<!DOCTYPE html>
 <div class="endpoint locked" data-locked="1" onclick="fetchEndpoint('/api/sessions')">
   <span class="method get">GET</span>
   <span class="path">/api/sessions</span>
-  <span class="path" style="color:#6c7086">?search=&amp;filter=</span>
-  <div class="desc">List all visible sessions (filterable by search query and activity type)</div>
+  <span class="path" style="color:#6c7086">?search=&amp;filter=&amp;dir=</span>
+  <div class="desc">List all visible sessions (filterable by search query, activity type, and directory)</div>
 </div>
 
 <div class="endpoint locked" data-locked="1" onclick="fetchEndpoint('/api/sessions/{id}')">

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -134,6 +134,14 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 	defer s.manager.Close()
 
+	// Deliberately synchronous (core.SessionManager.Reload, not the
+	// progressive ReloadStreaming the TUI/GUI use for their first load):
+	// API clients expect complete data as soon as the server starts
+	// accepting requests, not a snapshot that's still growing. A warm
+	// persisted cache (EnableCachePersistence above) already makes even
+	// this first reload fast in the common case, so there's little to gain
+	// from streaming it and a real cost (partial results reachable over
+	// HTTP) to avoid.
 	if err := s.manager.Reload(); err != nil {
 		log.Printf("Warning: initial reload failed: %v", err)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/apiauth"
 	"github.com/illegalstudio/lazyagent/internal/core"
 	"github.com/illegalstudio/lazyagent/internal/model"
+	"github.com/illegalstudio/lazyagent/internal/sessions"
 )
 
 // DefaultPort is the preferred port. If busy, the server tries sequential ports.
@@ -55,6 +56,9 @@ func New(host string, provider core.SessionProvider, bearerToken, authSalt strin
 	cfg := core.LoadConfig()
 	manager := core.NewSessionManager(cfg.WindowMinutes, provider)
 	manager.SetExcludeCWDSubstrings(cfg.ExcludeCWDSubstrings)
+	if dir, ok := sessions.ResolveCacheDir(); ok {
+		manager.EnableCachePersistence(dir)
+	}
 	if bus != nil {
 		manager.SetEventBus(bus)
 	}
@@ -128,7 +132,7 @@ func (s *Server) Run(ctx context.Context) error {
 	if err := s.manager.StartWatcher(); err != nil {
 		log.Printf("Warning: file watcher unavailable: %v", err)
 	}
-	defer s.manager.StopWatcher()
+	defer s.manager.Close()
 
 	if err := s.manager.Reload(); err != nil {
 		log.Printf("Warning: initial reload failed: %v", err)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -259,12 +260,59 @@ func (s *Server) handleGetSessions(w http.ResponseWriter, r *http.Request) {
 	filter := core.ActivityKind(r.URL.Query().Get("filter"))
 
 	visible := s.manager.QuerySessions(search, filter)
+
+	if dir := r.URL.Query().Get("dir"); dir != "" {
+		filtered, ok := s.filterByDir(w, visible, dir)
+		if !ok {
+			return // filterByDir already wrote the 400 response
+		}
+		visible = filtered
+	}
+
 	items := make([]SessionItem, 0, len(visible))
 	for _, sess := range visible {
 		activity := s.manager.ActivityFor(sess.SessionID)
 		items = append(items, s.buildSessionItem(sess, activity))
 	}
 	writeJSON(w, http.StatusOK, items)
+}
+
+// filterByDir narrows visible to the sessions whose CWD is dir or a
+// subdirectory of it, using the exact matching semantics `lazyagent
+// sessions` uses (core.DirMatchVariants/CWDMatchesDir — see task 15).
+//
+// Unlike the CLI, dir is not required to exist on this machine: the API may
+// serve a remote client (e.g. a mobile app) whose filesystem the server
+// never sees, so requiring os.Stat to succeed would make the filter
+// unusable for exactly the clients it's for. core.DirMatchVariants already
+// treats a failed symlink resolution as "no extra variant" rather than an
+// error, so a nonexistent dir just matches on its cleaned path.
+//
+// dir must be absolute, though: the API has no meaningful "current
+// directory" to resolve a relative path against on the caller's behalf, and
+// resolving one against the server process's own cwd would silently do the
+// wrong thing. That (and any other resolution failure) is reported as 400
+// with a JSON {"error": "..."} body, matching this handler file's existing
+// convention (see handleSetSessionName, handleGetSession).
+//
+// Returns ok=false when it has already written an error response.
+func (s *Server) filterByDir(w http.ResponseWriter, visible []*model.Session, dir string) (filtered []*model.Session, ok bool) {
+	if !filepath.IsAbs(dir) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "dir must be an absolute path"})
+		return nil, false
+	}
+	variants, err := core.DirMatchVariants(dir)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return nil, false
+	}
+	out := make([]*model.Session, 0, len(visible))
+	for _, sess := range visible {
+		if core.CWDMatchesDir(sess.CWD, variants) {
+			out = append(out, sess)
+		}
+	}
+	return out, true
 }
 
 func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -2,10 +2,14 @@ package api
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -58,6 +62,35 @@ func authedGet(t *testing.T, url string) *http.Response {
 	return resp
 }
 
+// fixedSessionProvider returns a fixed set of sessions, for tests that need
+// GET /api/sessions to have known CWDs to filter against.
+type fixedSessionProvider struct {
+	sessions []*model.Session
+}
+
+func (p fixedSessionProvider) DiscoverSessions() ([]*model.Session, error) { return p.sessions, nil }
+func (fixedSessionProvider) UseWatcher() bool                              { return false }
+func (fixedSessionProvider) RefreshInterval() time.Duration                { return 0 }
+func (fixedSessionProvider) WatchDirs() []string                           { return nil }
+
+// newTestServerWithSessions is like newTestServer but seeds the manager
+// with a fixed set of sessions via one synchronous Reload, so dir-filter
+// tests have known CWDs to filter against.
+func newTestServerWithSessions(t *testing.T, sessions []*model.Session) (*Server, *httptest.Server) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	srv, err := New(":0", fixedSessionProvider{sessions: sessions}, testToken, testSalt, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	srv.ln.Close()
+	if err := srv.manager.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	ts := httptest.NewServer(srv.srv.Handler)
+	return srv, ts
+}
+
 func TestGetSessions(t *testing.T) {
 	_, ts := newTestServer(t)
 	defer ts.Close()
@@ -73,6 +106,133 @@ func TestGetSessions(t *testing.T) {
 	var items []SessionItem
 	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
 		t.Fatalf("decode: %v", err)
+	}
+}
+
+// TestGetSessionsNoDirParamUnchanged is the binding "byte-identical"
+// requirement: an absent dir param and an explicit empty dir= must produce
+// exactly the same response as GET /api/sessions always has, unfiltered.
+func TestGetSessionsNoDirParamUnchanged(t *testing.T) {
+	base := t.TempDir()
+	now := time.Now()
+	sessions := []*model.Session{
+		{SessionID: "a", CWD: base, LastActivity: now},
+		{SessionID: "b", CWD: "/somewhere/else", LastActivity: now},
+	}
+	_, ts := newTestServerWithSessions(t, sessions)
+	defer ts.Close()
+
+	respNoParam := authedGet(t, ts.URL+"/api/sessions")
+	defer respNoParam.Body.Close()
+	bodyNoParam, err := io.ReadAll(respNoParam.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	respEmptyParam := authedGet(t, ts.URL+"/api/sessions?dir=")
+	defer respEmptyParam.Body.Close()
+	bodyEmptyParam, err := io.ReadAll(respEmptyParam.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(bodyNoParam, bodyEmptyParam) {
+		t.Fatalf("dir= (empty) must be byte-identical to no dir param at all\nno-param: %s\nempty:    %s", bodyNoParam, bodyEmptyParam)
+	}
+
+	var items []SessionItem
+	if err := json.Unmarshal(bodyNoParam, &items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2 (both sessions, unfiltered)", len(items))
+	}
+}
+
+// TestGetSessionsDirFilter covers exact match, subdirectory match, and
+// false-prefix exclusion — the same matching semantics as `lazyagent
+// sessions`.
+func TestGetSessionsDirFilter(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	now := time.Now()
+	sessions := []*model.Session{
+		{SessionID: "exact", CWD: base, LastActivity: now},
+		{SessionID: "subdir", CWD: sub, LastActivity: now},
+		{SessionID: "false-prefix", CWD: base + "extra", LastActivity: now},
+		{SessionID: "unrelated", CWD: "/somewhere/else", LastActivity: now},
+	}
+	_, ts := newTestServerWithSessions(t, sessions)
+	defer ts.Close()
+
+	resp := authedGet(t, ts.URL+"/api/sessions?dir="+url.QueryEscape(base))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var items []SessionItem
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make(map[string]bool, len(items))
+	for _, it := range items {
+		got[it.SessionID] = true
+	}
+	if len(items) != 2 || !got["exact"] || !got["subdir"] {
+		t.Fatalf("dir filter returned %v (%d items), want exactly [exact subdir]", got, len(items))
+	}
+}
+
+// TestGetSessionsDirFilterRejectsRelativePath: the API has no meaningful
+// "current directory" for a remote client, so a non-absolute dir is a 400,
+// matching the existing error convention (JSON body with an "error" key).
+func TestGetSessionsDirFilterRejectsRelativePath(t *testing.T) {
+	_, ts := newTestServer(t)
+	defer ts.Close()
+
+	resp := authedGet(t, ts.URL+"/api/sessions?dir=relative/path")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", ct)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["error"] == "" {
+		t.Fatal("expected a non-empty \"error\" field in the 400 body")
+	}
+}
+
+// TestGetSessionsDirFilterNonexistentDirMatchesCleanedPath is the API
+// relaxation vs. the CLI: the API may serve remote clients, so a dir that
+// doesn't exist on this machine's disk is not an error — it matches on the
+// cleaned path alone (no symlink resolution possible, no existence check).
+func TestGetSessionsDirFilterNonexistentDirMatchesCleanedPath(t *testing.T) {
+	base := t.TempDir()
+	nonexistent := filepath.Join(base, "does-not-exist")
+	now := time.Now()
+	sessions := []*model.Session{
+		{SessionID: "target", CWD: nonexistent, LastActivity: now},
+		{SessionID: "other", CWD: base, LastActivity: now},
+	}
+	_, ts := newTestServerWithSessions(t, sessions)
+	defer ts.Close()
+
+	resp := authedGet(t, ts.URL+"/api/sessions?dir="+url.QueryEscape(nonexistent))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no existence requirement)", resp.StatusCode)
+	}
+	var items []SessionItem
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(items) != 1 || items[0].SessionID != "target" {
+		t.Fatalf("got %d items (%v), want exactly [target]", len(items), items)
 	}
 }
 

--- a/internal/claude/cwdindex.go
+++ b/internal/claude/cwdindex.go
@@ -26,11 +26,16 @@ const cwdIndexFormatVersion = 1
 // size change, for uniformity with codex's index and as a defensive
 // safety net (see shouldParseForCWD's doc comment).
 //
-// Only files whose cwd conclusively does NOT match a query ever populate
-// this index — see discoverInDir's cwdMatch != nil && cached == nil guard,
-// the only place it's consulted. Files that get parsed end up in
-// model.SessionCache instead, whose persisted full-hit fast path already
-// avoids re-reading them.
+// An entry is populated for every file that reaches the prefilter check at
+// all — see discoverInDir's cwdMatch != nil && cached == nil guard, the
+// only place it's consulted — regardless of whether that file ends up
+// skipped or parsed (shouldParseForCWDIndexed always resolves headCWD
+// before deciding either way). The index's ongoing value is concentrated in
+// the skipped files, though: a parsed file also lands in model.SessionCache,
+// whose persisted full-hit fast path takes over for it on every later run
+// without ever consulting this index again, whereas a skipped file never
+// enters SessionCache at all and so keeps needing this index's answer on
+// every run.
 type CWDIndex struct {
 	mu      sync.Mutex
 	entries map[string]cwdIndexEntry
@@ -47,6 +52,22 @@ type cwdIndexEntry struct {
 // NewCWDIndex creates an empty CWDIndex.
 func NewCWDIndex() *CWDIndex {
 	return &CWDIndex{entries: make(map[string]cwdIndexEntry)}
+}
+
+// Prune removes index entries for files no longer present in the seen set,
+// mirroring model.SessionCache.Prune. Without this, a session file removed
+// from ~/.claude/projects between runs would leave its entry in the index
+// forever, since nothing else ever visits that path again to overwrite or
+// expire it. discoverInDir already builds the seen set for cache.Prune; the
+// same set is reused here.
+func (idx *CWDIndex) Prune(seen map[string]struct{}) {
+	idx.mu.Lock()
+	for k := range idx.entries {
+		if _, ok := seen[k]; !ok {
+			delete(idx.entries, k)
+		}
+	}
+	idx.mu.Unlock()
 }
 
 // headCWDIndexed returns the same (cwd, ok) headCWD(path) would for path's

--- a/internal/claude/cwdindex.go
+++ b/internal/claude/cwdindex.go
@@ -1,0 +1,122 @@
+package claude
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/diskcache"
+)
+
+// cwdIndexFormatVersion is bumped whenever the persisted shape changes in a
+// backward-incompatible way.
+const cwdIndexFormatVersion = 1
+
+// CWDIndex memoizes headCWD results per claude session JSONL file, keyed by
+// path with an (mtime, size) validity check, so that once a file's
+// head-scan outcome is known for its CURRENT content, repeated discovery
+// calls — including calls from a later process, if the index is persisted
+// and reloaded — never re-read the file to answer the same question again.
+//
+// headCWD is a pure function of a file's content (it takes no matcher), so
+// memoizing it is always sound to reuse for ANY future cwdMatch, regardless
+// of which matcher originally triggered the scan. Unlike codex, claude's
+// session.CWD is first-cwd-wins (see scanEntries in jsonl.go) and therefore
+// stable across appends — but entries are still invalidated on ANY mtime or
+// size change, for uniformity with codex's index and as a defensive
+// safety net (see shouldParseForCWD's doc comment).
+//
+// Only files whose cwd conclusively does NOT match a query ever populate
+// this index — see discoverInDir's cwdMatch != nil && cached == nil guard,
+// the only place it's consulted. Files that get parsed end up in
+// model.SessionCache instead, whose persisted full-hit fast path already
+// avoids re-reading them.
+type CWDIndex struct {
+	mu      sync.Mutex
+	entries map[string]cwdIndexEntry
+}
+
+type cwdIndexEntry struct {
+	mtime time.Time
+	size  int64
+
+	headCWD string
+	headOK  bool
+}
+
+// NewCWDIndex creates an empty CWDIndex.
+func NewCWDIndex() *CWDIndex {
+	return &CWDIndex{entries: make(map[string]cwdIndexEntry)}
+}
+
+// headCWDIndexed returns the same (cwd, ok) headCWD(path) would for path's
+// current content, using a cached result when the index already holds a
+// valid (mtime/size-matching) entry, and computing + storing it fresh
+// otherwise.
+func (idx *CWDIndex) headCWDIndexed(path string, mtime time.Time, size int64) (cwd string, ok bool) {
+	idx.mu.Lock()
+	if e, found := idx.entries[path]; found && e.mtime.Equal(mtime) && e.size == size {
+		idx.mu.Unlock()
+		return e.headCWD, e.headOK
+	}
+	idx.mu.Unlock()
+
+	cwd, ok = headCWD(path)
+
+	idx.mu.Lock()
+	idx.entries[path] = cwdIndexEntry{mtime: mtime, size: size, headCWD: cwd, headOK: ok}
+	idx.mu.Unlock()
+	return cwd, ok
+}
+
+// persistedCWDEntry is the on-disk shape of one CWDIndex entry.
+type persistedCWDEntry struct {
+	MTime   time.Time `json:"mtime"`
+	Size    int64     `json:"size"`
+	HeadCWD string    `json:"headCwd"`
+	HeadOK  bool      `json:"headOk"`
+}
+
+type persistedCWDIndex struct {
+	FormatVersion int                          `json:"formatVersion"`
+	Entries       map[string]persistedCWDEntry `json:"entries"`
+}
+
+// SaveTo atomically writes the index to path (temp file + rename), 0600
+// permissions.
+func (idx *CWDIndex) SaveTo(path string) error {
+	idx.mu.Lock()
+	snapshot := persistedCWDIndex{
+		FormatVersion: cwdIndexFormatVersion,
+		Entries:       make(map[string]persistedCWDEntry, len(idx.entries)),
+	}
+	for k, e := range idx.entries {
+		snapshot.Entries[k] = persistedCWDEntry{MTime: e.mtime, Size: e.size, HeadCWD: e.headCWD, HeadOK: e.headOK}
+	}
+	idx.mu.Unlock()
+
+	return diskcache.AtomicWriteJSON(path, snapshot)
+}
+
+// LoadFrom best-effort loads a persisted snapshot from path and merges its
+// entries into the index. Any file-level problem (missing/unreadable file,
+// malformed JSON, format version mismatch) is reported via the returned
+// error and leaves the index completely untouched — callers on the
+// discovery path are expected to ignore the error and continue with a cold
+// (but valid) index.
+func (idx *CWDIndex) LoadFrom(path string) error {
+	var snapshot persistedCWDIndex
+	if err := diskcache.ReadJSON(path, &snapshot); err != nil {
+		return err
+	}
+	if snapshot.FormatVersion != cwdIndexFormatVersion {
+		return fmt.Errorf("cwd index %s: format version %d, want %d", path, snapshot.FormatVersion, cwdIndexFormatVersion)
+	}
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for k, e := range snapshot.Entries {
+		idx.entries[k] = cwdIndexEntry{mtime: e.MTime, size: e.Size, headCWD: e.HeadCWD, headOK: e.HeadOK}
+	}
+	return nil
+}

--- a/internal/claude/cwdindex_test.go
+++ b/internal/claude/cwdindex_test.go
@@ -1,0 +1,315 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func claudeSessionPaths(sessions []*model.Session) map[string]bool {
+	m := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		m[s.JSONLPath] = true
+	}
+	return m
+}
+
+// TestCWDIndex_HeadHitAvoidsReread corrupts the file on disk after priming
+// the index (preserving its exact mtime/size), then confirms
+// headCWDIndexed still returns the original result -- proof it came from
+// the index, not a fresh read of the now-corrupted file. Mirrors codex's
+// equivalent test and the existing
+// TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile
+// technique used elsewhere in this package.
+func TestCWDIndex_HeadHitAvoidsReread(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	cwd, ok := idx.headCWDIndexed(path, mtime, size)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("priming call: headCWDIndexed = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+
+	garbage := make([]byte, size)
+	for i := range garbage {
+		garbage[i] = 'x'
+	}
+	if err := os.WriteFile(path, garbage, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, ok = idx.headCWDIndexed(path, mtime, size)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("cached call after corruption: headCWDIndexed = (%q, %v), want (/tmp/project-a, true) from the index, not a re-read", cwd, ok)
+	}
+}
+
+// TestCWDIndex_InvalidatedOnChange confirms a changed file (different mtime
+// and size) is never trusted from a stale entry -- the brief's "use the
+// same invalidate-on-change rule for uniformity and safety" requirement for
+// claude, even though first-cwd-wins is technically stable across appends.
+func TestCWDIndex_InvalidatedOnChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime1, size1 := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	cwd, ok := idx.headCWDIndexed(path, mtime1, size1)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("first scan = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+
+	// Replace the file with new (different-length) content under a new cwd.
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-b")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info2, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime2, size2 := info2.ModTime(), info2.Size()
+
+	cwd, ok = idx.headCWDIndexed(path, mtime2, size2)
+	if !ok || cwd != "/tmp/project-b" {
+		t.Fatalf("after replace, headCWDIndexed = (%q, %v), want (/tmp/project-b, true) -- the stale project-a entry must not be trusted", cwd, ok)
+	}
+}
+
+func TestCWDIndex_CachesConservativeNotOK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(noCWDLine(1)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	_, ok := idx.headCWDIndexed(path, mtime, size)
+	if ok {
+		t.Fatal("headCWDIndexed ok = true, want false (no cwd in window)")
+	}
+	_, ok = idx.headCWDIndexed(path, mtime, size)
+	if ok {
+		t.Fatal("cached headCWDIndexed ok = true, want false -- a cached ok=false must not be upgraded")
+	}
+}
+
+// --- shouldParseForCWDIndexed must match shouldParseForCWD exactly ---
+
+func TestShouldParseForCWDIndexed_NilIndexMatchesUnindexed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	match := func(cwd string) bool { return cwd == "/tmp/project-a" }
+
+	want := shouldParseForCWD(path, match)
+	got := shouldParseForCWDIndexed(path, match, nil)
+	if got != want {
+		t.Fatalf("shouldParseForCWDIndexed(nil idx) = %v, want %v", got, want)
+	}
+}
+
+func TestShouldParseForCWDIndexed_ColdEqualsUnindexed(t *testing.T) {
+	dir := t.TempDir()
+
+	headMatches := filepath.Join(dir, "a.jsonl")
+	os.WriteFile(headMatches, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644)
+	headRulesOut := filepath.Join(dir, "b.jsonl")
+	os.WriteFile(headRulesOut, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644)
+	noCWDInWindow := filepath.Join(dir, "c.jsonl")
+	os.WriteFile(noCWDInWindow, []byte(noCWDLine(1)+"\n"), 0o644)
+
+	match := func(cwd string) bool { return cwd == "/tmp/project-b" }
+
+	for _, path := range []string{headMatches, headRulesOut, noCWDInWindow} {
+		want := shouldParseForCWD(path, match)
+		got := shouldParseForCWDIndexed(path, match, NewCWDIndex())
+		if got != want {
+			t.Errorf("path %s: shouldParseForCWDIndexed(cold idx) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestShouldParseForCWDIndexed_WarmEqualsUnindexed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	match := func(cwd string) bool { return cwd == "/tmp/project-b" }
+
+	idx := NewCWDIndex()
+	want := shouldParseForCWD(path, match)
+	_ = shouldParseForCWDIndexed(path, match, idx) // prime
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+	garbage := make([]byte, size)
+	for i := range garbage {
+		garbage[i] = 'x'
+	}
+	if err := os.WriteFile(path, garbage, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	got := shouldParseForCWDIndexed(path, match, idx)
+	if got != want {
+		t.Fatalf("warm shouldParseForCWDIndexed (file corrupted, same mtime/size) = %v, want %v", got, want)
+	}
+}
+
+// --- persistence ---
+
+func TestCWDIndex_SaveLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-claude.json")
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	idx.headCWDIndexed(path, mtime, size)
+	if err := idx.SaveTo(cachePath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded := NewCWDIndex()
+	if err := loaded.LoadFrom(cachePath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, ok := loaded.headCWDIndexed(path, mtime, size)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("loaded headCWDIndexed = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+}
+
+func TestCWDIndex_SaveTo_FilePermissions0600(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-claude.json")
+
+	idx := NewCWDIndex()
+	if err := idx.SaveTo(cachePath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+	info, err := os.Stat(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("perms = %o, want 0600", perm)
+	}
+}
+
+func TestCWDIndex_LoadFrom_CorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-claude.json")
+	if err := os.WriteFile(cachePath, []byte("{not valid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewCWDIndex()
+	if err := idx.LoadFrom(cachePath); err == nil {
+		t.Fatal("LoadFrom corrupt JSON: want error, got nil")
+	}
+}
+
+func TestCWDIndex_LoadFrom_WrongFormatVersion(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-claude.json")
+	if err := os.WriteFile(cachePath, []byte(`{"formatVersion":999,"entries":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewCWDIndex()
+	if err := idx.LoadFrom(cachePath); err == nil {
+		t.Fatal("LoadFrom wrong format version: want error, got nil")
+	}
+}
+
+// --- discovery-level equivalence with a persisted+reloaded CWDIndex ---
+
+func TestDiscoverSessionsFilteredIndexed_PersistedIndexEquivalentToCold(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	writeClaudeSession(t, projectsDir, "dir-a", "sess-a", []string{cwdLine("/tmp/project-a")})
+	writeClaudeSession(t, projectsDir, "dir-b", "sess-b", []string{cwdLine("/tmp/project-b")})
+	writeClaudeSession(t, projectsDir, "dir-c", "sess-c", []string{noCWDLine(1)})
+
+	match := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	cwdIndexPath := filepath.Join(t.TempDir(), "cwdindex-claude.json")
+
+	cold, err := DiscoverSessionsFilteredIndexed(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match, nil)
+	if err != nil {
+		t.Fatalf("cold discovery: %v", err)
+	}
+
+	firstIdx := NewCWDIndex()
+	if _, err := DiscoverSessionsFilteredIndexed(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match, firstIdx); err != nil {
+		t.Fatalf("priming discovery: %v", err)
+	}
+	if err := firstIdx.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	reloadedIdx := NewCWDIndex()
+	if err := reloadedIdx.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	warm, err := DiscoverSessionsFilteredIndexed(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match, reloadedIdx)
+	if err != nil {
+		t.Fatalf("warm discovery: %v", err)
+	}
+
+	coldPaths := claudeSessionPaths(cold)
+	warmPaths := claudeSessionPaths(warm)
+	if len(coldPaths) != len(warmPaths) {
+		t.Fatalf("warm session count = %d, want %d (cold)", len(warmPaths), len(coldPaths))
+	}
+	for p := range coldPaths {
+		if !warmPaths[p] {
+			t.Errorf("warm discovery missing %s, present in cold discovery", p)
+		}
+	}
+}

--- a/internal/claude/cwdindex_test.go
+++ b/internal/claude/cwdindex_test.go
@@ -1,6 +1,7 @@
 package claude
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -269,6 +270,52 @@ func TestCWDIndex_LoadFrom_WrongFormatVersion(t *testing.T) {
 	}
 }
 
+// TestCWDIndex_PruneRemovesDeletedFileEntries covers a full discovery+save
+// cycle: a file that gets skipped (non-matching cwd) populates a cwd-index
+// entry; once that file is deleted, the next discovery pass must prune its
+// now-stale entry so a save afterward doesn't persist it forever.
+func TestCWDIndex_PruneRemovesDeletedFileEntries(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	pathToDelete := writeClaudeSession(t, projectsDir, "dir-prune", "sess-prune", []string{cwdLine("/tmp/other")})
+	cwdIndexPath := filepath.Join(t.TempDir(), "cwdindex-claude.json")
+	match := func(cwd string) bool { return cwd == "/tmp/match" }
+
+	cwdIdx := NewCWDIndex()
+	if _, err := DiscoverSessionsFilteredIndexed(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match, cwdIdx); err != nil {
+		t.Fatalf("run1: %v", err)
+	}
+	if err := cwdIdx.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	if err := os.Remove(pathToDelete); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := NewCWDIndex()
+	if err := reloaded.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if _, ok := reloaded.entries[pathToDelete]; !ok {
+		t.Fatal("expected the reloaded index to still have an entry for the (now deleted) file before this run's discovery prunes it")
+	}
+
+	if _, err := DiscoverSessionsFilteredIndexed(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match, reloaded); err != nil {
+		t.Fatalf("run2 (over the mutated tree, file deleted): %v", err)
+	}
+	if err := reloaded.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo after prune: %v", err)
+	}
+
+	final := NewCWDIndex()
+	if err := final.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom final: %v", err)
+	}
+	if _, ok := final.entries[pathToDelete]; ok {
+		t.Fatal("expected the deleted file's entry to be pruned from the persisted index after the discovery+save cycle")
+	}
+}
+
 // --- discovery-level equivalence with a persisted+reloaded CWDIndex ---
 
 func TestDiscoverSessionsFilteredIndexed_PersistedIndexEquivalentToCold(t *testing.T) {
@@ -314,22 +361,111 @@ func TestDiscoverSessionsFilteredIndexed_PersistedIndexEquivalentToCold(t *testi
 	}
 }
 
-func claudeAssertSameSessionSet(t *testing.T, label string, cold, got []*model.Session) {
+// claudeErrorfer is the minimal subset of *testing.T that claudeSessionDigest
+// and claudeAssertSameSessionSet need. It exists (instead of taking
+// *testing.T directly) so
+// TestClaudeAssertSameSessionSet_CatchesStaleContentAtSamePath can pass a
+// non-*testing.T fake that records a failure without that failure
+// propagating to the test currently running claudeAssertSameSessionSet's
+// own test — testing.TB can't be used for this, since it has an unexported
+// method that only the standard library's *testing.T/B/F can implement.
+// Every real call site passes a plain *testing.T, which satisfies this
+// smaller interface implicitly.
+type claudeErrorfer interface {
+	Helper()
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// claudeSessionDigest renders s as JSON for content comparison. Session has
+// no fields populated from wall-clock time (every timestamp on it comes
+// from parsed JSONL content via time.Parse, never time.Now()), so there are
+// no legitimately-nondeterministic fields to normalize before comparing two
+// independently-produced sessions for the same file — a byte-different
+// digest here always means a genuine content difference, not incidental
+// representation noise (e.g. time.Time's internal monotonic-reading
+// representation, which reflect.DeepEqual is sensitive to but JSON
+// marshaling normalizes away, since it only ever encodes the RFC3339Nano
+// wall-clock value).
+func claudeSessionDigest(t claudeErrorfer, s *model.Session) string {
 	t.Helper()
-	coldPaths := claudeSessionPaths(cold)
-	gotPaths := claudeSessionPaths(got)
-	if len(coldPaths) != len(gotPaths) {
-		t.Errorf("%s: session count = %d, want %d", label, len(gotPaths), len(coldPaths))
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal session for digest: %v", err)
 	}
-	for p := range coldPaths {
-		if !gotPaths[p] {
+	return string(data)
+}
+
+// claudeAssertSameSessionSet fails t if cold and got don't contain sessions
+// with the exact same JSONLPaths AND, for each shared path, byte-identical
+// content. A path-only comparison would pass a stale-content-same-path
+// regression (a persisted entry served for a file whose content actually
+// changed) undetected, since both sides would agree on which files are
+// present without ever checking what was returned for them.
+func claudeAssertSameSessionSet(t claudeErrorfer, label string, cold, got []*model.Session) {
+	t.Helper()
+	coldByPath := make(map[string]*model.Session, len(cold))
+	for _, s := range cold {
+		coldByPath[s.JSONLPath] = s
+	}
+	gotByPath := make(map[string]*model.Session, len(got))
+	for _, s := range got {
+		gotByPath[s.JSONLPath] = s
+	}
+	if len(coldByPath) != len(gotByPath) {
+		t.Errorf("%s: session count = %d, want %d", label, len(gotByPath), len(coldByPath))
+	}
+	for p, cs := range coldByPath {
+		gs, ok := gotByPath[p]
+		if !ok {
 			t.Errorf("%s: missing %s (present in cold discovery)", label, p)
+			continue
+		}
+		if wantDigest, gotDigest := claudeSessionDigest(t, cs), claudeSessionDigest(t, gs); wantDigest != gotDigest {
+			t.Errorf("%s: session content for %s differs from cold discovery\ncold: %s\ngot:  %s", label, p, wantDigest, gotDigest)
 		}
 	}
-	for p := range gotPaths {
-		if !coldPaths[p] {
+	for p := range gotByPath {
+		if _, ok := coldByPath[p]; !ok {
 			t.Errorf("%s: unexpected extra %s (absent from cold discovery)", label, p)
 		}
+	}
+}
+
+// claudeFakeErrorfer records whether Errorf/Fatalf was called, without
+// failing the test actually running -- used only to verify that
+// claudeAssertSameSessionSet itself reports a failure for a given input.
+type claudeFakeErrorfer struct {
+	failed bool
+}
+
+func (f *claudeFakeErrorfer) Helper()                           {}
+func (f *claudeFakeErrorfer) Errorf(format string, args ...any) { f.failed = true }
+func (f *claudeFakeErrorfer) Fatalf(format string, args ...any) { f.failed = true }
+
+// TestClaudeAssertSameSessionSet_CatchesStaleContentAtSamePath is claude's
+// counterpart to codex's TestAssertSameSessionSet_CatchesStaleContentAtSamePath
+// -- proves the content check added to claudeAssertSameSessionSet actually
+// catches a same-path-but-different-content regression, which a
+// JSONLPath-set-only comparison would miss entirely.
+func TestClaudeAssertSameSessionSet_CatchesStaleContentAtSamePath(t *testing.T) {
+	cold := []*model.Session{
+		{JSONLPath: "/tmp/x.jsonl", SessionID: "s1", CWD: "/tmp/match", TotalMessages: 5},
+	}
+	stale := []*model.Session{
+		{JSONLPath: "/tmp/x.jsonl", SessionID: "s1-STALE", CWD: "/tmp/match", TotalMessages: 1},
+	}
+
+	fake := &claudeFakeErrorfer{}
+	claudeAssertSameSessionSet(fake, "simulated", cold, stale)
+	if !fake.failed {
+		t.Fatal("claudeAssertSameSessionSet did not detect a same-path, different-content regression -- the content-digest check added to it is not actually catching this bug class")
+	}
+
+	fakeOK := &claudeFakeErrorfer{}
+	claudeAssertSameSessionSet(fakeOK, "simulated", cold, cold)
+	if fakeOK.failed {
+		t.Fatal("claudeAssertSameSessionSet flagged identical content as a mismatch")
 	}
 }
 

--- a/internal/claude/cwdindex_test.go
+++ b/internal/claude/cwdindex_test.go
@@ -313,3 +313,180 @@ func TestDiscoverSessionsFilteredIndexed_PersistedIndexEquivalentToCold(t *testi
 		}
 	}
 }
+
+func claudeAssertSameSessionSet(t *testing.T, label string, cold, got []*model.Session) {
+	t.Helper()
+	coldPaths := claudeSessionPaths(cold)
+	gotPaths := claudeSessionPaths(got)
+	if len(coldPaths) != len(gotPaths) {
+		t.Errorf("%s: session count = %d, want %d", label, len(gotPaths), len(coldPaths))
+	}
+	for p := range coldPaths {
+		if !gotPaths[p] {
+			t.Errorf("%s: missing %s (present in cold discovery)", label, p)
+		}
+	}
+	for p := range gotPaths {
+		if !coldPaths[p] {
+			t.Errorf("%s: unexpected extra %s (absent from cold discovery)", label, p)
+		}
+	}
+}
+
+// TestDiscoverSessionsFilteredIndexed_ComprehensiveEquivalence is claude's
+// counterpart to codex's test of the same name: discovery using a
+// persisted-and-reloaded SessionCache + CWDIndex must match cold discovery
+// across the brief's required fixture-tree scenarios: unchanged files, a
+// truncated/replaced file with the same mtime but a different size, a
+// truncated/replaced file with a different mtime, a deleted file, a
+// corrupted persisted cache/index JSON, and a wrong-formatVersion persisted
+// cache/index JSON. (The "appended file changes the answer" scenario is
+// codex-specific per the brief -- claude's headCWD scans forward from the
+// start of the file, so an append can never change what it finds; see
+// shouldParseForCWD's doc comment. Truncation/replacement is what actually
+// exercises claude's invalidate-on-change rule.)
+func TestDiscoverSessionsFilteredIndexed_ComprehensiveEquivalence(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	match := func(cwd string) bool { return cwd == "/tmp/match" }
+
+	paths := map[string]string{
+		"unchanged_match":    writeClaudeSession(t, projectsDir, "dir-unchanged-match", "sess-unchanged-match", []string{cwdLine("/tmp/match")}),
+		"unchanged_nonmatch": writeClaudeSession(t, projectsDir, "dir-unchanged-nonmatch", "sess-unchanged-nonmatch", []string{cwdLine("/tmp/other")}),
+		// The original cwd here is deliberately a different length than
+		// "/tmp/match" (below), so the mutation genuinely changes the
+		// file's size, not just its bytes -- a same-length replacement
+		// would accidentally collide on size and fail to exercise the
+		// "same mtime, different size" invalidation path at all.
+		"truncated_same_mtime": writeClaudeSession(t, projectsDir, "dir-trunc-same", "sess-trunc-same", []string{cwdLine("/tmp/some-other-much-longer-directory-name")}),
+		"truncated_diff_mtime": writeClaudeSession(t, projectsDir, "dir-trunc-diff", "sess-trunc-diff", []string{cwdLine("/tmp/some-other-much-longer-directory-name")}),
+		"deleted":              writeClaudeSession(t, projectsDir, "dir-deleted", "sess-deleted", []string{cwdLine("/tmp/other")}),
+	}
+
+	cache := model.NewSessionCache()
+	cwdIdx := NewCWDIndex()
+	if _, err := DiscoverSessionsFilteredIndexed(cache, NewDesktopCache(), []string{configDir}, match, cwdIdx); err != nil {
+		t.Fatalf("run1: %v", err)
+	}
+	cacheDir := t.TempDir()
+	discoveryPath := filepath.Join(cacheDir, "discovery-claude.json")
+	cwdIndexPath := filepath.Join(cacheDir, "cwdindex-claude.json")
+	if err := cache.SaveTo(discoveryPath); err != nil {
+		t.Fatalf("SaveTo cache: %v", err)
+	}
+	if err := cwdIdx.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo cwdIdx: %v", err)
+	}
+
+	infoSame, err := os.Stat(paths["truncated_same_mtime"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	origMtime := infoSame.ModTime()
+	if err := os.WriteFile(paths["truncated_same_mtime"], []byte(cwdLine("/tmp/match")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(paths["truncated_same_mtime"], origMtime, origMtime); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(paths["truncated_diff_mtime"], []byte(cwdLine("/tmp/match")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(paths["deleted"]); err != nil {
+		t.Fatal(err)
+	}
+
+	cold, err := DiscoverSessionsFilteredIndexed(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match, nil)
+	if err != nil {
+		t.Fatalf("cold run: %v", err)
+	}
+
+	reloadedCache := model.NewSessionCache()
+	if err := reloadedCache.LoadFrom(discoveryPath); err != nil {
+		t.Fatalf("LoadFrom cache: %v", err)
+	}
+	reloadedIdx := NewCWDIndex()
+	if err := reloadedIdx.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom cwdIdx: %v", err)
+	}
+	warm, err := DiscoverSessionsFilteredIndexed(reloadedCache, NewDesktopCache(), []string{configDir}, match, reloadedIdx)
+	if err != nil {
+		t.Fatalf("warm run: %v", err)
+	}
+
+	claudeAssertSameSessionSet(t, "warm-vs-cold after mutations", cold, warm)
+
+	warmPaths := claudeSessionPaths(warm)
+	if !warmPaths[paths["truncated_same_mtime"]] {
+		t.Errorf("truncated (same mtime, different size) file missing from warm results")
+	}
+	if !warmPaths[paths["truncated_diff_mtime"]] {
+		t.Errorf("truncated (different mtime) file missing from warm results")
+	}
+	if warmPaths[paths["deleted"]] {
+		t.Errorf("deleted file unexpectedly present in warm results")
+	}
+
+	corruptionCases := []struct {
+		name string
+		path string
+	}{
+		{"corrupted_cache_json", discoveryPath},
+		{"corrupted_cwdindex_json", cwdIndexPath},
+	}
+	for _, tc := range corruptionCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(tc.path, []byte("{not valid json"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			c := model.NewSessionCache()
+			idx := NewCWDIndex()
+			var loadErr error
+			if tc.path == discoveryPath {
+				loadErr = c.LoadFrom(discoveryPath)
+			} else {
+				loadErr = idx.LoadFrom(cwdIndexPath)
+			}
+			if loadErr == nil {
+				t.Fatal("LoadFrom corrupted JSON: want error, got nil")
+			}
+			got, err := DiscoverSessionsFilteredIndexed(c, NewDesktopCache(), []string{configDir}, match, idx)
+			if err != nil {
+				t.Fatalf("discovery: %v", err)
+			}
+			claudeAssertSameSessionSet(t, tc.name, cold, got)
+		})
+	}
+
+	versionCases := []struct {
+		name string
+		path string
+	}{
+		{"wrong_format_version_cache", discoveryPath},
+		{"wrong_format_version_cwdindex", cwdIndexPath},
+	}
+	for _, tc := range versionCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(tc.path, []byte(`{"formatVersion":999,"entries":{}}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			c := model.NewSessionCache()
+			idx := NewCWDIndex()
+			var loadErr error
+			if tc.path == discoveryPath {
+				loadErr = c.LoadFrom(discoveryPath)
+			} else {
+				loadErr = idx.LoadFrom(cwdIndexPath)
+			}
+			if loadErr == nil {
+				t.Fatal("LoadFrom wrong format version: want error, got nil")
+			}
+			got, err := DiscoverSessionsFilteredIndexed(c, NewDesktopCache(), []string{configDir}, match, idx)
+			if err != nil {
+				t.Fatalf("discovery: %v", err)
+			}
+			claudeAssertSameSessionSet(t, tc.name, cold, got)
+		})
+	}
+}

--- a/internal/claude/process.go
+++ b/internal/claude/process.go
@@ -126,6 +126,17 @@ func DiscoverSessions(cache *model.SessionCache, desktopCache *DesktopCache, con
 // cwdMatch may be nil, in which case every session matches (equivalent to
 // DiscoverSessions).
 func DiscoverSessionsFiltered(cache *model.SessionCache, desktopCache *DesktopCache, configDirs []string, cwdMatch func(string) bool) ([]*model.Session, error) {
+	return DiscoverSessionsFilteredIndexed(cache, desktopCache, configDirs, cwdMatch, nil)
+}
+
+// DiscoverSessionsFilteredIndexed is DiscoverSessionsFiltered plus a
+// CWDIndex: cwdIdx (may be nil, equivalent to DiscoverSessionsFiltered)
+// lets the head-scan prefilter reuse previously-determined results — from
+// earlier in this process or reloaded from a persisted index written by a
+// previous run — for files whose (mtime, size) haven't changed, avoiding
+// the head-scan I/O entirely for files that keep getting skipped run after
+// run.
+func DiscoverSessionsFilteredIndexed(cache *model.SessionCache, desktopCache *DesktopCache, configDirs []string, cwdMatch func(string) bool, cwdIdx *CWDIndex) ([]*model.Session, error) {
 	projectsDirs := ClaudeProjectsDirs(configDirs)
 	if len(projectsDirs) == 0 {
 		return nil, fmt.Errorf("could not find any Claude projects directories")
@@ -136,7 +147,7 @@ func DiscoverSessionsFiltered(cache *model.SessionCache, desktopCache *DesktopCa
 	seen := make(map[string]struct{})
 	var sessions []*model.Session
 	for _, projectsDir := range projectsDirs {
-		sessions = discoverInDir(projectsDir, cache, wtCache, seen, sessions, cwdMatch)
+		sessions = discoverInDir(projectsDir, cache, wtCache, seen, sessions, cwdMatch, cwdIdx)
 	}
 	cache.Prune(seen)
 
@@ -177,7 +188,7 @@ type parseResult struct {
 // discoverInDir scans a single projects directory for JSONL session files
 // and appends discovered sessions to the provided slice.
 // Files that need parsing (cache miss or incremental update) are parsed in parallel.
-func discoverInDir(projectsDir string, cache *model.SessionCache, wtCache map[string]wtInfo, seen map[string]struct{}, sessions []*model.Session, cwdMatch func(string) bool) []*model.Session {
+func discoverInDir(projectsDir string, cache *model.SessionCache, wtCache map[string]wtInfo, seen map[string]struct{}, sessions []*model.Session, cwdMatch func(string) bool, cwdIdx *CWDIndex) []*model.Session {
 	entries, err := os.ReadDir(projectsDir)
 	if err != nil {
 		return sessions // Directory may not exist; skip it
@@ -221,7 +232,7 @@ func discoverInDir(projectsDir string, cache *model.SessionCache, wtCache map[st
 				// regardless (only new lines are read), and the uniform
 				// post-parse filter below is the single source of truth for
 				// whether they're included.
-				if !shouldParseForCWD(jsonlFile, cwdMatch) {
+				if !shouldParseForCWDIndexed(jsonlFile, cwdMatch, cwdIdx) {
 					continue
 				}
 			}
@@ -404,10 +415,38 @@ func headCWD(path string) (cwd string, ok bool) {
 // a cwd within its bounded window, this conservatively returns true, so a
 // session is never skipped without certainty; the actual parsed cwd is
 // still checked afterward by the caller's uniform post-parse filter.
+//
+// This is shouldParseForCWDIndexed with a nil index (always live I/O) — see
+// that function for the cache-aware version used by discovery once a
+// CWDIndex is available.
 func shouldParseForCWD(path string, cwdMatch func(string) bool) bool {
-	cwd, ok := headCWD(path)
+	return shouldParseForCWDIndexed(path, cwdMatch, nil)
+}
+
+// shouldParseForCWDIndexed is shouldParseForCWD's cache-aware counterpart:
+// the identical decision (see shouldParseForCWD's doc comment), but headCWD
+// is looked up through cwdIdx when cwdIdx is non-nil, instead of always
+// re-reading the file. headCWD is a pure function of a file's content (it
+// takes no matcher), so a cached result is exactly what fresh I/O would
+// return for an unchanged file, regardless of which matcher originally
+// populated the cache entry. cwdIdx == nil reproduces shouldParseForCWD's
+// plain (always-live-I/O) behavior exactly.
+func shouldParseForCWDIndexed(path string, cwdMatch func(string) bool, cwdIdx *CWDIndex) bool {
+	if cwdIdx == nil {
+		cwd, ok := headCWD(path)
+		if !ok {
+			return true // can't tell within the window — parse it
+		}
+		return cwdMatch(cwd)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return true // can't stat — conservative parse, same as headCWD's own "can't open" -> not ok -> true
+	}
+	cwd, ok := cwdIdx.headCWDIndexed(path, info.ModTime(), info.Size())
 	if !ok {
-		return true // can't tell within the window — parse it
+		return true
 	}
 	return cwdMatch(cwd)
 }

--- a/internal/claude/process.go
+++ b/internal/claude/process.go
@@ -150,6 +150,9 @@ func DiscoverSessionsFilteredIndexed(cache *model.SessionCache, desktopCache *De
 		sessions = discoverInDir(projectsDir, cache, wtCache, seen, sessions, cwdMatch, cwdIdx)
 	}
 	cache.Prune(seen)
+	if cwdIdx != nil {
+		cwdIdx.Prune(seen)
+	}
 
 	// Enrich with Claude Desktop metadata. Desktop sessions are a separate,
 	// small source (never prefiltered) — this only annotates whichever

--- a/internal/claude/process.go
+++ b/internal/claude/process.go
@@ -1,6 +1,8 @@
 package claude
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -102,6 +104,28 @@ func ProjectDirForCWD(cwd string) string {
 // DiscoverSessions scans Claude projects directories for JSONL session files.
 // Every JSONL file is a separate session. Uses caches to skip unchanged files.
 func DiscoverSessions(cache *model.SessionCache, desktopCache *DesktopCache, configDirs []string) ([]*model.Session, error) {
+	return DiscoverSessionsFiltered(cache, desktopCache, configDirs, nil)
+}
+
+// DiscoverSessionsFiltered scans Claude projects directories like
+// DiscoverSessions, but skips fully parsing files whose cwd is known — with
+// certainty — not to match cwdMatch. session.CWD is first-cwd-wins (see
+// scanEntries in jsonl.go: it's set from the first entry that carries a
+// non-empty "cwd" field and never overwritten afterward), so a bounded
+// forward scan of a file's head (headCWD) that finds that same first
+// non-empty cwd IS the value a full parse would assign — a positive,
+// non-matching result is a confident skip, with no tail-scan fallback needed
+// (unlike codex's turn_context, which is last-wins and can drift over the
+// file). A file is skipped ONLY when headCWD positively resolves a
+// non-matching cwd; whenever the outcome is uncertain (unreadable, no cwd
+// field within the bounded window, etc.) the file is parsed anyway, and
+// every parsed session's *actual* cwd is checked against cwdMatch before
+// being returned — so a session is never silently dropped, only ever parsed
+// unnecessarily in the worst case.
+//
+// cwdMatch may be nil, in which case every session matches (equivalent to
+// DiscoverSessions).
+func DiscoverSessionsFiltered(cache *model.SessionCache, desktopCache *DesktopCache, configDirs []string, cwdMatch func(string) bool) ([]*model.Session, error) {
 	projectsDirs := ClaudeProjectsDirs(configDirs)
 	if len(projectsDirs) == 0 {
 		return nil, fmt.Errorf("could not find any Claude projects directories")
@@ -112,11 +136,14 @@ func DiscoverSessions(cache *model.SessionCache, desktopCache *DesktopCache, con
 	seen := make(map[string]struct{})
 	var sessions []*model.Session
 	for _, projectsDir := range projectsDirs {
-		sessions = discoverInDir(projectsDir, cache, wtCache, seen, sessions)
+		sessions = discoverInDir(projectsDir, cache, wtCache, seen, sessions, cwdMatch)
 	}
 	cache.Prune(seen)
 
-	// Enrich with Claude Desktop metadata.
+	// Enrich with Claude Desktop metadata. Desktop sessions are a separate,
+	// small source (never prefiltered) — this only annotates whichever
+	// sessions cwdMatch already let through above, so it stays correct
+	// regardless of how cwdMatch filtered the list.
 	desktopMeta := loadDesktopMetadata(desktopCache)
 	for _, session := range sessions {
 		if meta, ok := desktopMeta[session.SessionID]; ok {
@@ -132,11 +159,11 @@ func DiscoverSessions(cache *model.SessionCache, desktopCache *DesktopCache, con
 
 // parseJob holds the input for a single JSONL file parse operation.
 type parseJob struct {
-	jsonlFile  string
-	dirName    string // project directory name for CWD fallback
-	cached     *model.Session
-	offset     int64
-	mtime      time.Time
+	jsonlFile string
+	dirName   string // project directory name for CWD fallback
+	cached    *model.Session
+	offset    int64
+	mtime     time.Time
 }
 
 // parseResult holds the output of a single JSONL file parse operation.
@@ -150,7 +177,7 @@ type parseResult struct {
 // discoverInDir scans a single projects directory for JSONL session files
 // and appends discovered sessions to the provided slice.
 // Files that need parsing (cache miss or incremental update) are parsed in parallel.
-func discoverInDir(projectsDir string, cache *model.SessionCache, wtCache map[string]wtInfo, seen map[string]struct{}, sessions []*model.Session) []*model.Session {
+func discoverInDir(projectsDir string, cache *model.SessionCache, wtCache map[string]wtInfo, seen map[string]struct{}, sessions []*model.Session, cwdMatch func(string) bool) []*model.Session {
 	entries, err := os.ReadDir(projectsDir)
 	if err != nil {
 		return sessions // Directory may not exist; skip it
@@ -173,10 +200,32 @@ func discoverInDir(projectsDir string, cache *model.SessionCache, wtCache map[st
 			cached, offset, mtime := cache.GetIncremental(jsonlFile)
 
 			if cached != nil && offset == 0 {
-				// Full cache hit — no parsing needed.
+				// Full cache hit — cached.CWD is the value a previous parse
+				// (full or incremental — either way, fully caught up to
+				// this file's current content) assigned: first-cwd-wins, or
+				// the decodeDirName fallback (see phase 2 below). Either
+				// way it's stable and final, so it's safe to filter on
+				// directly without touching the file.
+				if cwdMatch != nil && !cwdMatch(cached.CWD) {
+					continue
+				}
 				sessions = append(sessions, cached)
 				continue
 			}
+
+			if cwdMatch != nil && cached == nil {
+				// A genuine first-time full parse (no cached data at all): try
+				// to rule the file out before committing to the expensive parse.
+				// Incremental jobs (cached != nil, offset > 0) are deliberately
+				// NOT prefiltered here — their appended bytes are cheap to parse
+				// regardless (only new lines are read), and the uniform
+				// post-parse filter below is the single source of truth for
+				// whether they're included.
+				if !shouldParseForCWD(jsonlFile, cwdMatch) {
+					continue
+				}
+			}
+
 			jobs = append(jobs, parseJob{
 				jsonlFile: jsonlFile,
 				dirName:   projectEntry.Name(),
@@ -253,7 +302,16 @@ func discoverInDir(projectsDir string, cache *model.SessionCache, wtCache map[st
 			continue
 		}
 		enrichWorktree(r.session, wtCache)
+		// Always cache the fully parsed result, regardless of this call's
+		// matcher — the cache is shared across queries.
 		cache.Put(r.jsonlFile, r.mtime, r.newOffset, r.session)
+		// Uniform post-parse filter: the head-scan prefilter above is purely
+		// a skip optimization, so the parsed session's actual CWD (not
+		// whatever the prefilter guessed) is the single source of truth for
+		// whether it's returned.
+		if cwdMatch != nil && !cwdMatch(r.session.CWD) {
+			continue
+		}
 		sessions = append(sessions, r.session)
 	}
 	return sessions
@@ -274,4 +332,72 @@ func decodeDirName(name string) string {
 	// Reverse of ProjectDirForCWD: dashes → slashes, prepend /
 	// This is a best-effort heuristic
 	return "/" + strings.ReplaceAll(name, "-", "/")
+}
+
+// maxHeadScanBytes and maxHeadScanLines bound how much of a claude session
+// JSONL file headCWD will read before giving up, so a pathological file
+// (huge lines, or many lines with no cwd field) can't force reading large
+// amounts of data into memory or make the prefilter itself expensive.
+const (
+	maxHeadScanBytes = 64 * 1024
+	maxHeadScanLines = 25
+)
+
+// headCWD reads forward from the start of a claude session JSONL file,
+// looking for the first entry that carries a non-empty top-level "cwd"
+// field, stopping as soon as one is found or the bounded window
+// (maxHeadScanBytes / maxHeadScanLines, whichever is hit first) is
+// exhausted. Because session.CWD is first-cwd-wins (see scanEntries in
+// jsonl.go), this is exactly the cwd a full parse would assign to the
+// session — so a result found here is not a heuristic, it's the actual
+// answer, obtained without paying for the rest of the file.
+//
+// ok is false whenever no cwd could be determined within the bounded window
+// (missing file, empty file, the window closed before any entry supplied a
+// cwd) — callers must treat that as "unknown, don't filter it out" rather
+// than "no match", since the real cwd might still appear later in the file.
+func headCWD(path string) (cwd string, ok bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var bytesRead, lines int
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		lines++
+		bytesRead += len(line) + 1 // +1 for the stripped newline
+
+		var e struct {
+			CWD string `json:"cwd"`
+		}
+		if json.Unmarshal(line, &e) == nil && e.CWD != "" {
+			return e.CWD, true
+		}
+
+		if lines >= maxHeadScanLines || bytesRead >= maxHeadScanBytes {
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// shouldParseForCWD reports whether a session file might still end up
+// matching cwdMatch and should therefore be parsed. It returns false —
+// "skip, don't parse" — ONLY when headCWD positively resolves a cwd (the
+// same value a full parse would assign to session.CWD, since claude is
+// first-cwd-wins) and cwdMatch rejects it. Whenever headCWD can't determine
+// a cwd within its bounded window, this conservatively returns true, so a
+// session is never skipped without certainty; the actual parsed cwd is
+// still checked afterward by the caller's uniform post-parse filter.
+func shouldParseForCWD(path string, cwdMatch func(string) bool) bool {
+	cwd, ok := headCWD(path)
+	if !ok {
+		return true // can't tell within the window — parse it
+	}
+	return cwdMatch(cwd)
 }

--- a/internal/claude/process.go
+++ b/internal/claude/process.go
@@ -352,6 +352,18 @@ const (
 // session — so a result found here is not a heuristic, it's the actual
 // answer, obtained without paying for the rest of the file.
 //
+// Each line is unmarshaled into the same jsonlEntry type scanEntries uses,
+// with the same "any unmarshal error skips this line" rule (jsonl.go's
+// scanEntries: `if err := json.Unmarshal(...); err != nil { continue }`,
+// checked before the cwd assignment). This matters: encoding/json fills in
+// whatever fields it can from a JSON object before reporting a type
+// mismatch on an unrelated field (e.g. a string where jsonlEntry.CostUSD
+// expects a float64), so a smaller/different struct that happens not to
+// declare that field would silently accept a line scanEntries would have
+// skipped — producing a cwd headCWD is confident about but a full parse
+// would never have used. Reusing jsonlEntry verbatim makes the two decoders
+// equivalent by construction, not by claim.
+//
 // ok is false whenever no cwd could be determined within the bounded window
 // (missing file, empty file, the window closed before any entry supplied a
 // cwd) — callers must treat that as "unknown, don't filter it out" rather
@@ -372,10 +384,8 @@ func headCWD(path string) (cwd string, ok bool) {
 		lines++
 		bytesRead += len(line) + 1 // +1 for the stripped newline
 
-		var e struct {
-			CWD string `json:"cwd"`
-		}
-		if json.Unmarshal(line, &e) == nil && e.CWD != "" {
+		var e jsonlEntry
+		if err := json.Unmarshal(line, &e); err == nil && e.CWD != "" {
 			return e.CWD, true
 		}
 

--- a/internal/claude/process_test.go
+++ b/internal/claude/process_test.go
@@ -1,9 +1,15 @@
 package claude
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
 	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
 )
 
 func TestClaudeProjectsDirs_WithConfigDirs(t *testing.T) {
@@ -69,5 +75,437 @@ func TestClaudeProjectsDirs_ConfigDirsOverridesEnv(t *testing.T) {
 	}
 	if dirs[0] != "/explicit/dir/projects" {
 		t.Errorf("dirs[0] = %q, want /explicit/dir/projects", dirs[0])
+	}
+}
+
+// --- fixture helpers for headCWD / DiscoverSessionsFiltered tests ---
+
+// newTestProjectsRoot creates a fresh temp "config dir" and its "projects"
+// subdirectory, mirroring ~/.claude and ~/.claude/projects, and returns
+// both — configDir is what DiscoverSessions(Filtered)'s configDirs
+// parameter expects (it appends "projects" itself via ClaudeProjectsDirs).
+func newTestProjectsRoot(t *testing.T) (configDir, projectsDir string) {
+	t.Helper()
+	configDir = t.TempDir()
+	projectsDir = filepath.Join(configDir, "projects")
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return configDir, projectsDir
+}
+
+// writeClaudeSession writes a claude session JSONL file at
+// projectsDir/<dirName>/<sessionID>.jsonl (mirroring the real
+// ~/.claude/projects/<encoded-cwd>/<sessionID>.jsonl layout) with exactly
+// the given raw lines, and returns its path.
+func writeClaudeSession(t *testing.T, projectsDir, dirName, sessionID string, lines []string) string {
+	t.Helper()
+	dir := filepath.Join(projectsDir, dirName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, sessionID+".jsonl")
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// cwdLine returns a minimal, valid claude JSONL entry carrying cwd on its
+// top-level "cwd" field — the field both headCWD and scanEntries key off.
+func cwdLine(cwd string) string {
+	return fmt.Sprintf(`{"type":"system","cwd":%q,"timestamp":"2026-03-01T11:00:00.000Z"}`, cwd)
+}
+
+// noCWDLine returns a valid claude JSONL entry with no "cwd" field at all —
+// used to pad a fixture past headCWD's scan window without ever supplying
+// a cwd.
+func noCWDLine(i int) string {
+	return fmt.Sprintf(`{"type":"system","note":"filler-%d","timestamp":"2026-03-01T11:00:00.000Z"}`, i)
+}
+
+// --- headCWD ---
+
+func TestHeadCWD_FirstLineCWD(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	content := cwdLine("/tmp/project-a") + "\n" + cwdLine("/tmp/project-b") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd, ok := headCWD(path)
+	if !ok {
+		t.Fatal("headCWD ok = false, want true")
+	}
+	if cwd != "/tmp/project-a" {
+		t.Fatalf("headCWD cwd = %q, want /tmp/project-a (first entry wins)", cwd)
+	}
+}
+
+func TestHeadCWD_CWDOnLaterLineWithinWindow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	lines := []string{noCWDLine(1), noCWDLine(2), cwdLine("/tmp/project-a")}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd, ok := headCWD(path)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("headCWD = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+}
+
+func TestHeadCWD_GarbageLinesSkippedUntilCWDFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	lines := []string{"not valid json at all", "{also not json", cwdLine("/tmp/project-a")}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cwd, ok := headCWD(path)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("headCWD = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+}
+
+func TestHeadCWD_NoCWDAnywhereInFile_NotOk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	lines := []string{noCWDLine(1), noCWDLine(2), noCWDLine(3)}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := headCWD(path); ok {
+		t.Fatal("headCWD ok = true, want false (no cwd anywhere in the file)")
+	}
+}
+
+func TestHeadCWD_LineCountCapExceeded_NotOk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	var lines []string
+	for i := 0; i < maxHeadScanLines+5; i++ {
+		lines = append(lines, noCWDLine(i))
+	}
+	lines = append(lines, cwdLine("/tmp/project-a")) // lies beyond the cap
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := headCWD(path); ok {
+		t.Fatal("headCWD ok = true, want false (cwd lies beyond the line-count cap)")
+	}
+}
+
+func TestHeadCWD_ByteSizeCapExceeded_NotOk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	pad := strings.Repeat("x", 15000)
+	// 5 lines (well under the 25-line cap) already exceed the 64 KiB byte
+	// cap, so this isolates byte-cap behavior from line-count-cap behavior.
+	var lines []string
+	for i := 0; i < 5; i++ {
+		lines = append(lines, fmt.Sprintf(`{"type":"system","note":%q}`, pad))
+	}
+	lines = append(lines, cwdLine("/tmp/project-a")) // lies beyond the byte cap
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := headCWD(path); ok {
+		t.Fatal("headCWD ok = true, want false (cwd lies beyond the byte-size cap, well within the line-count cap)")
+	}
+}
+
+func TestHeadCWD_EmptyFile_NotOk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := headCWD(path); ok {
+		t.Fatal("headCWD ok = true, want false for empty file")
+	}
+}
+
+func TestHeadCWD_NonexistentFile_NotOk(t *testing.T) {
+	if _, ok := headCWD(filepath.Join(t.TempDir(), "missing.jsonl")); ok {
+		t.Fatal("headCWD ok = true, want false for missing file")
+	}
+}
+
+// --- shouldParseForCWD ---
+
+func TestShouldParseForCWD_HeadMatches(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	match := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	if !shouldParseForCWD(path, match) {
+		t.Fatal("shouldParseForCWD = false, want true (head matches)")
+	}
+}
+
+func TestShouldParseForCWD_HeadConclusivelyRulesOut(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	match := func(cwd string) bool { return cwd == "/tmp/project-b" }
+	if shouldParseForCWD(path, match) {
+		t.Fatal("shouldParseForCWD = true, want false (head conclusively shows a different, non-matching cwd)")
+	}
+}
+
+func TestShouldParseForCWD_NoCWDInWindowFallsBackToParse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(noCWDLine(1)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	match := func(cwd string) bool { return false }
+	if !shouldParseForCWD(path, match) {
+		t.Fatal("shouldParseForCWD = false, want true (no cwd within the window — conservative parse)")
+	}
+}
+
+// --- DiscoverSessionsFiltered ---
+
+func TestDiscoverSessionsFiltered_ScopesToMatchingCWD(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	pathA := writeClaudeSession(t, projectsDir, "dir-a", "sess-a", []string{cwdLine("/tmp/project-a")})
+	pathB := writeClaudeSession(t, projectsDir, "dir-b", "sess-b", []string{cwdLine("/tmp/project-b")})
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	sessions, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, matchA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotPaths := make(map[string]bool)
+	for _, s := range sessions {
+		gotPaths[s.JSONLPath] = true
+	}
+	if !gotPaths[pathA] {
+		t.Errorf("expected matching cwd file %s to be included", pathA)
+	}
+	if gotPaths[pathB] {
+		t.Errorf("did not expect non-matching cwd file %s to be included", pathB)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+}
+
+func TestDiscoverSessionsFiltered_NilMatcherReturnsAll(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	writeClaudeSession(t, projectsDir, "dir-a", "sess-a", []string{cwdLine("/tmp/project-a")})
+	writeClaudeSession(t, projectsDir, "dir-b", "sess-b", []string{cwdLine("/tmp/project-b")})
+	writeClaudeSession(t, projectsDir, "dir-c", "sess-c", []string{noCWDLine(1)})
+
+	sessions, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Fatalf("got %d sessions, want 3 (nil matcher must not filter anything)", len(sessions))
+	}
+}
+
+func TestDiscoverSessions_StillReturnsEverything(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	writeClaudeSession(t, projectsDir, "dir-a", "sess-a", []string{cwdLine("/tmp/project-a")})
+	writeClaudeSession(t, projectsDir, "dir-b", "sess-b", []string{cwdLine("/tmp/project-b")})
+
+	sessions, err := DiscoverSessions(model.NewSessionCache(), NewDesktopCache(), []string{configDir})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+}
+
+// TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile
+// asserts the full-cache-hit fast path actually relies on cached.CWD instead
+// of touching the file: it corrupts pathA's on-disk content after priming
+// the cache (while preserving its exact mtime, so GetIncremental still
+// reports a full hit) and confirms the filtered result is still correct —
+// which is only possible if the cached CWD, not a re-read of the now-garbage
+// file, is what got checked.
+func TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	pathA := writeClaudeSession(t, projectsDir, "dir-a", "sess-a", []string{cwdLine("/tmp/project-a")})
+	pathB := writeClaudeSession(t, projectsDir, "dir-b", "sess-b", []string{cwdLine("/tmp/project-b")})
+
+	cache := model.NewSessionCache()
+	// Prime the cache with a full parse (nil matcher) so both files are cached.
+	if _, err := DiscoverSessionsFiltered(cache, NewDesktopCache(), []string{configDir}, nil); err != nil {
+		t.Fatalf("priming pass: unexpected error: %v", err)
+	}
+
+	infoA, err := os.Stat(pathA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtimeA := infoA.ModTime()
+
+	// Corrupt pathA on disk (a re-read would find no cwd at all), but
+	// restore its exact mtime so the cache still treats it as unchanged.
+	if err := os.WriteFile(pathA, []byte("garbage, not json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(pathA, mtimeA, mtimeA); err != nil {
+		t.Fatal(err)
+	}
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	sessions, err := DiscoverSessionsFiltered(cache, NewDesktopCache(), []string{configDir}, matchA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotPaths := make(map[string]bool)
+	for _, s := range sessions {
+		gotPaths[s.JSONLPath] = true
+	}
+	if !gotPaths[pathA] {
+		t.Errorf("expected cached matching-cwd file %s to be included via cached.CWD despite corrupted on-disk content", pathA)
+	}
+	if gotPaths[pathB] {
+		t.Errorf("did not expect cached non-matching-cwd file %s to be included", pathB)
+	}
+}
+
+// TestDiscoverSessionsFiltered_ConservativeWhenNoCWDInWindow covers the
+// conservative branch: headCWD can't determine a cwd within its bounded
+// window, so the file must still be parsed rather than skipped. It's then
+// included via the existing decodeDirName(dirName) fallback that phase 2
+// applies whenever a fully parsed session ends up with an empty CWD.
+func TestDiscoverSessionsFiltered_ConservativeWhenNoCWDInWindow(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	path := writeClaudeSession(t, projectsDir, "dir-x", "sess-no-cwd", []string{noCWDLine(1), noCWDLine(2)})
+
+	match := func(cwd string) bool { return cwd == decodeDirName("dir-x") }
+	sessions, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].JSONLPath != path {
+		t.Fatalf("sessions = %#v, want the no-cwd-in-window session included via the decodeDirName fallback", sessions)
+	}
+}
+
+// TestDiscoverSessionsFiltered_ImmuneToEncoderMismatch_UnderscoreViolation
+// reproduces violation class (a) found by Task 8's empirical check: a real
+// project directory whose name does not round-trip through
+// ProjectDirForCWD, because Claude's real directory naming folds "_" into
+// "-" too (ProjectDirForCWD doesn't). A directory-name-based skip rule would
+// get this wrong; the head-scan design never looks at the directory name at
+// all, so it can't be fooled by an encoder mismatch — it reads the real cwd
+// straight from the file.
+func TestDiscoverSessionsFiltered_ImmuneToEncoderMismatch_UnderscoreViolation(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	path := writeClaudeSession(t, projectsDir, "totally-unrelated-dirname", "sess-underscore", []string{cwdLine("/tmp/nltk_data")})
+
+	match := func(cwd string) bool { return cwd == "/tmp/nltk_data" }
+	sessions, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, match)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].JSONLPath != path {
+		t.Fatalf("sessions = %#v, want the session under the mismatched-name directory included", sessions)
+	}
+}
+
+// TestDiscoverSessionsFiltered_ImmuneToResumedElsewhereViolation reproduces
+// violation class (b) found by Task 8's empirical check: a session resumed
+// from a different directory than where it started ends up filed under a
+// project directory named for the LATEST cwd, while its (first-cwd-wins)
+// session.CWD is still the ORIGINAL cwd. A query for the original cwd must
+// still find it, matching today's unfiltered discovery; a query for the
+// directory it's actually filed under must NOT return it, since that's not
+// what session.CWD resolves to.
+func TestDiscoverSessionsFiltered_ImmuneToResumedElsewhereViolation(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	path := writeClaudeSession(t, projectsDir, "dir-for-project-b", "sess-resumed", []string{
+		cwdLine("/tmp/project-a"), // first cwd — wins, becomes session.CWD
+		cwdLine("/tmp/project-b"), // later cwd (session resumed elsewhere) — ignored
+	})
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	sessionsA, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, matchA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessionsA) != 1 || sessionsA[0].JSONLPath != path {
+		t.Fatalf("sessions for project-a = %#v, want the resumed session included (its first cwd is project-a)", sessionsA)
+	}
+
+	matchB := func(cwd string) bool { return cwd == "/tmp/project-b" }
+	sessionsB, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, matchB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessionsB) != 0 {
+		t.Fatalf("sessions for project-b = %#v, want empty: session.CWD is project-a (first-wins), even though the file is filed under a project-b-named directory", sessionsB)
+	}
+}
+
+// TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery is an
+// equivalence-property test: for a tree covering a plain match, a plain
+// non-match, a no-cwd-anywhere file, and both real violation classes found
+// by Task 8's empirical check (encoder mismatch, resumed-elsewhere),
+// DiscoverSessionsFiltered's result must equal filtering a full (unfiltered)
+// discovery pass by the same matcher — proving the fast path never silently
+// drops a session the slow path would have returned.
+func TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	writeClaudeSession(t, projectsDir, "dir-a", "sess-a", []string{cwdLine("/tmp/project-a")})
+	writeClaudeSession(t, projectsDir, "dir-b", "sess-b", []string{cwdLine("/tmp/project-b")})
+	writeClaudeSession(t, projectsDir, "dir-no-cwd", "sess-no-cwd", []string{noCWDLine(1)})
+	writeClaudeSession(t, projectsDir, "totally-unrelated-dirname", "sess-underscore", []string{cwdLine("/tmp/nltk_data")})
+	writeClaudeSession(t, projectsDir, "dir-for-project-b", "sess-resumed", []string{
+		cwdLine("/tmp/project-a"),
+		cwdLine("/tmp/project-b"),
+	})
+
+	matchers := map[string]func(string) bool{
+		"project-a":      func(cwd string) bool { return cwd == "/tmp/project-a" },
+		"project-b":      func(cwd string) bool { return cwd == "/tmp/project-b" },
+		"nltk_data":      func(cwd string) bool { return cwd == "/tmp/nltk_data" },
+		"nothing-at-all": func(cwd string) bool { return cwd == "/tmp/does-not-exist" },
+	}
+
+	for name, matcher := range matchers {
+		t.Run(name, func(t *testing.T) {
+			full, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, nil)
+			if err != nil {
+				t.Fatalf("full discovery: unexpected error: %v", err)
+			}
+			var want []string
+			for _, s := range full {
+				if matcher(s.CWD) {
+					want = append(want, s.JSONLPath)
+				}
+			}
+			sort.Strings(want)
+
+			got, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, matcher)
+			if err != nil {
+				t.Fatalf("filtered discovery: unexpected error: %v", err)
+			}
+			var gotPaths []string
+			for _, s := range got {
+				gotPaths = append(gotPaths, s.JSONLPath)
+			}
+			sort.Strings(gotPaths)
+
+			if !slices.Equal(want, gotPaths) {
+				t.Fatalf("filtered discovery = %v, want %v (must equal manual filter of full discovery)", gotPaths, want)
+			}
+		})
 	}
 }

--- a/internal/claude/process_test.go
+++ b/internal/claude/process_test.go
@@ -125,6 +125,19 @@ func noCWDLine(i int) string {
 	return fmt.Sprintf(`{"type":"system","note":"filler-%d","timestamp":"2026-03-01T11:00:00.000Z"}`, i)
 }
 
+// cwdLineWithBadCostUSD returns a claude JSONL entry with a well-formed cwd
+// but a type-mismatched "costUSD" field (a JSON string where jsonlEntry
+// declares it as a float64). scanEntries decodes each line into the full
+// jsonlEntry and skips the whole line on ANY unmarshal error, checked
+// before the cwd assignment (jsonl.go) — and encoding/json reports a type
+// mismatch on costUSD even though cwd itself decoded fine, so a full parse
+// never sees this line's cwd at all. This is the exact class of line a
+// smaller/different decoder (one that doesn't declare a costUSD field, and
+// so never notices the mismatch) would wrongly accept.
+func cwdLineWithBadCostUSD(cwd string) string {
+	return fmt.Sprintf(`{"type":"system","cwd":%q,"costUSD":"not-a-number","timestamp":"2026-03-01T11:00:00.000Z"}`, cwd)
+}
+
 // --- headCWD ---
 
 func TestHeadCWD_FirstLineCWD(t *testing.T) {
@@ -230,6 +243,29 @@ func TestHeadCWD_EmptyFile_NotOk(t *testing.T) {
 func TestHeadCWD_NonexistentFile_NotOk(t *testing.T) {
 	if _, ok := headCWD(filepath.Join(t.TempDir(), "missing.jsonl")); ok {
 		t.Fatal("headCWD ok = true, want false for missing file")
+	}
+}
+
+// TestHeadCWD_TypeMismatchOnUnrelatedFieldSkipsLine reproduces a review-
+// caught bug: headCWD used to decode each line into a minimal {cwd string}
+// struct, which — unlike scanEntries' full jsonlEntry decode — has no field
+// for costUSD at all, so it silently ignores a type-mismatched costUSD
+// instead of erroring the whole line the way scanEntries does. That let
+// headCWD confidently return a cwd a full parse would never actually have
+// assigned. Line 1 here has a well-formed cwd plus a bad costUSD (the exact
+// class scanEntries would skip); line 2 has a different, clean cwd. headCWD
+// must skip line 1 (matching scanEntries) and return line 2's cwd.
+func TestHeadCWD_TypeMismatchOnUnrelatedFieldSkipsLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	lines := []string{cwdLineWithBadCostUSD("/tmp/wrong"), cwdLine("/tmp/right")}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, ok := headCWD(path)
+	if !ok || cwd != "/tmp/right" {
+		t.Fatalf("headCWD = (%q, %v), want (/tmp/right, true) — line 1's cwd must be skipped like scanEntries would skip it (type mismatch on costUSD)", cwd, ok)
 	}
 }
 
@@ -454,6 +490,101 @@ func TestDiscoverSessionsFiltered_ImmuneToResumedElsewhereViolation(t *testing.T
 	}
 }
 
+// TestDiscoverSessionsFiltered_TypeMismatchLineSkippedLikeFullParse
+// reproduces a review-caught bug at the DiscoverSessionsFiltered level:
+// headCWD used to decode into a minimal {cwd string} struct that silently
+// accepted a line with a type-mismatched unrelated field (costUSD as a
+// string) — a line the full jsonlEntry decode scanEntries uses would skip
+// entirely. That let the prefilter confidently report a cwd
+// ("/tmp/wrong") a full parse would never actually assign to session.CWD
+// (which ends up "/tmp/right", from the next clean line) — a silent false
+// negative for any query matching "/tmp/right" and a silent false positive
+// for any query matching "/tmp/wrong".
+func TestDiscoverSessionsFiltered_TypeMismatchLineSkippedLikeFullParse(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	path := writeClaudeSession(t, projectsDir, "dir-type-mismatch", "sess-type-mismatch", []string{
+		cwdLineWithBadCostUSD("/tmp/wrong"), // scanEntries skips this whole line
+		cwdLine("/tmp/right"),               // ...so this is what session.CWD actually becomes
+	})
+
+	matchRight := func(cwd string) bool { return cwd == "/tmp/right" }
+	sessionsRight, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, matchRight)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessionsRight) != 1 || sessionsRight[0].JSONLPath != path {
+		t.Fatalf("sessions for /tmp/right = %#v, want the session included (its real, post-parse cwd, once the bad line is skipped, is /tmp/right)", sessionsRight)
+	}
+
+	matchWrong := func(cwd string) bool { return cwd == "/tmp/wrong" }
+	sessionsWrong, err := DiscoverSessionsFiltered(model.NewSessionCache(), NewDesktopCache(), []string{configDir}, matchWrong)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessionsWrong) != 0 {
+		t.Fatalf("sessions for /tmp/wrong = %#v, want empty: a full parse never assigns session.CWD=/tmp/wrong (scanEntries skips that whole line, exactly like headCWD now does)", sessionsWrong)
+	}
+}
+
+// TestDiscoverSessionsFiltered_IncrementalAppendAlwaysReparsedPostParseFilterDecides
+// covers the offset>0 branch: discoverInDir deliberately never prefilters
+// incremental jobs (see the comment there) — they must always be enqueued
+// and reparsed, with the uniform post-parse filter as the sole arbiter of
+// inclusion, even when queried with a matcher that doesn't match. This
+// primes a cache, appends a real user-message line (observable via
+// UserMessages, independent of CWD), and issues a NON-matching query —
+// then inspects the cache directly (via GetIncremental) to confirm that
+// non-matching query alone already triggered the reparse (the cache now
+// reports a full hit with the appended line's effect applied), rather than
+// silently skipping the file because its cwd didn't match.
+func TestDiscoverSessionsFiltered_IncrementalAppendAlwaysReparsedPostParseFilterDecides(t *testing.T) {
+	configDir, projectsDir := newTestProjectsRoot(t)
+	path := writeClaudeSession(t, projectsDir, "dir-a", "sess-a", []string{cwdLine("/tmp/project-a")})
+
+	cache := model.NewSessionCache()
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+
+	primed, err := DiscoverSessionsFiltered(cache, NewDesktopCache(), []string{configDir}, matchA)
+	if err != nil {
+		t.Fatalf("priming pass: unexpected error: %v", err)
+	}
+	if len(primed) != 1 || primed[0].UserMessages != 0 {
+		t.Fatalf("primed session = %#v, want 1 session with 0 user messages", primed)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"type":"user","cwd":"/tmp/project-a","timestamp":"2026-03-01T11:00:01.000Z","message":{"role":"user","content":"hello"}}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	matchOther := func(cwd string) bool { return cwd == "/tmp/does-not-exist" }
+	sessionsOther, err := DiscoverSessionsFiltered(cache, NewDesktopCache(), []string{configDir}, matchOther)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessionsOther) != 0 {
+		t.Fatalf("sessions = %#v, want empty (post-parse filter must exclude a real non-match)", sessionsOther)
+	}
+
+	// The non-matching query above must already have enqueued and reparsed
+	// the grown file — proven by asking the cache directly, with no further
+	// disk changes: a full hit (offset 0) whose cached session reflects the
+	// appended line means the reparse happened, not a skip.
+	cachedAfter, offsetAfter, _ := cache.GetIncremental(path)
+	if offsetAfter != 0 {
+		t.Fatalf("cache offset after the non-matching query = %d, want 0 (a full hit) — the incremental branch must always be enqueued and reparsed, never skipped by the prefilter, even for a non-matching cwdMatch", offsetAfter)
+	}
+	if cachedAfter == nil || cachedAfter.UserMessages != 1 {
+		t.Fatalf("cachedAfter = %#v, want a session with UserMessages=1 (the appended line must have been parsed by the earlier non-matching query)", cachedAfter)
+	}
+}
+
 // TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery is an
 // equivalence-property test: for a tree covering a plain match, a plain
 // non-match, a no-cwd-anywhere file, and both real violation classes found
@@ -471,12 +602,22 @@ func TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery(t *tes
 		cwdLine("/tmp/project-a"),
 		cwdLine("/tmp/project-b"),
 	})
+	// Review-caught regression fixture: a well-formed cwd sharing a line
+	// with a type-mismatched unrelated field, followed by a clean different
+	// cwd — scanEntries skips the whole first line, so session.CWD ends up
+	// "/tmp/right", never "/tmp/wrong".
+	writeClaudeSession(t, projectsDir, "dir-type-mismatch", "sess-type-mismatch", []string{
+		cwdLineWithBadCostUSD("/tmp/wrong"),
+		cwdLine("/tmp/right"),
+	})
 
 	matchers := map[string]func(string) bool{
-		"project-a":      func(cwd string) bool { return cwd == "/tmp/project-a" },
-		"project-b":      func(cwd string) bool { return cwd == "/tmp/project-b" },
-		"nltk_data":      func(cwd string) bool { return cwd == "/tmp/nltk_data" },
-		"nothing-at-all": func(cwd string) bool { return cwd == "/tmp/does-not-exist" },
+		"project-a":           func(cwd string) bool { return cwd == "/tmp/project-a" },
+		"project-b":           func(cwd string) bool { return cwd == "/tmp/project-b" },
+		"nltk_data":           func(cwd string) bool { return cwd == "/tmp/nltk_data" },
+		"type-mismatch-right": func(cwd string) bool { return cwd == "/tmp/right" },
+		"type-mismatch-wrong": func(cwd string) bool { return cwd == "/tmp/wrong" },
+		"nothing-at-all":      func(cwd string) bool { return cwd == "/tmp/does-not-exist" },
 	}
 
 	for name, matcher := range matchers {

--- a/internal/codex/cwdindex.go
+++ b/internal/codex/cwdindex.go
@@ -1,0 +1,173 @@
+package codex
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/diskcache"
+)
+
+// cwdIndexFormatVersion is bumped whenever the persisted shape changes in a
+// backward-incompatible way.
+const cwdIndexFormatVersion = 1
+
+// CWDIndex memoizes headCWD and tailFinalCWD results per rollout file,
+// keyed by path with an (mtime, size) validity check, so that once a file's
+// head/tail scan outcome is known for its CURRENT content, repeated
+// discovery calls — including calls from a later process, if the index is
+// persisted and reloaded — never re-read the file to answer the same
+// question again.
+//
+// Both headCWD and tailFinalCWD are pure functions of a file's content (they
+// take no matcher), so memoizing either is always sound to reuse for ANY
+// future cwdMatch, regardless of which matcher originally triggered the
+// scan — unlike shouldParseForCWD's overall boolean decision, which does
+// depend on the matcher passed to that particular call and so is never
+// itself cached (see shouldParseForCWDIndexed, which replays the exact same
+// decision tree as shouldParseForCWD using these two memoized primitives).
+//
+// Entries are invalidated (recomputed from scratch) whenever a file's mtime
+// or size changes at all: an appended turn_context can change a rollout
+// file's final cwd, so any change must not be trusted, even though most
+// appends don't touch cwd.
+//
+// Only files whose cwd conclusively does NOT match a query ever populate
+// this index — see discoverSessionsFromDir's cwdMatch != nil && cached ==
+// nil guard, the only place it's consulted. Files that get parsed end up in
+// model.SessionCache instead, whose persisted full-hit fast path already
+// avoids re-reading them.
+type CWDIndex struct {
+	mu      sync.Mutex
+	entries map[string]cwdIndexEntry
+}
+
+type cwdIndexEntry struct {
+	mtime time.Time
+	size  int64
+
+	headCWD string
+	headOK  bool
+
+	tailScanned bool
+	tailCWD     string
+	tailFound   bool
+}
+
+// NewCWDIndex creates an empty CWDIndex.
+func NewCWDIndex() *CWDIndex {
+	return &CWDIndex{entries: make(map[string]cwdIndexEntry)}
+}
+
+// headCWDIndexed returns the same (cwd, ok) headCWD(path) would for path's
+// current content, using a cached result when the index already holds a
+// valid (mtime/size-matching) entry, and computing + storing it fresh
+// otherwise. mtime and size must be the caller's already-obtained current
+// stat of path, shared with any accompanying tailFinalCWDIndexed call for
+// the same path so both agree on what "current" means and no redundant stat
+// calls or TOCTOU gap is introduced.
+func (idx *CWDIndex) headCWDIndexed(path string, mtime time.Time, size int64) (cwd string, ok bool) {
+	idx.mu.Lock()
+	if e, found := idx.entries[path]; found && e.mtime.Equal(mtime) && e.size == size {
+		idx.mu.Unlock()
+		return e.headCWD, e.headOK
+	}
+	idx.mu.Unlock()
+
+	cwd, ok = headCWD(path)
+
+	idx.mu.Lock()
+	idx.entries[path] = cwdIndexEntry{mtime: mtime, size: size, headCWD: cwd, headOK: ok}
+	idx.mu.Unlock()
+	return cwd, ok
+}
+
+// tailFinalCWDIndexed is headCWDIndexed's counterpart for tailFinalCWD. When
+// called after headCWDIndexed for the same (path, mtime, size), it shares
+// that call's entry (adding the tail fields to it); called on its own, it
+// creates a fresh entry with only the tail fields populated.
+func (idx *CWDIndex) tailFinalCWDIndexed(path string, mtime time.Time, size int64) (cwd string, found bool) {
+	idx.mu.Lock()
+	if e, ok := idx.entries[path]; ok && e.mtime.Equal(mtime) && e.size == size && e.tailScanned {
+		idx.mu.Unlock()
+		return e.tailCWD, e.tailFound
+	}
+	idx.mu.Unlock()
+
+	cwd, found = tailFinalCWD(path)
+
+	idx.mu.Lock()
+	e, ok := idx.entries[path]
+	if !ok || !e.mtime.Equal(mtime) || e.size != size {
+		e = cwdIndexEntry{mtime: mtime, size: size}
+	}
+	e.tailScanned = true
+	e.tailCWD = cwd
+	e.tailFound = found
+	idx.entries[path] = e
+	idx.mu.Unlock()
+	return cwd, found
+}
+
+// persistedCWDEntry is the on-disk shape of one CWDIndex entry.
+type persistedCWDEntry struct {
+	MTime       time.Time `json:"mtime"`
+	Size        int64     `json:"size"`
+	HeadCWD     string    `json:"headCwd"`
+	HeadOK      bool      `json:"headOk"`
+	TailScanned bool      `json:"tailScanned"`
+	TailCWD     string    `json:"tailCwd"`
+	TailFound   bool      `json:"tailFound"`
+}
+
+type persistedCWDIndex struct {
+	FormatVersion int                          `json:"formatVersion"`
+	Entries       map[string]persistedCWDEntry `json:"entries"`
+}
+
+// SaveTo atomically writes the index to path (temp file + rename), 0600
+// permissions.
+func (idx *CWDIndex) SaveTo(path string) error {
+	idx.mu.Lock()
+	snapshot := persistedCWDIndex{
+		FormatVersion: cwdIndexFormatVersion,
+		Entries:       make(map[string]persistedCWDEntry, len(idx.entries)),
+	}
+	for k, e := range idx.entries {
+		snapshot.Entries[k] = persistedCWDEntry{
+			MTime: e.mtime, Size: e.size,
+			HeadCWD: e.headCWD, HeadOK: e.headOK,
+			TailScanned: e.tailScanned, TailCWD: e.tailCWD, TailFound: e.tailFound,
+		}
+	}
+	idx.mu.Unlock()
+
+	return diskcache.AtomicWriteJSON(path, snapshot)
+}
+
+// LoadFrom best-effort loads a persisted snapshot from path and merges its
+// entries into the index. Any file-level problem (missing/unreadable file,
+// malformed JSON, format version mismatch) is reported via the returned
+// error and leaves the index completely untouched — callers on the
+// discovery path are expected to ignore the error and continue with a cold
+// (but valid) index.
+func (idx *CWDIndex) LoadFrom(path string) error {
+	var snapshot persistedCWDIndex
+	if err := diskcache.ReadJSON(path, &snapshot); err != nil {
+		return err
+	}
+	if snapshot.FormatVersion != cwdIndexFormatVersion {
+		return fmt.Errorf("cwd index %s: format version %d, want %d", path, snapshot.FormatVersion, cwdIndexFormatVersion)
+	}
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	for k, e := range snapshot.Entries {
+		idx.entries[k] = cwdIndexEntry{
+			mtime: e.MTime, size: e.Size,
+			headCWD: e.HeadCWD, headOK: e.HeadOK,
+			tailScanned: e.TailScanned, tailCWD: e.TailCWD, tailFound: e.TailFound,
+		}
+	}
+	return nil
+}

--- a/internal/codex/cwdindex.go
+++ b/internal/codex/cwdindex.go
@@ -32,11 +32,16 @@ const cwdIndexFormatVersion = 1
 // file's final cwd, so any change must not be trusted, even though most
 // appends don't touch cwd.
 //
-// Only files whose cwd conclusively does NOT match a query ever populate
-// this index — see discoverSessionsFromDir's cwdMatch != nil && cached ==
-// nil guard, the only place it's consulted. Files that get parsed end up in
-// model.SessionCache instead, whose persisted full-hit fast path already
-// avoids re-reading them.
+// An entry is populated for every file that reaches the prefilter check at
+// all — see discoverSessionsFromDir's cwdMatch != nil && cached == nil
+// guard, the only place it's consulted — regardless of whether that file
+// ends up skipped or parsed (shouldParseForCWDIndexed always resolves
+// headCWD, and sometimes tailFinalCWD, before deciding either way). The
+// index's ongoing value is concentrated in the skipped files, though: a
+// parsed file also lands in model.SessionCache, whose persisted full-hit
+// fast path takes over for it on every later run without ever consulting
+// this index again, whereas a skipped file never enters SessionCache at
+// all and so keeps needing this index's answer on every run.
 type CWDIndex struct {
 	mu      sync.Mutex
 	entries map[string]cwdIndexEntry
@@ -57,6 +62,23 @@ type cwdIndexEntry struct {
 // NewCWDIndex creates an empty CWDIndex.
 func NewCWDIndex() *CWDIndex {
 	return &CWDIndex{entries: make(map[string]cwdIndexEntry)}
+}
+
+// Prune removes index entries for files no longer present in the seen set,
+// mirroring model.SessionCache.Prune. Without this, a file removed from the
+// rollout tree between runs (codex rotates/prunes old sessions) would leave
+// its entry in the index forever, since nothing else ever visits that path
+// again to overwrite or expire it — an unbounded, if slow, growth leak once
+// the index is persisted across runs. discoverSessionsFromDir already
+// builds the seen set for cache.Prune; the same set is reused here.
+func (idx *CWDIndex) Prune(seen map[string]struct{}) {
+	idx.mu.Lock()
+	for k := range idx.entries {
+		if _, ok := seen[k]; !ok {
+			delete(idx.entries, k)
+		}
+	}
+	idx.mu.Unlock()
 }
 
 // headCWDIndexed returns the same (cwd, ok) headCWD(path) would for path's

--- a/internal/codex/cwdindex_test.go
+++ b/internal/codex/cwdindex_test.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -320,6 +321,57 @@ func TestCWDIndex_LoadFrom_WrongFormatVersion(t *testing.T) {
 	}
 }
 
+// TestCWDIndex_PruneRemovesDeletedFileEntries covers a full discovery+save
+// cycle: a file that gets skipped (non-matching cwd) populates a cwd-index
+// entry; once that file is deleted from the rollout tree, the next
+// discovery pass must prune its now-stale entry so a save afterward doesn't
+// persist it forever (codex rotates/prunes old sessions, so this isn't a
+// hypothetical -- without pruning, the index would grow unboundedly with
+// entries for files that no longer exist).
+func TestCWDIndex_PruneRemovesDeletedFileEntries(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+	cwdIndexPath := filepath.Join(t.TempDir(), "cwdindex-codex.json")
+	match := func(cwd string) bool { return cwd == "/tmp/match" }
+
+	pathToDelete := writeRolloutFile(t, dir, 1, "sess-prune-0000-0000-000000000000", "/tmp/other")
+
+	cwdIdx := NewCWDIndex()
+	if _, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), match, cwdIdx); err != nil {
+		t.Fatalf("run1: %v", err)
+	}
+	if err := cwdIdx.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	if err := os.Remove(pathToDelete); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := NewCWDIndex()
+	if err := reloaded.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	if _, ok := reloaded.entries[pathToDelete]; !ok {
+		t.Fatal("expected the reloaded index to still have an entry for the (now deleted) file before this run's discovery prunes it")
+	}
+
+	if _, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), match, reloaded); err != nil {
+		t.Fatalf("run2 (over the mutated tree, file deleted): %v", err)
+	}
+	if err := reloaded.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo after prune: %v", err)
+	}
+
+	final := NewCWDIndex()
+	if err := final.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom final: %v", err)
+	}
+	if _, ok := final.entries[pathToDelete]; ok {
+		t.Fatal("expected the deleted file's entry to be pruned from the persisted index after the discovery+save cycle")
+	}
+}
+
 // --- discovery-level equivalence with a persisted+reloaded CWDIndex ---
 
 // TestDiscoverSessionsFilteredIndexed_PersistedIndexEquivalentToCold is the
@@ -389,24 +441,120 @@ func sessionPaths(sessions []*model.Session) map[string]bool {
 	return m
 }
 
-// assertSameSessionSet fails t if cold and got don't contain the exact same
-// set of JSONLPaths.
-func assertSameSessionSet(t *testing.T, label string, cold, got []*model.Session) {
+// errorfer is the minimal subset of *testing.T that sessionDigest and
+// assertSameSessionSet need. It exists (instead of taking *testing.T
+// directly) so TestAssertSameSessionSet_CatchesStaleContentAtSamePath can
+// pass a non-*testing.T fake that records a failure without that failure
+// propagating to the test currently running assertSameSessionSet's own
+// test — testing.TB can't be used for this, since it has an unexported
+// method that only the standard library's *testing.T/B/F can implement.
+// Every real call site passes a plain *testing.T, which satisfies this
+// smaller interface implicitly.
+type errorfer interface {
+	Helper()
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// sessionDigest renders s as JSON for content comparison. Session has no
+// fields populated from wall-clock time (every timestamp on it comes from
+// parsed JSONL content via time.Parse, never time.Now()), so there are no
+// legitimately-nondeterministic fields to normalize before comparing two
+// independently-produced sessions for the same file — a byte-different
+// digest here always means a genuine content difference, not incidental
+// representation noise (e.g. time.Time's internal monotonic-reading
+// representation, which reflect.DeepEqual is sensitive to but JSON
+// marshaling normalizes away, since it only ever encodes the RFC3339Nano
+// wall-clock value).
+func sessionDigest(t errorfer, s *model.Session) string {
 	t.Helper()
-	coldPaths := sessionPaths(cold)
-	gotPaths := sessionPaths(got)
-	if len(coldPaths) != len(gotPaths) {
-		t.Errorf("%s: session count = %d, want %d", label, len(gotPaths), len(coldPaths))
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal session for digest: %v", err)
 	}
-	for p := range coldPaths {
-		if !gotPaths[p] {
+	return string(data)
+}
+
+// assertSameSessionSet fails t if cold and got don't contain sessions with
+// the exact same JSONLPaths AND, for each shared path, byte-identical
+// content. A path-only comparison would pass a stale-content-same-path
+// regression (a persisted entry served for a file whose content actually
+// changed) undetected, since both sides would agree on which files are
+// present without ever checking what was returned for them.
+func assertSameSessionSet(t errorfer, label string, cold, got []*model.Session) {
+	t.Helper()
+	coldByPath := make(map[string]*model.Session, len(cold))
+	for _, s := range cold {
+		coldByPath[s.JSONLPath] = s
+	}
+	gotByPath := make(map[string]*model.Session, len(got))
+	for _, s := range got {
+		gotByPath[s.JSONLPath] = s
+	}
+	if len(coldByPath) != len(gotByPath) {
+		t.Errorf("%s: session count = %d, want %d", label, len(gotByPath), len(coldByPath))
+	}
+	for p, cs := range coldByPath {
+		gs, ok := gotByPath[p]
+		if !ok {
 			t.Errorf("%s: missing %s (present in cold discovery)", label, p)
+			continue
+		}
+		if wantDigest, gotDigest := sessionDigest(t, cs), sessionDigest(t, gs); wantDigest != gotDigest {
+			t.Errorf("%s: session content for %s differs from cold discovery\ncold: %s\ngot:  %s", label, p, wantDigest, gotDigest)
 		}
 	}
-	for p := range gotPaths {
-		if !coldPaths[p] {
+	for p := range gotByPath {
+		if _, ok := coldByPath[p]; !ok {
 			t.Errorf("%s: unexpected extra %s (absent from cold discovery)", label, p)
 		}
+	}
+}
+
+// fakeErrorfer records whether Errorf/Fatalf was called, without failing
+// the test actually running -- used only to verify that assertSameSessionSet
+// itself reports a failure for a given input, since a real *testing.T's
+// Errorf would otherwise mark the enclosing test (and, via t.Run's
+// propagation, any parent) failed regardless of what's checked afterward.
+type fakeErrorfer struct {
+	failed bool
+}
+
+func (f *fakeErrorfer) Helper()                           {}
+func (f *fakeErrorfer) Errorf(format string, args ...any) { f.failed = true }
+func (f *fakeErrorfer) Fatalf(format string, args ...any) { f.failed = true }
+
+// TestAssertSameSessionSet_CatchesStaleContentAtSamePath proves the content
+// check added to assertSameSessionSet actually earns its keep: a
+// same-path-but-different-content regression (the exact bug class df89efa
+// fixed -- a stale cached session served for a file whose real content
+// changed, without necessarily changing which files are present at all) is
+// invisible to a JSONLPath-set-only comparison, since both sides agree on
+// which paths are present. It manufactures two sessions at the identical
+// path with different field values directly (not via real discovery) so
+// this is deterministic and independent of any particular fixture mutation
+// happening to also change match status.
+func TestAssertSameSessionSet_CatchesStaleContentAtSamePath(t *testing.T) {
+	cold := []*model.Session{
+		{JSONLPath: "/tmp/x.jsonl", SessionID: "s1", CWD: "/tmp/match", TotalMessages: 5},
+	}
+	stale := []*model.Session{
+		{JSONLPath: "/tmp/x.jsonl", SessionID: "s1-STALE", CWD: "/tmp/match", TotalMessages: 1},
+	}
+
+	fake := &fakeErrorfer{}
+	assertSameSessionSet(fake, "simulated", cold, stale)
+	if !fake.failed {
+		t.Fatal("assertSameSessionSet did not detect a same-path, different-content regression -- the content-digest check added to it is not actually catching this bug class")
+	}
+
+	// Sanity check the other direction too: identical content at the same
+	// path must NOT be flagged, so the fake and the check itself are both
+	// wired correctly (not just always reporting failed).
+	fakeOK := &fakeErrorfer{}
+	assertSameSessionSet(fakeOK, "simulated", cold, cold)
+	if fakeOK.failed {
+		t.Fatal("assertSameSessionSet flagged identical content as a mismatch")
 	}
 }
 

--- a/internal/codex/cwdindex_test.go
+++ b/internal/codex/cwdindex_test.go
@@ -1,0 +1,390 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// --- CWDIndex: headCWDIndexed / tailFinalCWDIndexed avoid I/O on a hit ---
+
+// TestCWDIndex_HeadHitAvoidsReread corrupts the file on disk after priming
+// the index (preserving its exact mtime, the same technique
+// TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile
+// uses for model.SessionCache), then confirms headCWDIndexed still returns
+// the original result -- proof it came from the index, not a fresh read of
+// the now-corrupted file.
+func TestCWDIndex_HeadHitAvoidsReread(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	cwd, ok := idx.headCWDIndexed(path, mtime, size)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("priming call: headCWDIndexed = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+
+	if err := os.WriteFile(path, []byte("garbage, not json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, ok = idx.headCWDIndexed(path, mtime, size)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("cached call after corruption: headCWDIndexed = (%q, %v), want (/tmp/project-a, true) from the index, not a re-read", cwd, ok)
+	}
+}
+
+// TestCWDIndex_TailHitAvoidsReread is TestCWDIndex_HeadHitAvoidsReread's
+// counterpart for tailFinalCWDIndexed -- the genuinely expensive scan this
+// whole index exists to avoid repeating.
+func TestCWDIndex_TailHitAvoidsReread(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", false))
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	cwd, found := idx.tailFinalCWDIndexed(path, mtime, size)
+	if !found || cwd != "/tmp/project-b" {
+		t.Fatalf("priming call: tailFinalCWDIndexed = (%q, %v), want (/tmp/project-b, true)", cwd, found)
+	}
+
+	if err := os.WriteFile(path, []byte("garbage, not json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, found = idx.tailFinalCWDIndexed(path, mtime, size)
+	if !found || cwd != "/tmp/project-b" {
+		t.Fatalf("cached call after corruption: tailFinalCWDIndexed = (%q, %v), want (/tmp/project-b, true) from the index, not a re-read", cwd, found)
+	}
+}
+
+// TestCWDIndex_InvalidatedOnSizeChange is the brief's core codex safety
+// scenario: an appended turn_context can change a file's final cwd, so a
+// stale tail entry must never be trusted once size/mtime changes -- the
+// entry must be recomputed, not reused.
+func TestCWDIndex_InvalidatedOnSizeChange(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-a", false))
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime1, size1 := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	cwd, found := idx.tailFinalCWDIndexed(path, mtime1, size1)
+	if !found || cwd != "/tmp/project-a" {
+		t.Fatalf("first scan = (%q, %v), want (/tmp/project-a, true)", cwd, found)
+	}
+
+	// Append a turn_context that changes the file's final cwd -- both size
+	// and mtime change.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"timestamp":"2026-03-01T11:00:05.000Z","type":"turn_context","payload":{"cwd":"/tmp/project-b","model":"gpt-5.2-codex","git":{"branch":"main"}}}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	info2, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime2, size2 := info2.ModTime(), info2.Size()
+	if mtime2.Equal(mtime1) && size2 == size1 {
+		t.Fatal("fixture bug: append did not change mtime or size")
+	}
+
+	cwd, found = idx.tailFinalCWDIndexed(path, mtime2, size2)
+	if !found || cwd != "/tmp/project-b" {
+		t.Fatalf("after append, tailFinalCWDIndexed = (%q, %v), want (/tmp/project-b, true) -- the stale project-a entry must not be trusted", cwd, found)
+	}
+}
+
+// --- CWDIndex: ok=false / found=false must also be cached, and must not be upgraded ---
+
+func TestCWDIndex_CachesConservativeHeadNotOK(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFile(t, dir, 1, "sess-c-0000-0000-0000-000000000000", "") // malformed head
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	_, ok := idx.headCWDIndexed(path, mtime, size)
+	if ok {
+		t.Fatal("headCWDIndexed ok = true, want false (malformed head)")
+	}
+	// Second call must reuse the cached "not ok" -- verified indirectly: it
+	// must remain false even though nothing else changed.
+	_, ok = idx.headCWDIndexed(path, mtime, size)
+	if ok {
+		t.Fatal("cached headCWDIndexed ok = true, want false -- a cached ok=false must not be upgraded")
+	}
+}
+
+// --- shouldParseForCWDIndexed: must match shouldParseForCWD exactly for any
+// scenario, whether idx is nil, cold, or warm. ---
+
+func TestShouldParseForCWDIndexed_NilIndexMatchesUnindexed(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	match := func(cwd string) bool { return cwd == "/tmp/project-a" }
+
+	want := shouldParseForCWD(path, match)
+	got := shouldParseForCWDIndexed(path, match, nil)
+	if got != want {
+		t.Fatalf("shouldParseForCWDIndexed(nil idx) = %v, want %v (must match shouldParseForCWD)", got, want)
+	}
+}
+
+// TestShouldParseForCWDIndexed_ColdEqualsUnindexed checks every branch of
+// shouldParseForCWD (head matches / tail conclusively rules out / tail
+// inconclusive / head unreadable) gives the identical answer through a cold
+// (freshly constructed, empty) index -- proving the indexed path replays
+// the exact same decision tree, not an approximation of it.
+func TestShouldParseForCWDIndexed_ColdEqualsUnindexed(t *testing.T) {
+	dir := t.TempDir()
+
+	headMatches := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	tailRulesOut := writeRolloutFileRaw(t, dir, 2, "sess-drift-0000-0000-0000-000000000000", []string{
+		`{"timestamp":"2026-03-01T11:00:00.000Z","type":"session_meta","payload":{"id":"s1","cwd":"/tmp/project-a"}}`,
+		`{"timestamp":"2026-03-01T11:00:01.000Z","type":"turn_context","payload":{"cwd":"/tmp/project-c"}}`,
+	})
+	tailInconclusive := writeRolloutFile(t, dir, 3, "sess-only-meta-0000-0000-0000-000000000000", "/tmp/project-a")
+	headUnreadable := writeRolloutFile(t, dir, 4, "sess-c-0000-0000-0000-000000000000", "")
+
+	match := func(cwd string) bool { return cwd == "/tmp/project-b" }
+
+	for _, path := range []string{headMatches, tailRulesOut, tailInconclusive, headUnreadable} {
+		want := shouldParseForCWD(path, match)
+		got := shouldParseForCWDIndexed(path, match, NewCWDIndex())
+		if got != want {
+			t.Errorf("path %s: shouldParseForCWDIndexed(cold idx) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// TestShouldParseForCWDIndexed_WarmEqualsUnindexed re-runs the same fixture
+// set through an index that already holds entries for every path (primed by
+// a first call), confirming the warm (I/O-free) path gives the same answer
+// as fresh I/O would.
+func TestShouldParseForCWDIndexed_WarmEqualsUnindexed(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFileRaw(t, dir, 2, "sess-drift-0000-0000-0000-000000000000", []string{
+		`{"timestamp":"2026-03-01T11:00:00.000Z","type":"session_meta","payload":{"id":"s1","cwd":"/tmp/project-a"}}`,
+		`{"timestamp":"2026-03-01T11:00:01.000Z","type":"turn_context","payload":{"cwd":"/tmp/project-c"}}`,
+	})
+	match := func(cwd string) bool { return cwd == "/tmp/project-b" }
+
+	idx := NewCWDIndex()
+	want := shouldParseForCWD(path, match)
+	_ = shouldParseForCWDIndexed(path, match, idx) // prime
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	// Corrupt the file's content in place (same length, so size is
+	// unchanged; mtime restored exactly), so the second call's os.Stat
+	// still finds the same (mtime, size) the index entry was keyed on. A
+	// fresh read of this corrupted content would find no valid cwd at all
+	// (unlike the original, which conclusively rules out the match) --
+	// the only way this call can still equal `want` is if it answers from
+	// the index instead of re-reading the file.
+	garbage := make([]byte, size)
+	for i := range garbage {
+		garbage[i] = 'x'
+	}
+	if err := os.WriteFile(path, garbage, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	got := shouldParseForCWDIndexed(path, match, idx)
+	if got != want {
+		t.Fatalf("warm shouldParseForCWDIndexed (file corrupted, same mtime/size) = %v, want %v (must come from the index, not a re-read)", got, want)
+	}
+}
+
+// --- CWDIndex persistence ---
+
+func TestCWDIndex_SaveLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-codex.json")
+	path := writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", false))
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	idx.headCWDIndexed(path, mtime, size)
+	idx.tailFinalCWDIndexed(path, mtime, size)
+
+	if err := idx.SaveTo(cachePath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded := NewCWDIndex()
+	if err := loaded.LoadFrom(cachePath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, ok := loaded.headCWDIndexed(path, mtime, size)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("loaded headCWDIndexed = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+	tail, found := loaded.tailFinalCWDIndexed(path, mtime, size)
+	if !found || tail != "/tmp/project-b" {
+		t.Fatalf("loaded tailFinalCWDIndexed = (%q, %v), want (/tmp/project-b, true)", tail, found)
+	}
+}
+
+func TestCWDIndex_SaveTo_FilePermissions0600(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-codex.json")
+
+	idx := NewCWDIndex()
+	if err := idx.SaveTo(cachePath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+	info, err := os.Stat(cachePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("perms = %o, want 0600", perm)
+	}
+}
+
+func TestCWDIndex_LoadFrom_CorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-codex.json")
+	if err := os.WriteFile(cachePath, []byte("{not valid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewCWDIndex()
+	if err := idx.LoadFrom(cachePath); err == nil {
+		t.Fatal("LoadFrom corrupt JSON: want error, got nil")
+	}
+}
+
+func TestCWDIndex_LoadFrom_WrongFormatVersion(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "cwdindex-codex.json")
+	if err := os.WriteFile(cachePath, []byte(`{"formatVersion":999,"entries":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := NewCWDIndex()
+	if err := idx.LoadFrom(cachePath); err == nil {
+		t.Fatal("LoadFrom wrong format version: want error, got nil")
+	}
+}
+
+// --- discovery-level equivalence with a persisted+reloaded CWDIndex ---
+
+// TestDiscoverSessionsFilteredIndexed_PersistedIndexEquivalentToCold is the
+// brief's mandated equivalence property test at the discovery level: a
+// filtered discovery run using a CWDIndex that was populated by an earlier
+// run, saved to disk, and reloaded into a brand new CWDIndex, must return
+// exactly the same session set as a cold run (nil index) over the same
+// (unchanged) fixture tree.
+func TestDiscoverSessionsFilteredIndexed_PersistedIndexEquivalentToCold(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(dir, "session_index.jsonl")
+	cwdIndexPath := filepath.Join(t.TempDir(), "cwdindex-codex.json")
+
+	writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
+	writeRolloutFileRaw(t, dir, 3, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-c", false))
+
+	match := func(cwd string) bool { return cwd == "/tmp/project-a" }
+
+	cold, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), match, nil)
+	if err != nil {
+		t.Fatalf("cold discovery: %v", err)
+	}
+
+	// First run: populate a fresh index, then persist it.
+	firstIdx := NewCWDIndex()
+	if _, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), match, firstIdx); err != nil {
+		t.Fatalf("priming discovery: %v", err)
+	}
+	if err := firstIdx.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	// Second run: fresh SessionCache (so files get prefiltered again, not
+	// full-cache-hit), but a reloaded CWDIndex.
+	reloadedIdx := NewCWDIndex()
+	if err := reloadedIdx.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	warm, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), match, reloadedIdx)
+	if err != nil {
+		t.Fatalf("warm discovery: %v", err)
+	}
+
+	coldPaths := sessionPaths(cold)
+	warmPaths := sessionPaths(warm)
+	if len(coldPaths) != len(warmPaths) {
+		t.Fatalf("warm session count = %d, want %d (cold)", len(warmPaths), len(coldPaths))
+	}
+	for p := range coldPaths {
+		if !warmPaths[p] {
+			t.Errorf("warm discovery missing %s, present in cold discovery", p)
+		}
+	}
+	for p := range warmPaths {
+		if !coldPaths[p] {
+			t.Errorf("warm discovery has extra %s, not present in cold discovery", p)
+		}
+	}
+}
+
+func sessionPaths(sessions []*model.Session) map[string]bool {
+	m := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		m[s.JSONLPath] = true
+	}
+	return m
+}

--- a/internal/codex/cwdindex_test.go
+++ b/internal/codex/cwdindex_test.go
@@ -388,3 +388,205 @@ func sessionPaths(sessions []*model.Session) map[string]bool {
 	}
 	return m
 }
+
+// assertSameSessionSet fails t if cold and got don't contain the exact same
+// set of JSONLPaths.
+func assertSameSessionSet(t *testing.T, label string, cold, got []*model.Session) {
+	t.Helper()
+	coldPaths := sessionPaths(cold)
+	gotPaths := sessionPaths(got)
+	if len(coldPaths) != len(gotPaths) {
+		t.Errorf("%s: session count = %d, want %d", label, len(gotPaths), len(coldPaths))
+	}
+	for p := range coldPaths {
+		if !gotPaths[p] {
+			t.Errorf("%s: missing %s (present in cold discovery)", label, p)
+		}
+	}
+	for p := range gotPaths {
+		if !coldPaths[p] {
+			t.Errorf("%s: unexpected extra %s (absent from cold discovery)", label, p)
+		}
+	}
+}
+
+// TestDiscoverSessionsFilteredIndexed_ComprehensiveEquivalence is the
+// brief's mandated end-to-end equivalence property test, covering every
+// required fixture-tree scenario in one pass: discovery using a
+// persisted-and-reloaded SessionCache + CWDIndex must match cold discovery
+// for unchanged files, an appended file whose final cwd changes (the
+// cwd-index's core codex-specific safety requirement -- the stale entry
+// must be invalidated by the size change and re-scanned), a
+// truncated/replaced file with the same mtime but a different size, a
+// truncated/replaced file with a different mtime, a deleted file, a
+// corrupted persisted cache/index JSON, and a wrong-formatVersion persisted
+// cache/index JSON.
+func TestDiscoverSessionsFilteredIndexed_ComprehensiveEquivalence(t *testing.T) {
+	match := func(cwd string) bool { return cwd == "/tmp/match" }
+
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+	paths := map[string]string{
+		"unchanged_match":    writeRolloutFile(t, dir, 1, "sess-unchanged-match-000000000000", "/tmp/match"),
+		"unchanged_nonmatch": writeRolloutFile(t, dir, 2, "sess-unchanged-nonmatch-00000000000", "/tmp/other"),
+		"appended": writeRolloutFileRaw(t, dir, 3, "sess-appended-0000-0000-000000000000", []string{
+			`{"timestamp":"2026-03-03T11:00:00.000Z","type":"session_meta","payload":{"id":"sess-appended","cwd":"/tmp/other-a"}}`,
+			`{"timestamp":"2026-03-03T11:00:01.000Z","type":"turn_context","payload":{"cwd":"/tmp/other-b"}}`,
+		}),
+		"truncated_same_mtime": writeRolloutFile(t, dir, 4, "sess-trunc-same-0000-0000000000000", "/tmp/other"),
+		"truncated_diff_mtime": writeRolloutFile(t, dir, 5, "sess-trunc-diff-0000-0000000000000", "/tmp/other"),
+		"deleted":              writeRolloutFile(t, dir, 6, "sess-deleted-0000-0000-000000000000", "/tmp/other"),
+	}
+
+	// Run 1 (cold): populate both caches over the ORIGINAL fixture tree,
+	// then persist them.
+	cache := model.NewSessionCache()
+	cwdIdx := NewCWDIndex()
+	if _, err := discoverSessionsFromDir(dir, indexPath, cache, match, cwdIdx); err != nil {
+		t.Fatalf("run1: %v", err)
+	}
+	cacheDir := t.TempDir()
+	discoveryPath := filepath.Join(cacheDir, "discovery-codex.json")
+	cwdIndexPath := filepath.Join(cacheDir, "cwdindex-codex.json")
+	if err := cache.SaveTo(discoveryPath); err != nil {
+		t.Fatalf("SaveTo cache: %v", err)
+	}
+	if err := cwdIdx.SaveTo(cwdIndexPath); err != nil {
+		t.Fatalf("SaveTo cwdIdx: %v", err)
+	}
+
+	// Mutate the fixture tree between runs, one mutation per scenario.
+	f, err := os.OpenFile(paths["appended"], os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"timestamp":"2026-03-03T11:00:02.000Z","type":"turn_context","payload":{"cwd":"/tmp/match"}}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	infoSame, err := os.Stat(paths["truncated_same_mtime"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	origMtime := infoSame.ModTime()
+	if err := os.WriteFile(paths["truncated_same_mtime"], []byte(`{"timestamp":"2026-03-04T11:00:00.000Z","type":"session_meta","payload":{"id":"sess-trunc-same","cwd":"/tmp/match"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(paths["truncated_same_mtime"], origMtime, origMtime); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(paths["truncated_diff_mtime"], []byte(`{"timestamp":"2026-03-05T11:00:00.000Z","type":"session_meta","payload":{"id":"sess-trunc-diff","cwd":"/tmp/match"}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Remove(paths["deleted"]); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cold baseline: a completely fresh discovery over the mutated tree.
+	cold, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), match, nil)
+	if err != nil {
+		t.Fatalf("cold run: %v", err)
+	}
+
+	// Warm: reload both persisted caches (from the ORIGINAL, pre-mutation
+	// state) and rerun over the mutated tree.
+	reloadedCache := model.NewSessionCache()
+	if err := reloadedCache.LoadFrom(discoveryPath); err != nil {
+		t.Fatalf("LoadFrom cache: %v", err)
+	}
+	reloadedIdx := NewCWDIndex()
+	if err := reloadedIdx.LoadFrom(cwdIndexPath); err != nil {
+		t.Fatalf("LoadFrom cwdIdx: %v", err)
+	}
+	warm, err := discoverSessionsFromDir(dir, indexPath, reloadedCache, match, reloadedIdx)
+	if err != nil {
+		t.Fatalf("warm run: %v", err)
+	}
+
+	assertSameSessionSet(t, "warm-vs-cold after mutations", cold, warm)
+
+	warmPaths := sessionPaths(warm)
+	if !warmPaths[paths["appended"]] {
+		t.Errorf("appended file (final cwd changed to match) missing from warm results -- the stale non-matching cwd-index entry must be invalidated by the size change and re-scanned")
+	}
+	if !warmPaths[paths["truncated_same_mtime"]] {
+		t.Errorf("truncated (same mtime, different size) file missing from warm results")
+	}
+	if !warmPaths[paths["truncated_diff_mtime"]] {
+		t.Errorf("truncated (different mtime) file missing from warm results")
+	}
+	if warmPaths[paths["deleted"]] {
+		t.Errorf("deleted file unexpectedly present in warm results")
+	}
+
+	// A corrupted or version-mismatched persisted file (cache or cwd index)
+	// must behave exactly like starting fully cold -- never error, never
+	// leak stale data -- verified against the same mutated-tree cold
+	// baseline computed above.
+	corruptionCases := []struct {
+		name string
+		path string
+	}{
+		{"corrupted_cache_json", discoveryPath},
+		{"corrupted_cwdindex_json", cwdIndexPath},
+	}
+	for _, tc := range corruptionCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(tc.path, []byte("{not valid json"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			c := model.NewSessionCache()
+			idx := NewCWDIndex()
+			var loadErr error
+			if tc.path == discoveryPath {
+				loadErr = c.LoadFrom(discoveryPath)
+			} else {
+				loadErr = idx.LoadFrom(cwdIndexPath)
+			}
+			if loadErr == nil {
+				t.Fatal("LoadFrom corrupted JSON: want error, got nil")
+			}
+			got, err := discoverSessionsFromDir(dir, indexPath, c, match, idx)
+			if err != nil {
+				t.Fatalf("discovery: %v", err)
+			}
+			assertSameSessionSet(t, tc.name, cold, got)
+		})
+	}
+
+	versionCases := []struct {
+		name string
+		path string
+	}{
+		{"wrong_format_version_cache", discoveryPath},
+		{"wrong_format_version_cwdindex", cwdIndexPath},
+	}
+	for _, tc := range versionCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(tc.path, []byte(`{"formatVersion":999,"entries":{}}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			c := model.NewSessionCache()
+			idx := NewCWDIndex()
+			var loadErr error
+			if tc.path == discoveryPath {
+				loadErr = c.LoadFrom(discoveryPath)
+			} else {
+				loadErr = idx.LoadFrom(cwdIndexPath)
+			}
+			if loadErr == nil {
+				t.Fatal("LoadFrom wrong format version: want error, got nil")
+			}
+			got, err := discoverSessionsFromDir(dir, indexPath, c, match, idx)
+			if err != nil {
+				t.Fatalf("discovery: %v", err)
+			}
+			assertSameSessionSet(t, tc.name, cold, got)
+		})
+	}
+}

--- a/internal/codex/process.go
+++ b/internal/codex/process.go
@@ -2,8 +2,10 @@ package codex
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -36,7 +38,20 @@ func SessionIndexPath() string {
 
 // DiscoverSessions scans the Codex sessions tree for JSONL session files.
 func DiscoverSessions(cache *model.SessionCache) ([]*model.Session, error) {
-	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache)
+	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache, nil)
+}
+
+// DiscoverSessionsFiltered scans the Codex sessions tree like DiscoverSessions,
+// but skips fully parsing files whose working directory does not match
+// cwdMatch. A file's cwd is determined cheaply via a head-read of its first
+// line (see headCWD); when that cannot be determined, the file is
+// conservatively treated as matching and fully parsed, so a session is never
+// silently dropped — the worst case is an unnecessary full parse.
+//
+// cwdMatch may be nil, in which case every session matches (equivalent to
+// DiscoverSessions).
+func DiscoverSessionsFiltered(cache *model.SessionCache, cwdMatch func(string) bool) ([]*model.Session, error) {
+	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache, cwdMatch)
 }
 
 type parseJob struct {
@@ -53,7 +68,7 @@ type parseResult struct {
 	newOffset int64
 }
 
-func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.SessionCache) ([]*model.Session, error) {
+func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.SessionCache, cwdMatch func(string) bool) ([]*model.Session, error) {
 	if sessionsDir == "" {
 		return nil, fmt.Errorf("could not find home directory")
 	}
@@ -76,9 +91,24 @@ func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.Session
 		cached, offset, mtime := cache.GetIncremental(path)
 
 		if cached != nil && offset == 0 {
+			// Full cache hit — we already know the cwd, no need to touch the file.
+			if cwdMatch != nil && !cwdMatch(cached.CWD) {
+				return nil
+			}
 			sessions = append(sessions, cached)
 			return nil
 		}
+
+		if cwdMatch != nil {
+			// Cheap prefilter before committing to a full (or incremental)
+			// parse: head-read the file's cwd from its first line. If it
+			// can't be determined, conservatively fall through to a full
+			// parse rather than risk silently dropping a session.
+			if cwd, ok := headCWD(path); ok && !cwdMatch(cwd) {
+				return nil
+			}
+		}
+
 		jobs = append(jobs, parseJob{
 			path:   path,
 			cached: cached,
@@ -222,6 +252,62 @@ type sessionMetaPayload struct {
 	CLIVersion    string          `json:"cli_version"`
 	AgentNickname string          `json:"agent_nickname"`
 	Source        json.RawMessage `json:"source"`
+}
+
+// maxHeadLineSize bounds how much of a rollout file's first line headCWD
+// will read before giving up, so a pathological line can't force reading
+// large amounts of data into memory.
+const maxHeadLineSize = 1 << 20 // 1 MiB
+
+// headCWD reads only the first line of a Codex rollout JSONL file and, if it
+// is a well-formed session_meta entry with a non-empty cwd, returns that cwd.
+// It never reads past the first newline (or maxHeadLineSize, whichever comes
+// first), so it stays cheap even on multi-GiB files. ok is false whenever the
+// cwd could not be determined (missing file, empty file, unparsable first
+// line, wrong envelope type, or missing cwd) — callers should treat that as
+// "unknown, don't filter it out" rather than "no match".
+func headCWD(path string) (cwd string, ok bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	r := bufio.NewReaderSize(f, 64*1024)
+	var line []byte
+	for {
+		chunk, err := r.ReadSlice('\n')
+		line = append(line, chunk...)
+		if len(line) > maxHeadLineSize {
+			return "", false
+		}
+		if err == nil {
+			break
+		}
+		if err == bufio.ErrBufferFull {
+			continue
+		}
+		if err == io.EOF {
+			if len(line) == 0 {
+				return "", false
+			}
+			break // last (only) line, no trailing newline
+		}
+		return "", false
+	}
+
+	var env jsonlEnvelope
+	if err := json.Unmarshal(bytes.TrimRight(line, "\r\n"), &env); err != nil {
+		return "", false
+	}
+	if env.Type != "session_meta" {
+		return "", false
+	}
+	var meta sessionMetaPayload
+	if err := json.Unmarshal(env.Payload, &meta); err != nil || meta.CWD == "" {
+		return "", false
+	}
+	return meta.CWD, true
 }
 
 type turnContextPayload struct {

--- a/internal/codex/process.go
+++ b/internal/codex/process.go
@@ -221,6 +221,9 @@ func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.Session
 	}
 
 	cache.Prune(seen)
+	if cwdIdx != nil {
+		cwdIdx.Prune(seen)
+	}
 	return sessions, nil
 }
 

--- a/internal/codex/process.go
+++ b/internal/codex/process.go
@@ -38,7 +38,7 @@ func SessionIndexPath() string {
 
 // DiscoverSessions scans the Codex sessions tree for JSONL session files.
 func DiscoverSessions(cache *model.SessionCache) ([]*model.Session, error) {
-	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache, nil)
+	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache, nil, nil)
 }
 
 // DiscoverSessionsFiltered scans the Codex sessions tree like DiscoverSessions,
@@ -59,7 +59,17 @@ func DiscoverSessions(cache *model.SessionCache) ([]*model.Session, error) {
 // cwdMatch may be nil, in which case every session matches (equivalent to
 // DiscoverSessions).
 func DiscoverSessionsFiltered(cache *model.SessionCache, cwdMatch func(string) bool) ([]*model.Session, error) {
-	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache, cwdMatch)
+	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache, cwdMatch, nil)
+}
+
+// DiscoverSessionsFilteredIndexed is DiscoverSessionsFiltered plus a
+// CWDIndex: cwdIdx (may be nil, equivalent to DiscoverSessionsFiltered)
+// lets the head/tail prefilter reuse previously-determined results — from
+// earlier in this process or reloaded from a persisted index written by a
+// previous run — for files whose (mtime, size) haven't changed, avoiding
+// the I/O entirely for files that keep getting skipped run after run.
+func DiscoverSessionsFilteredIndexed(cache *model.SessionCache, cwdMatch func(string) bool, cwdIdx *CWDIndex) ([]*model.Session, error) {
+	return discoverSessionsFromDir(SessionsDir(), SessionIndexPath(), cache, cwdMatch, cwdIdx)
 }
 
 type parseJob struct {
@@ -76,7 +86,7 @@ type parseResult struct {
 	newOffset int64
 }
 
-func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.SessionCache, cwdMatch func(string) bool) ([]*model.Session, error) {
+func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.SessionCache, cwdMatch func(string) bool, cwdIdx *CWDIndex) ([]*model.Session, error) {
 	if sessionsDir == "" {
 		return nil, fmt.Errorf("could not find home directory")
 	}
@@ -117,7 +127,7 @@ func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.Session
 			// regardless, any cached.CWD they'd be checked against may
 			// already be stale, and the uniform post-parse filter below is
 			// the single source of truth for whether they're included.
-			if !shouldParseForCWD(path, cwdMatch) {
+			if !shouldParseForCWDIndexed(path, cwdMatch, cwdIdx) {
 				return nil
 			}
 		}
@@ -418,17 +428,57 @@ func tailFinalCWD(path string) (cwd string, found bool) {
 // returns true, so a session is never skipped without certainty; the actual
 // parsed cwd is still checked afterward by the caller's uniform post-parse
 // filter.
+//
+// This is shouldParseForCWDIndexed with a nil index (always live I/O) — see
+// that function for the cache-aware version used by discovery once a
+// CWDIndex is available.
 func shouldParseForCWD(path string, cwdMatch func(string) bool) bool {
-	cwd, ok := headCWD(path)
+	return shouldParseForCWDIndexed(path, cwdMatch, nil)
+}
+
+// shouldParseForCWDIndexed is shouldParseForCWD's cache-aware counterpart:
+// byte-for-byte the same decision tree (see shouldParseForCWD's doc
+// comment), but each of the two underlying I/O primitives — headCWD and
+// tailFinalCWD — is looked up through cwdIdx when cwdIdx is non-nil,
+// instead of always re-reading the file. Both primitives are pure functions
+// of a file's content (they take no matcher), so a cached result is exactly
+// what fresh I/O would return for an unchanged file, regardless of which
+// matcher originally populated the cache entry — reusing them changes
+// nothing about the decision itself, only how the two inputs are obtained.
+// cwdIdx == nil reproduces shouldParseForCWD's plain (always-live-I/O)
+// behavior exactly.
+func shouldParseForCWDIndexed(path string, cwdMatch func(string) bool, cwdIdx *CWDIndex) bool {
+	if cwdIdx == nil {
+		cwd, ok := headCWD(path)
+		if !ok {
+			return true // can't tell from the head — parse it
+		}
+		if cwdMatch(cwd) {
+			return true
+		}
+		tail, found := tailFinalCWD(path)
+		if !found {
+			return true // tail window didn't contain a turn_context — parse it
+		}
+		return cwdMatch(tail)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return true // can't stat — conservative parse, same as headCWD's own "can't open" -> not ok -> true
+	}
+	mtime, size := info.ModTime(), info.Size()
+
+	cwd, ok := cwdIdx.headCWDIndexed(path, mtime, size)
 	if !ok {
-		return true // can't tell from the head — parse it
+		return true
 	}
 	if cwdMatch(cwd) {
 		return true
 	}
-	tail, found := tailFinalCWD(path)
+	tail, found := cwdIdx.tailFinalCWDIndexed(path, mtime, size)
 	if !found {
-		return true // tail window didn't contain a turn_context — parse it
+		return true
 	}
 	return cwdMatch(tail)
 }

--- a/internal/codex/process.go
+++ b/internal/codex/process.go
@@ -42,11 +42,19 @@ func DiscoverSessions(cache *model.SessionCache) ([]*model.Session, error) {
 }
 
 // DiscoverSessionsFiltered scans the Codex sessions tree like DiscoverSessions,
-// but skips fully parsing files whose working directory does not match
-// cwdMatch. A file's cwd is determined cheaply via a head-read of its first
-// line (see headCWD); when that cannot be determined, the file is
-// conservatively treated as matching and fully parsed, so a session is never
-// silently dropped — the worst case is an unnecessary full parse.
+// but skips fully parsing files whose cwd is known — with certainty — not to
+// match cwdMatch. A file's *final* cwd (what a full parse would end up
+// producing, since later turn_context entries overwrite session_meta's
+// initial cwd — see parseJSONL's turn_context handling) is determined
+// cheaply via a head-read of the first line (headCWD) and, when that alone
+// isn't conclusive, a bounded backward scan of the file's last 512 KiB for
+// the most recent turn_context cwd (tailFinalCWD, see shouldParseForCWD). A
+// file is skipped ONLY when one of those positively resolves a non-matching
+// final cwd; whenever the outcome is uncertain (head unreadable, no
+// turn_context found in the tail window, etc.) the file is parsed anyway,
+// and every parsed session's *actual* final cwd is checked against cwdMatch
+// before being returned — so a session is never silently dropped, only ever
+// parsed unnecessarily in the worst case.
 //
 // cwdMatch may be nil, in which case every session matches (equivalent to
 // DiscoverSessions).
@@ -91,7 +99,9 @@ func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.Session
 		cached, offset, mtime := cache.GetIncremental(path)
 
 		if cached != nil && offset == 0 {
-			// Full cache hit — we already know the cwd, no need to touch the file.
+			// Full cache hit — cached.CWD is the *final* cwd from a
+			// previous full parse (turn_context overwrites already applied),
+			// so it's safe to filter on directly without touching the file.
 			if cwdMatch != nil && !cwdMatch(cached.CWD) {
 				return nil
 			}
@@ -99,12 +109,15 @@ func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.Session
 			return nil
 		}
 
-		if cwdMatch != nil {
-			// Cheap prefilter before committing to a full (or incremental)
-			// parse: head-read the file's cwd from its first line. If it
-			// can't be determined, conservatively fall through to a full
-			// parse rather than risk silently dropping a session.
-			if cwd, ok := headCWD(path); ok && !cwdMatch(cwd) {
+		if cwdMatch != nil && cached == nil {
+			// A genuine first-time full parse (no cached data at all): try
+			// to rule the file out before committing to the expensive parse.
+			// Incremental jobs (cached != nil, offset > 0) are deliberately
+			// NOT prefiltered here — their appended bytes are cheap to parse
+			// regardless, any cached.CWD they'd be checked against may
+			// already be stale, and the uniform post-parse filter below is
+			// the single source of truth for whether they're included.
+			if !shouldParseForCWD(path, cwdMatch) {
 				return nil
 			}
 		}
@@ -183,7 +196,16 @@ func discoverSessionsFromDir(sessionsDir, indexPath string, cache *model.Session
 				continue
 			}
 			enrichSession(r.session, wtCache, names)
+			// Always cache the fully parsed result, regardless of this
+			// call's matcher — the cache is shared across queries.
 			cache.Put(r.path, r.mtime, r.newOffset, r.session)
+			// Uniform post-parse filter: the head/tail prefilter above is
+			// purely a skip optimization, so the parsed session's actual
+			// CWD (not whatever the prefilter guessed) is the single
+			// source of truth for whether it's returned.
+			if cwdMatch != nil && !cwdMatch(r.session.CWD) {
+				continue
+			}
 			sessions = append(sessions, r.session)
 		}
 	}
@@ -308,6 +330,107 @@ func headCWD(path string) (cwd string, ok bool) {
 		return "", false
 	}
 	return meta.CWD, true
+}
+
+// maxTailScanSize bounds how much of a rollout file's tail tailFinalCWD will
+// read when looking for the last turn_context cwd.
+const maxTailScanSize = 512 * 1024 // 512 KiB
+
+// tailFinalCWD reads up to the last maxTailScanSize bytes of a Codex rollout
+// file (a single bounded seek+read) and scans backwards through its lines
+// for the most recent turn_context entry with a non-empty payload.cwd —
+// mirroring parseJSONL's turn_context handling, where later entries
+// overwrite the session's cwd and an empty cwd does not overwrite. Because
+// later turn_context entries always win, the last non-empty one (searching
+// backwards from EOF) IS the file's final cwd, matching what a full parse
+// would produce.
+//
+// found is false when no turn_context with a non-empty cwd appears in the
+// scanned window — the file may have none at all, or the last one lies
+// further back than the window covers — callers must treat that as
+// "unknown, don't rule the file out" rather than "no match".
+func tailFinalCWD(path string) (cwd string, found bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return "", false
+	}
+	size := info.Size()
+	if size == 0 {
+		return "", false
+	}
+
+	start := int64(0)
+	if size > maxTailScanSize {
+		start = size - maxTailScanSize
+	}
+	if _, err := f.Seek(start, io.SeekStart); err != nil {
+		return "", false
+	}
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return "", false
+	}
+
+	lines := bytes.Split(buf, []byte("\n"))
+	if start > 0 && len(lines) > 0 {
+		// The window boundary likely cut the first line off mid-record —
+		// discard it rather than risk mis-parsing a truncated line.
+		lines = lines[1:]
+	}
+
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := bytes.TrimRight(lines[i], "\r")
+		if len(line) == 0 {
+			continue
+		}
+		var env jsonlEnvelope
+		if err := json.Unmarshal(line, &env); err != nil {
+			continue
+		}
+		if env.Type != "turn_context" {
+			continue
+		}
+		var ctx turnContextPayload
+		if err := json.Unmarshal(env.Payload, &ctx); err != nil {
+			continue
+		}
+		if ctx.CWD != "" {
+			return ctx.CWD, true
+		}
+	}
+	return "", false
+}
+
+// shouldParseForCWD reports whether a rollout file might still end up
+// matching cwdMatch and should therefore be parsed. It tries headCWD first
+// (cheap, first line only); if that doesn't match, it falls back to
+// tailFinalCWD, which finds the file's actual final cwd (later turn_context
+// entries overwrite session_meta's initial cwd — see parseJSONL). It returns
+// false — "skip, don't parse" — ONLY when the tail scan positively finds a
+// non-matching final cwd. Every other outcome (head matches, tail finds a
+// match, or neither head nor tail can determine the cwd) conservatively
+// returns true, so a session is never skipped without certainty; the actual
+// parsed cwd is still checked afterward by the caller's uniform post-parse
+// filter.
+func shouldParseForCWD(path string, cwdMatch func(string) bool) bool {
+	cwd, ok := headCWD(path)
+	if !ok {
+		return true // can't tell from the head — parse it
+	}
+	if cwdMatch(cwd) {
+		return true
+	}
+	tail, found := tailFinalCWD(path)
+	if !found {
+		return true // tail window didn't contain a turn_context — parse it
+	}
+	return cwdMatch(tail)
 }
 
 type turnContextPayload struct {

--- a/internal/codex/process_test.go
+++ b/internal/codex/process_test.go
@@ -51,7 +51,7 @@ func TestDiscoverSessions_FromSyntheticDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -166,7 +166,7 @@ func TestDiscoverSessions_ParallelMultipleFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestDiscoverSessionsFiltered_ScopesToMatchingCWD(t *testing.T) {
 
 	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
 
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchA)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchA, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -318,7 +318,7 @@ func TestDiscoverSessionsFiltered_NilMatcherReturnsAll(t *testing.T) {
 	writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
 	writeRolloutFile(t, dir, 3, "sess-c-0000-0000-0000-000000000000", "")
 
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -343,7 +343,7 @@ func TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile(
 
 	cache := model.NewSessionCache()
 	// Prime the cache with a full parse (nil matcher) so both files are cached.
-	if _, err := discoverSessionsFromDir(dir, indexPath, cache, nil); err != nil {
+	if _, err := discoverSessionsFromDir(dir, indexPath, cache, nil, nil); err != nil {
 		t.Fatalf("priming pass: unexpected error: %v", err)
 	}
 
@@ -363,7 +363,7 @@ func TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile(
 	}
 
 	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
-	sessions, err := discoverSessionsFromDir(dir, indexPath, cache, matchA)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, cache, matchA, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestDiscoverSessions_StillReturnsEverything(t *testing.T) {
 	writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
 	writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
 
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -540,7 +540,7 @@ func TestDiscoverSessionsFiltered_CWDDriftMatchesFinalCWDViaTailScan(t *testing.
 	path := writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", false))
 
 	matchB := func(cwd string) bool { return cwd == "/tmp/project-b" }
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchB)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchB, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -563,7 +563,7 @@ func TestDiscoverSessionsFiltered_CWDDriftExcludesOriginalCWDViaPostParseFilter(
 	// session's *final* cwd (after the turn_context) is project-b, so it
 	// must be excluded now that the post-parse filter is authoritative.
 	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchA)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchA, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -579,7 +579,7 @@ func TestDiscoverSessionsFiltered_EmptyTurnContextCWDDoesNotOverwriteFinal(t *te
 	writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", true))
 
 	matchB := func(cwd string) bool { return cwd == "/tmp/project-b" }
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchB)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchB, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -618,7 +618,7 @@ func TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery(t *tes
 
 	for name, matcher := range matchers {
 		t.Run(name, func(t *testing.T) {
-			full, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+			full, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil, nil)
 			if err != nil {
 				t.Fatalf("full discovery: unexpected error: %v", err)
 			}
@@ -630,7 +630,7 @@ func TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery(t *tes
 			}
 			sort.Strings(want)
 
-			got, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matcher)
+			got, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matcher, nil)
 			if err != nil {
 				t.Fatalf("filtered discovery: unexpected error: %v", err)
 			}
@@ -655,7 +655,7 @@ func TestDiscoverSessionsFiltered_IncrementalCacheHitUsesPostParseFilterNotStale
 
 	cache := model.NewSessionCache()
 	// Prime the cache with a full parse — cached.CWD is now /tmp/project-a.
-	if _, err := discoverSessionsFromDir(dir, indexPath, cache, nil); err != nil {
+	if _, err := discoverSessionsFromDir(dir, indexPath, cache, nil, nil); err != nil {
 		t.Fatalf("priming pass: unexpected error: %v", err)
 	}
 
@@ -674,7 +674,7 @@ func TestDiscoverSessionsFiltered_IncrementalCacheHitUsesPostParseFilterNotStale
 	}
 
 	matchB := func(cwd string) bool { return cwd == "/tmp/project-b" }
-	sessions, err := discoverSessionsFromDir(dir, indexPath, cache, matchB)
+	sessions, err := discoverSessionsFromDir(dir, indexPath, cache, matchB, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/codex/process_test.go
+++ b/internal/codex/process_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
@@ -270,7 +273,16 @@ func TestDiscoverSessionsFiltered_ScopesToMatchingCWD(t *testing.T) {
 
 	pathA := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
 	pathB := writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
-	pathMalformed := writeRolloutFile(t, dir, 3, "sess-c-0000-0000-0000-000000000000", "")
+	// Malformed first line (headCWD can't determine a cwd from it), but a
+	// real turn_context line further down establishes the session's actual
+	// cwd as project-a. This exercises the "unreadable head -> conservative
+	// full parse" path and confirms the file is genuinely parsed (not
+	// blanket-included) and correctly included because its *real* parsed
+	// cwd matches — not because the head was unreadable.
+	pathMalformed := writeRolloutFileRaw(t, dir, 3, "sess-c-0000-0000-0000-000000000000", []string{
+		`not a json line at all`,
+		`{"timestamp":"2026-03-03T11:00:01.000Z","type":"turn_context","payload":{"cwd":"/tmp/project-a","model":"gpt-5.2-codex","git":{"branch":"main"}}}`,
+	})
 
 	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
 
@@ -288,7 +300,7 @@ func TestDiscoverSessionsFiltered_ScopesToMatchingCWD(t *testing.T) {
 		t.Errorf("expected matching cwd file %s to be included", pathA)
 	}
 	if !gotPaths[pathMalformed] {
-		t.Errorf("expected malformed-first-line file %s to be included (conservative fallback)", pathMalformed)
+		t.Errorf("expected malformed-first-line file %s to be included: unreadable head must fall through to a full parse, and its real cwd (from turn_context) matches", pathMalformed)
 	}
 	if gotPaths[pathB] {
 		t.Errorf("did not expect non-matching cwd file %s to be included", pathB)
@@ -315,7 +327,14 @@ func TestDiscoverSessionsFiltered_NilMatcherReturnsAll(t *testing.T) {
 	}
 }
 
-func TestDiscoverSessionsFiltered_CacheHitFilteredWithoutFileRead(t *testing.T) {
+// TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile
+// asserts the full-cache-hit fast path actually relies on cached.CWD instead
+// of touching the file: it corrupts pathA's on-disk content after priming
+// the cache (while preserving its exact mtime, so GetIncremental still
+// reports a full hit) and confirms the filtered result is still correct —
+// which is only possible if the cached CWD, not a re-read of the now-garbage
+// file, is what got checked.
+func TestDiscoverSessionsFiltered_FullCacheHitUsesCachedCWDWithoutRereadingFile(t *testing.T) {
 	dir := t.TempDir()
 	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
 
@@ -326,6 +345,21 @@ func TestDiscoverSessionsFiltered_CacheHitFilteredWithoutFileRead(t *testing.T) 
 	// Prime the cache with a full parse (nil matcher) so both files are cached.
 	if _, err := discoverSessionsFromDir(dir, indexPath, cache, nil); err != nil {
 		t.Fatalf("priming pass: unexpected error: %v", err)
+	}
+
+	infoA, err := os.Stat(pathA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtimeA := infoA.ModTime()
+
+	// Corrupt pathA on disk (a re-read would find no valid cwd at all), but
+	// restore its exact mtime so the cache still treats it as unchanged.
+	if err := os.WriteFile(pathA, []byte("garbage, not json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(pathA, mtimeA, mtimeA); err != nil {
+		t.Fatal(err)
 	}
 
 	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
@@ -339,7 +373,7 @@ func TestDiscoverSessionsFiltered_CacheHitFilteredWithoutFileRead(t *testing.T) 
 		gotPaths[s.JSONLPath] = true
 	}
 	if !gotPaths[pathA] {
-		t.Errorf("expected cached matching-cwd file %s to be included", pathA)
+		t.Errorf("expected cached matching-cwd file %s to be included via cached.CWD despite corrupted on-disk content", pathA)
 	}
 	if gotPaths[pathB] {
 		t.Errorf("did not expect cached non-matching-cwd file %s to be included", pathB)
@@ -359,5 +393,292 @@ func TestDiscoverSessions_StillReturnsEverything(t *testing.T) {
 	}
 	if len(sessions) != 2 {
 		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+}
+
+// writeRolloutFileRaw writes a rollout file with exactly the given raw JSONL
+// lines, for tests that need to control turn_context entries precisely
+// (e.g. cwd drift scenarios that writeRolloutFile can't express).
+func writeRolloutFileRaw(t *testing.T, root string, day int, sessionID string, lines []string) string {
+	t.Helper()
+	dayDir := filepath.Join(root, "2026", "03", fmt.Sprintf("%02d", day))
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dayDir, fmt.Sprintf("rollout-2026-03-%02dT11-00-00-%s.jsonl", day, sessionID))
+	content := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// --- tailFinalCWD ---
+
+func TestTailFinalCWD_FindsLastNonEmptyCWD(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.jsonl")
+	content := `{"timestamp":"2026-03-01T11:00:00.000Z","type":"session_meta","payload":{"id":"s1","cwd":"/tmp/a"}}
+{"timestamp":"2026-03-01T11:00:01.000Z","type":"turn_context","payload":{"cwd":"/tmp/b"}}
+{"timestamp":"2026-03-01T11:00:02.000Z","type":"turn_context","payload":{}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, found := tailFinalCWD(path)
+	if !found {
+		t.Fatal("tailFinalCWD found = false, want true")
+	}
+	if cwd != "/tmp/b" {
+		t.Fatalf("cwd = %q, want /tmp/b (the empty-cwd turn_context after it must not win)", cwd)
+	}
+}
+
+func TestTailFinalCWD_NotFoundWhenNoTurnContext(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.jsonl")
+	content := `{"timestamp":"2026-03-01T11:00:00.000Z","type":"session_meta","payload":{"id":"s1","cwd":"/tmp/a"}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, found := tailFinalCWD(path); found {
+		t.Fatal("tailFinalCWD found = true, want false")
+	}
+}
+
+func TestTailFinalCWD_OutOfWindowTurnContextNotFound(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.jsonl")
+
+	var b strings.Builder
+	b.WriteString(`{"timestamp":"2026-03-01T11:00:00.000Z","type":"turn_context","payload":{"cwd":"/tmp/early"}}` + "\n")
+	// Pad well past the tail scan window with filler lines that aren't turn_context.
+	padLine := `{"timestamp":"2026-03-01T11:00:00.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"` + strings.Repeat("x", 200) + `"}]}}` + "\n"
+	for b.Len() < maxTailScanSize+4096 {
+		b.WriteString(padLine)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, found := tailFinalCWD(path); found {
+		t.Fatal("tailFinalCWD found = true, want false (the only turn_context lies outside the tail window)")
+	}
+}
+
+func TestTailFinalCWD_MissingFile(t *testing.T) {
+	if _, found := tailFinalCWD(filepath.Join(t.TempDir(), "missing.jsonl")); found {
+		t.Fatal("tailFinalCWD found = true, want false for missing file")
+	}
+}
+
+// --- shouldParseForCWD ---
+
+func TestShouldParseForCWD_HeadMatches(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	match := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	if !shouldParseForCWD(path, match) {
+		t.Fatal("shouldParseForCWD = false, want true (head matches)")
+	}
+}
+
+func TestShouldParseForCWD_TailConclusivelyRulesOut(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", []string{
+		`{"timestamp":"2026-03-01T11:00:00.000Z","type":"session_meta","payload":{"id":"s1","cwd":"/tmp/project-a"}}`,
+		`{"timestamp":"2026-03-01T11:00:01.000Z","type":"turn_context","payload":{"cwd":"/tmp/project-c"}}`,
+	})
+	match := func(cwd string) bool { return cwd == "/tmp/project-b" }
+	if shouldParseForCWD(path, match) {
+		t.Fatal("shouldParseForCWD = true, want false (tail conclusively shows a different final cwd)")
+	}
+}
+
+func TestShouldParseForCWD_TailInconclusiveFallsBackToParse(t *testing.T) {
+	dir := t.TempDir()
+	// writeRolloutFile emits session_meta + a response_item — no turn_context
+	// at all, so the tail scan can't determine a final cwd.
+	path := writeRolloutFile(t, dir, 1, "sess-only-meta-0000-0000-0000-000000000000", "/tmp/project-a")
+	match := func(cwd string) bool { return cwd == "/tmp/project-b" }
+	if !shouldParseForCWD(path, match) {
+		t.Fatal("shouldParseForCWD = false, want true (no turn_context in tail window — conservative parse)")
+	}
+}
+
+func TestShouldParseForCWD_HeadUnreadableFallsBackToParse(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRolloutFile(t, dir, 1, "sess-c-0000-0000-0000-000000000000", "") // malformed head
+	match := func(cwd string) bool { return false }
+	if !shouldParseForCWD(path, match) {
+		t.Fatal("shouldParseForCWD = false, want true (head unreadable — conservative parse)")
+	}
+}
+
+// --- CWD drift end-to-end (the case the head-only prefilter used to get wrong) ---
+
+func driftFixtureLines(finalCWD string, trailingEmptyTurnContext bool) []string {
+	lines := []string{
+		`{"timestamp":"2026-03-01T11:00:00.000Z","type":"session_meta","payload":{"id":"sess-drift","cwd":"/tmp/project-a","cli_version":"0.116.0","source":"cli"}}`,
+		fmt.Sprintf(`{"timestamp":"2026-03-01T11:00:01.000Z","type":"turn_context","payload":{"cwd":"%s","model":"gpt-5.2-codex","git":{"branch":"main"}}}`, finalCWD),
+	}
+	if trailingEmptyTurnContext {
+		lines = append(lines, `{"timestamp":"2026-03-01T11:00:02.000Z","type":"turn_context","payload":{"model":"gpt-5.2-codex","git":{"branch":"main"}}}`)
+	} else {
+		lines = append(lines, `{"timestamp":"2026-03-01T11:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}`)
+	}
+	return lines
+}
+
+func TestDiscoverSessionsFiltered_CWDDriftMatchesFinalCWDViaTailScan(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	path := writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", false))
+
+	matchB := func(cwd string) bool { return cwd == "/tmp/project-b" }
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].JSONLPath != path {
+		t.Fatalf("sessions = %#v, want the drifted session included (final cwd is project-b, even though session_meta said project-a)", sessions)
+	}
+	if sessions[0].CWD != "/tmp/project-b" {
+		t.Fatalf("CWD = %q, want /tmp/project-b", sessions[0].CWD)
+	}
+}
+
+func TestDiscoverSessionsFiltered_CWDDriftExcludesOriginalCWDViaPostParseFilter(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", false))
+
+	// Head (session_meta) says project-a, so this matcher would have
+	// wrongly included the session under the old head-only prefilter. The
+	// session's *final* cwd (after the turn_context) is project-b, so it
+	// must be excluded now that the post-parse filter is authoritative.
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("sessions = %#v, want empty: final cwd is project-b, not project-a, despite session_meta saying project-a", sessions)
+	}
+}
+
+func TestDiscoverSessionsFiltered_EmptyTurnContextCWDDoesNotOverwriteFinal(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	writeRolloutFileRaw(t, dir, 1, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", true))
+
+	matchB := func(cwd string) bool { return cwd == "/tmp/project-b" }
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %#v, want 1 (final cwd should still be project-b — the trailing turn_context has no cwd and must not overwrite it)", sessions)
+	}
+	if sessions[0].CWD != "/tmp/project-b" {
+		t.Fatalf("CWD = %q, want /tmp/project-b", sessions[0].CWD)
+	}
+}
+
+// TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery is an
+// equivalence-property test: for a tree covering a plain match, a plain
+// non-match, a malformed head, a cwd-drift file, and a no-turn_context file
+// (the "tail scan inconclusive" branch), DiscoverSessionsFiltered's result
+// must equal filtering a full (unfiltered) DiscoverSessions pass by the same
+// matcher — proving the fast path never silently drops a session the slow
+// path would have returned.
+func TestDiscoverSessionsFiltered_EquivalentToManualFilterOfFullDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
+	writeRolloutFile(t, dir, 3, "sess-c-0000-0000-0000-000000000000", "") // malformed head
+	writeRolloutFileRaw(t, dir, 4, "sess-drift-0000-0000-0000-000000000000", driftFixtureLines("/tmp/project-b", false))
+	writeRolloutFileRaw(t, dir, 5, "sess-only-meta-0000-0000-0000-000000000000", []string{
+		`{"timestamp":"2026-03-05T11:00:00.000Z","type":"session_meta","payload":{"id":"sess-only-meta","cwd":"/tmp/project-c","cli_version":"0.116.0","source":"cli"}}`,
+	})
+
+	matchers := map[string]func(string) bool{
+		"project-a":      func(cwd string) bool { return cwd == "/tmp/project-a" },
+		"project-b":      func(cwd string) bool { return cwd == "/tmp/project-b" },
+		"nothing-at-all": func(cwd string) bool { return cwd == "/tmp/does-not-exist" },
+	}
+
+	for name, matcher := range matchers {
+		t.Run(name, func(t *testing.T) {
+			full, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+			if err != nil {
+				t.Fatalf("full discovery: unexpected error: %v", err)
+			}
+			var want []string
+			for _, s := range full {
+				if matcher(s.CWD) {
+					want = append(want, s.JSONLPath)
+				}
+			}
+			sort.Strings(want)
+
+			got, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matcher)
+			if err != nil {
+				t.Fatalf("filtered discovery: unexpected error: %v", err)
+			}
+			var gotPaths []string
+			for _, s := range got {
+				gotPaths = append(gotPaths, s.JSONLPath)
+			}
+			sort.Strings(gotPaths)
+
+			if !slices.Equal(want, gotPaths) {
+				t.Fatalf("filtered discovery = %v, want %v (must equal manual filter of full discovery)", gotPaths, want)
+			}
+		})
+	}
+}
+
+func TestDiscoverSessionsFiltered_IncrementalCacheHitUsesPostParseFilterNotStaleCachedCWD(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	path := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+
+	cache := model.NewSessionCache()
+	// Prime the cache with a full parse — cached.CWD is now /tmp/project-a.
+	if _, err := discoverSessionsFromDir(dir, indexPath, cache, nil); err != nil {
+		t.Fatalf("priming pass: unexpected error: %v", err)
+	}
+
+	// Append a turn_context that moves the session's cwd to project-b. This
+	// grows the file, so the next GetIncremental returns (cached, offset>0)
+	// rather than a full hit — cached.CWD (project-a) is now stale.
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"timestamp":"2026-03-01T11:00:05.000Z","type":"turn_context","payload":{"cwd":"/tmp/project-b","model":"gpt-5.2-codex","git":{"branch":"main"}}}` + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	matchB := func(cwd string) bool { return cwd == "/tmp/project-b" }
+	sessions, err := discoverSessionsFromDir(dir, indexPath, cache, matchB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].CWD != "/tmp/project-b" {
+		t.Fatalf("sessions = %#v, want the incrementally-updated session included with final cwd project-b (stale cached.CWD project-a must not be used to filter it out)", sessions)
 	}
 }

--- a/internal/codex/process_test.go
+++ b/internal/codex/process_test.go
@@ -48,7 +48,7 @@ func TestDiscoverSessions_FromSyntheticDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache())
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestDiscoverSessions_ParallelMultipleFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache())
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -186,5 +186,178 @@ func TestDiscoverSessions_ParallelMultipleFiles(t *testing.T) {
 	}
 	if len(ids) != 5 {
 		t.Errorf("got %d unique session IDs, want 5", len(ids))
+	}
+}
+
+func TestHeadCWD_ValidSessionMeta(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.jsonl")
+	content := `{"timestamp":"2026-03-28T11:26:17.785Z","type":"session_meta","payload":{"id":"s1","cwd":"/tmp/project-a","cli_version":"0.116.0","source":"cli"}}
+{"timestamp":"2026-03-28T11:26:18.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, ok := headCWD(path)
+	if !ok {
+		t.Fatal("headCWD ok = false, want true")
+	}
+	if cwd != "/tmp/project-a" {
+		t.Fatalf("headCWD cwd = %q, want /tmp/project-a", cwd)
+	}
+}
+
+func TestHeadCWD_GarbageFirstLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.jsonl")
+	content := "not valid json at all\n{\"timestamp\":\"2026-03-28T11:26:18.000Z\",\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/tmp/project-a\"}}\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := headCWD(path); ok {
+		t.Fatal("headCWD ok = true, want false for garbage first line")
+	}
+}
+
+func TestHeadCWD_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := headCWD(path); ok {
+		t.Fatal("headCWD ok = true, want false for empty file")
+	}
+}
+
+func TestHeadCWD_NonexistentFile(t *testing.T) {
+	if _, ok := headCWD(filepath.Join(t.TempDir(), "missing.jsonl")); ok {
+		t.Fatal("headCWD ok = true, want false for missing file")
+	}
+}
+
+// writeRolloutFile is a small helper for the DiscoverSessionsFiltered tests:
+// it writes a minimal rollout file with the given cwd (or, if cwd is empty,
+// a garbage first line that headCWD cannot parse) under dir/2026/03/<day>.
+func writeRolloutFile(t *testing.T, root string, day int, sessionID, cwd string) string {
+	t.Helper()
+	dayDir := filepath.Join(root, "2026", "03", fmt.Sprintf("%02d", day))
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dayDir, fmt.Sprintf("rollout-2026-03-%02dT11-00-00-%s.jsonl", day, sessionID))
+
+	var firstLine string
+	if cwd == "" {
+		firstLine = `not a json line at all`
+	} else {
+		firstLine = fmt.Sprintf(`{"timestamp":"2026-03-%02dT11:00:00.000Z","type":"session_meta","payload":{"id":"%s","cwd":"%s","cli_version":"0.116.0","source":"cli"}}`, day, sessionID, cwd)
+	}
+	content := firstLine + "\n" + fmt.Sprintf(`{"timestamp":"2026-03-%02dT11:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}`, day) + "\n"
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDiscoverSessionsFiltered_ScopesToMatchingCWD(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	pathA := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	pathB := writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
+	pathMalformed := writeRolloutFile(t, dir, 3, "sess-c-0000-0000-0000-000000000000", "")
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), matchA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotPaths := make(map[string]bool)
+	for _, s := range sessions {
+		gotPaths[s.JSONLPath] = true
+	}
+
+	if !gotPaths[pathA] {
+		t.Errorf("expected matching cwd file %s to be included", pathA)
+	}
+	if !gotPaths[pathMalformed] {
+		t.Errorf("expected malformed-first-line file %s to be included (conservative fallback)", pathMalformed)
+	}
+	if gotPaths[pathB] {
+		t.Errorf("did not expect non-matching cwd file %s to be included", pathB)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
+	}
+}
+
+func TestDiscoverSessionsFiltered_NilMatcherReturnsAll(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
+	writeRolloutFile(t, dir, 3, "sess-c-0000-0000-0000-000000000000", "")
+
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Fatalf("got %d sessions, want 3 (nil matcher must not filter anything)", len(sessions))
+	}
+}
+
+func TestDiscoverSessionsFiltered_CacheHitFilteredWithoutFileRead(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	pathA := writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	pathB := writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
+
+	cache := model.NewSessionCache()
+	// Prime the cache with a full parse (nil matcher) so both files are cached.
+	if _, err := discoverSessionsFromDir(dir, indexPath, cache, nil); err != nil {
+		t.Fatalf("priming pass: unexpected error: %v", err)
+	}
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	sessions, err := discoverSessionsFromDir(dir, indexPath, cache, matchA)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotPaths := make(map[string]bool)
+	for _, s := range sessions {
+		gotPaths[s.JSONLPath] = true
+	}
+	if !gotPaths[pathA] {
+		t.Errorf("expected cached matching-cwd file %s to be included", pathA)
+	}
+	if gotPaths[pathB] {
+		t.Errorf("did not expect cached non-matching-cwd file %s to be included", pathB)
+	}
+}
+
+func TestDiscoverSessions_StillReturnsEverything(t *testing.T) {
+	dir := t.TempDir()
+	indexPath := filepath.Join(t.TempDir(), "session_index.jsonl")
+
+	writeRolloutFile(t, dir, 1, "sess-a-0000-0000-0000-000000000000", "/tmp/project-a")
+	writeRolloutFile(t, dir, 2, "sess-b-0000-0000-0000-000000000000", "/tmp/project-b")
+
+	sessions, err := discoverSessionsFromDir(dir, indexPath, model.NewSessionCache(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(sessions))
 	}
 }

--- a/internal/core/cache.go
+++ b/internal/core/cache.go
@@ -15,12 +15,13 @@ func firstErr(errs ...error) error {
 }
 
 // CachePersister is implemented by providers whose discovery caches can be
-// persisted between one-shot CLI runs (see internal/sessions.Run, the only
-// caller that wires this up — the TUI/GUI/API keep their in-memory-only
-// behavior). Both methods are best-effort: the cache is purely advisory, so
-// a non-nil error must never fail discovery. Callers are expected to invoke
-// these and ignore the returned error; it exists mainly so tests can assert
-// on it directly.
+// persisted between runs. internal/sessions.Run wires it up explicitly
+// around its own one-shot control flow; SessionManager.EnableCachePersistence
+// (used by the TUI, GUI/tray, and API server) wires it up once for every
+// long-lived surface. Both methods are best-effort: the cache is purely
+// advisory, so a non-nil error must never fail discovery. Callers are
+// expected to invoke these and ignore the returned error; it exists mainly
+// so tests can assert on it directly.
 type CachePersister interface {
 	// LoadCaches best-effort loads previously persisted caches from dir
 	// into the provider's in-memory caches.

--- a/internal/core/cache.go
+++ b/internal/core/cache.go
@@ -1,0 +1,62 @@
+package core
+
+// firstErr returns the first non-nil error among errs, or nil if all are
+// nil. Used by providers' SaveCaches/LoadCaches to report a problem from
+// whichever underlying cache file failed, while still attempting to save/
+// load every one of them (a failure on the cwd-index, say, shouldn't skip
+// saving the discovery cache).
+func firstErr(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CachePersister is implemented by providers whose discovery caches can be
+// persisted between one-shot CLI runs (see internal/sessions.Run, the only
+// caller that wires this up — the TUI/GUI/API keep their in-memory-only
+// behavior). Both methods are best-effort: the cache is purely advisory, so
+// a non-nil error must never fail discovery. Callers are expected to invoke
+// these and ignore the returned error; it exists mainly so tests can assert
+// on it directly.
+type CachePersister interface {
+	// LoadCaches best-effort loads previously persisted caches from dir
+	// into the provider's in-memory caches.
+	LoadCaches(dir string) error
+	// SaveCaches best-effort persists the provider's current in-memory
+	// caches to dir, creating dir (0700) if it doesn't exist.
+	SaveCaches(dir string) error
+}
+
+// LoadProviderCaches calls LoadCaches(dir) on p if p implements
+// CachePersister, recursing into a MultiProvider's members (so each member
+// that implements the interface gets a chance, and non-implementers are
+// silently skipped). The returned errors, if any, are discarded — loading a
+// persisted cache is advisory and must never fail discovery; see
+// CachePersister's doc comment.
+func LoadProviderCaches(p SessionProvider, dir string) {
+	if mp, ok := p.(MultiProvider); ok {
+		for _, member := range mp.Providers {
+			LoadProviderCaches(member, dir)
+		}
+		return
+	}
+	if cp, ok := p.(CachePersister); ok {
+		_ = cp.LoadCaches(dir)
+	}
+}
+
+// SaveProviderCaches is LoadProviderCaches's counterpart for SaveCaches.
+func SaveProviderCaches(p SessionProvider, dir string) {
+	if mp, ok := p.(MultiProvider); ok {
+		for _, member := range mp.Providers {
+			SaveProviderCaches(member, dir)
+		}
+		return
+	}
+	if cp, ok := p.(CachePersister); ok {
+		_ = cp.SaveCaches(dir)
+	}
+}

--- a/internal/core/cache_test.go
+++ b/internal/core/cache_test.go
@@ -1,0 +1,273 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// fakeCachePersister records LoadCaches/SaveCaches calls for testing
+// LoadProviderCaches/SaveProviderCaches's dispatch logic without touching
+// disk.
+type fakeCachePersister struct {
+	fakeProvider
+	loadedDir string
+	savedDir  string
+	loadErr   error
+	saveErr   error
+}
+
+func (f *fakeCachePersister) LoadCaches(dir string) error {
+	f.loadedDir = dir
+	return f.loadErr
+}
+
+func (f *fakeCachePersister) SaveCaches(dir string) error {
+	f.savedDir = dir
+	return f.saveErr
+}
+
+var _ CachePersister = (*fakeCachePersister)(nil)
+
+func TestLoadProviderCaches_NoopForNonImplementer(t *testing.T) {
+	p := fakeProvider{sessions: nil}
+	// Must not panic and must simply do nothing.
+	LoadProviderCaches(p, t.TempDir())
+}
+
+func TestSaveProviderCaches_NoopForNonImplementer(t *testing.T) {
+	p := fakeProvider{sessions: nil}
+	SaveProviderCaches(p, t.TempDir())
+}
+
+func TestLoadProviderCaches_CallsImplementer(t *testing.T) {
+	p := &fakeCachePersister{}
+	dir := t.TempDir()
+	LoadProviderCaches(p, dir)
+	if p.loadedDir != dir {
+		t.Fatalf("loadedDir = %q, want %q", p.loadedDir, dir)
+	}
+}
+
+func TestSaveProviderCaches_CallsImplementer(t *testing.T) {
+	p := &fakeCachePersister{}
+	dir := t.TempDir()
+	SaveProviderCaches(p, dir)
+	if p.savedDir != dir {
+		t.Fatalf("savedDir = %q, want %q", p.savedDir, dir)
+	}
+}
+
+// TestLoadProviderCaches_ErrorIsSwallowed and its Save counterpart document
+// that a non-nil error from LoadCaches/SaveCaches never propagates or
+// panics -- the cache is advisory and must never fail discovery.
+func TestLoadProviderCaches_ErrorIsSwallowed(t *testing.T) {
+	p := &fakeCachePersister{loadErr: errTest}
+	LoadProviderCaches(p, t.TempDir())
+}
+
+func TestSaveProviderCaches_ErrorIsSwallowed(t *testing.T) {
+	p := &fakeCachePersister{saveErr: errTest}
+	SaveProviderCaches(p, t.TempDir())
+}
+
+func TestLoadSaveProviderCaches_RecurseIntoMultiProvider(t *testing.T) {
+	implementer := &fakeCachePersister{}
+	nonImplementer := fakeProvider{}
+	mp := MultiProvider{Providers: []SessionProvider{implementer, nonImplementer}}
+
+	dir := t.TempDir()
+	LoadProviderCaches(mp, dir)
+	SaveProviderCaches(mp, dir)
+
+	if implementer.loadedDir != dir {
+		t.Fatalf("loadedDir = %q, want %q", implementer.loadedDir, dir)
+	}
+	if implementer.savedDir != dir {
+		t.Fatalf("savedDir = %q, want %q", implementer.savedDir, dir)
+	}
+}
+
+// --- compile-time interface assertions (also enforced alongside each
+// provider in provider.go, but keeping an explicit test-side check
+// documents the contract in one place) ---
+
+var (
+	_ CachePersister = (*LiveProvider)(nil)
+	_ CachePersister = (*CodexProvider)(nil)
+	_ CachePersister = (*PiProvider)(nil)
+	_ CachePersister = (*AmpProvider)(nil)
+	_ CachePersister = (*GrokProvider)(nil)
+	_ CachePersister = (*KimiProvider)(nil)
+)
+
+// --- CodexProvider: real Save/Load round trip ---
+
+func TestCodexProvider_SaveLoadCaches_RoundTrip(t *testing.T) {
+	dataDir := t.TempDir()
+	sessionPath := filepath.Join(dataDir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime := info.ModTime()
+
+	p := NewCodexProvider()
+	p.cache.Put(sessionPath, mtime, 10, &model.Session{SessionID: "s1", CWD: "/tmp/project-a", Agent: "codex"})
+
+	cacheDir := filepath.Join(t.TempDir(), "cachedir")
+	if err := p.SaveCaches(cacheDir); err != nil {
+		t.Fatalf("SaveCaches: %v", err)
+	}
+	for _, name := range []string{"discovery-codex.json", "cwdindex-codex.json"} {
+		if _, err := os.Stat(filepath.Join(cacheDir, name)); err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+	}
+
+	p2 := NewCodexProvider()
+	if err := p2.LoadCaches(cacheDir); err != nil {
+		t.Fatalf("LoadCaches: %v", err)
+	}
+
+	got, offset, gotMtime := p2.cache.GetIncremental(sessionPath)
+	if got == nil {
+		t.Fatal("GetIncremental after LoadCaches: got nil, want a full hit")
+	}
+	if offset != 0 || !gotMtime.Equal(mtime) || got.SessionID != "s1" {
+		t.Fatalf("got = (%+v, offset=%d, mtime=%v), want SessionID=s1 offset=0 mtime=%v", got, offset, gotMtime, mtime)
+	}
+}
+
+// TestCodexProvider_SaveCaches_CreatesDirWith0700 confirms SaveCaches
+// creates the cache directory itself (with 0700 perms) when it doesn't
+// already exist, since sessions.Run calls it without a separate mkdir step.
+func TestCodexProvider_SaveCaches_CreatesDirWith0700(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "does-not-exist-yet")
+
+	p := NewCodexProvider()
+	if err := p.SaveCaches(cacheDir); err != nil {
+		t.Fatalf("SaveCaches: %v", err)
+	}
+
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		t.Fatalf("expected cache dir to be created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("cache dir path is not a directory")
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("cache dir perms = %o, want 0700", perm)
+	}
+}
+
+// TestCodexProvider_LoadCaches_MissingDirIsAdvisory confirms LoadCaches on
+// a nonexistent directory (e.g. the very first run, before any cache was
+// ever saved) doesn't panic or leave the provider unusable -- it's
+// best-effort.
+func TestCodexProvider_LoadCaches_MissingDirIsAdvisory(t *testing.T) {
+	p := NewCodexProvider()
+	_ = p.LoadCaches(filepath.Join(t.TempDir(), "never-existed"))
+	got, _, _ := p.cache.GetIncremental(filepath.Join(t.TempDir(), "anything.jsonl"))
+	if got != nil {
+		t.Fatalf("cache after missing-dir LoadCaches = %+v, want nil (cold, untouched)", got)
+	}
+}
+
+// --- LiveProvider: real Save/Load round trip ---
+
+func TestLiveProvider_SaveLoadCaches_RoundTrip(t *testing.T) {
+	dataDir := t.TempDir()
+	sessionPath := filepath.Join(dataDir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime := info.ModTime()
+
+	p := NewLiveProvider(nil)
+	p.cache.Put(sessionPath, mtime, 10, &model.Session{SessionID: "s1", CWD: "/tmp/project-a", Agent: "claude"})
+
+	cacheDir := t.TempDir()
+	if err := p.SaveCaches(cacheDir); err != nil {
+		t.Fatalf("SaveCaches: %v", err)
+	}
+	for _, name := range []string{"discovery-claude.json", "cwdindex-claude.json"} {
+		if _, err := os.Stat(filepath.Join(cacheDir, name)); err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+	}
+
+	p2 := NewLiveProvider(nil)
+	if err := p2.LoadCaches(cacheDir); err != nil {
+		t.Fatalf("LoadCaches: %v", err)
+	}
+	got, offset, gotMtime := p2.cache.GetIncremental(sessionPath)
+	if got == nil || offset != 0 || !gotMtime.Equal(mtime) || got.SessionID != "s1" {
+		t.Fatalf("got = (%+v, offset=%d, mtime=%v), want SessionID=s1 offset=0 mtime=%v", got, offset, gotMtime, mtime)
+	}
+}
+
+// --- Pi/Amp/Grok/Kimi: file naming + round trip (they only wrap a plain
+// model.SessionCache, no cwd index) ---
+
+func TestPiProvider_SaveLoadCaches_RoundTrip(t *testing.T) {
+	p1, p2 := NewPiProvider(), NewPiProvider()
+	testSessionCacheOnlyProviderRoundTrip(t, "discovery-pi.json", p1, p1.cache, p2, p2.cache)
+}
+
+func TestAmpProvider_SaveLoadCaches_RoundTrip(t *testing.T) {
+	p1, p2 := NewAmpProvider(), NewAmpProvider()
+	testSessionCacheOnlyProviderRoundTrip(t, "discovery-amp.json", p1, p1.cache, p2, p2.cache)
+}
+
+func TestGrokProvider_SaveLoadCaches_RoundTrip(t *testing.T) {
+	p1, p2 := NewGrokProvider(), NewGrokProvider()
+	testSessionCacheOnlyProviderRoundTrip(t, "discovery-grok.json", p1, p1.cache, p2, p2.cache)
+}
+
+func TestKimiProvider_SaveLoadCaches_RoundTrip(t *testing.T) {
+	p1, p2 := NewKimiProvider(), NewKimiProvider()
+	testSessionCacheOnlyProviderRoundTrip(t, "discovery-kimi.json", p1, p1.cache, p2, p2.cache)
+}
+
+func testSessionCacheOnlyProviderRoundTrip(t *testing.T, wantFile string, p1 CachePersister, cache1 *model.SessionCache, p2 CachePersister, cache2 *model.SessionCache) {
+	t.Helper()
+	dataDir := t.TempDir()
+	sessionPath := filepath.Join(dataDir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime := info.ModTime()
+
+	cache1.Put(sessionPath, mtime, 10, &model.Session{SessionID: "s1"})
+
+	cacheDir := t.TempDir()
+	if err := p1.SaveCaches(cacheDir); err != nil {
+		t.Fatalf("SaveCaches: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, wantFile)); err != nil {
+		t.Fatalf("expected %s to exist: %v", wantFile, err)
+	}
+
+	if err := p2.LoadCaches(cacheDir); err != nil {
+		t.Fatalf("LoadCaches: %v", err)
+	}
+	got, offset, gotMtime := cache2.GetIncremental(sessionPath)
+	if got == nil || offset != 0 || !gotMtime.Equal(mtime) || got.SessionID != "s1" {
+		t.Fatalf("got = (%+v, offset=%d, mtime=%v), want SessionID=s1 offset=0 mtime=%v", got, offset, gotMtime, mtime)
+	}
+}

--- a/internal/core/cache_test.go
+++ b/internal/core/cache_test.go
@@ -10,21 +10,28 @@ import (
 
 // fakeCachePersister records LoadCaches/SaveCaches calls for testing
 // LoadProviderCaches/SaveProviderCaches's dispatch logic without touching
-// disk.
+// disk. loadCalls/saveCalls (in addition to the last-seen dir) let
+// SessionManager-level tests (session_persist_test.go) assert exactly how
+// many times each was invoked, e.g. "loaded exactly once before the first
+// discovery, never again on later reloads".
 type fakeCachePersister struct {
 	fakeProvider
 	loadedDir string
 	savedDir  string
 	loadErr   error
 	saveErr   error
+	loadCalls int
+	saveCalls int
 }
 
 func (f *fakeCachePersister) LoadCaches(dir string) error {
+	f.loadCalls++
 	f.loadedDir = dir
 	return f.loadErr
 }
 
 func (f *fakeCachePersister) SaveCaches(dir string) error {
+	f.saveCalls++
 	f.savedDir = dir
 	return f.saveErr
 }

--- a/internal/core/dirmatch.go
+++ b/internal/core/dirmatch.go
@@ -1,0 +1,80 @@
+package core
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// resolveSymlink returns the symlink-resolved, cleaned form of cleaned, and
+// whether that differs from cleaned (i.e. there was actually something to
+// resolve). Both DirMatchVariants and CWDMatchesDir need this same
+// clean+resolve step, just applied to different paths. A failure to resolve
+// (e.g. cleaned doesn't exist on disk) is not an error here: it just means
+// there is no additional variant to add, so callers fall back to the
+// cleaned path alone.
+func resolveSymlink(cleaned string) (resolved string, ok bool) {
+	r, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", false
+	}
+	r = filepath.Clean(r)
+	if r == cleaned {
+		return "", false
+	}
+	return r, true
+}
+
+// DirMatchVariants normalizes dir for matching: the cleaned absolute path
+// plus, when it differs, the symlink-resolved form — so /tmp also matches
+// sessions recorded under /private/tmp on macOS.
+//
+// dir need not exist on disk: this is pure path arithmetic
+// (filepath.Abs + filepath.Clean) plus a best-effort symlink resolution
+// that is silently skipped when filepath.EvalSymlinks fails (nonexistent
+// path, permission error, etc.) — callers that require dir to exist enforce
+// that themselves before calling this (see sessions.Run's os.Stat check).
+func DirMatchVariants(dir string) ([]string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	abs = filepath.Clean(abs)
+	variants := []string{abs}
+	if resolved, ok := resolveSymlink(abs); ok {
+		variants = append(variants, resolved)
+	}
+	return variants, nil
+}
+
+// matchesVariants reports whether cwd equals a variant or lies beneath one
+// (prefix on a path boundary: /foo/bar must not match /foo/barbaz).
+func matchesVariants(cwd string, variants []string) bool {
+	for _, v := range variants {
+		if cwd == v || strings.HasPrefix(cwd, v+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// CWDMatchesDir reports whether a session's recorded cwd falls under one of
+// the target variants (see DirMatchVariants). The spec matches on the
+// cleaned, *unresolved* recorded CWD first: a session recorded under a
+// symlinked subdirectory of the target (e.g. <target>/sub-link -> somewhere
+// else entirely) must still match, because the recorded path itself is
+// what lies under the target. Only when that fails do we fall back to
+// resolving symlinks in cwd, which is what lets e.g. /tmp-recorded sessions
+// match a /private/tmp target on macOS.
+func CWDMatchesDir(cwd string, variants []string) bool {
+	if cwd == "" {
+		return false
+	}
+	cwd = filepath.Clean(cwd)
+	if matchesVariants(cwd, variants) {
+		return true
+	}
+	if resolved, ok := resolveSymlink(cwd); ok {
+		return matchesVariants(resolved, variants)
+	}
+	return false
+}

--- a/internal/core/dirmatch_test.go
+++ b/internal/core/dirmatch_test.go
@@ -1,0 +1,125 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDirMatchDecisionTable is the shared-helper decision-equivalence table
+// (see task 15): every case here documents a match decision that
+// sessions.FilterByDir (via its targetVariants/matchesDir wrappers, which
+// delegate to DirMatchVariants/CWDMatchesDir) and the API's dir filter (via
+// these same functions called directly) must agree on, because both paths
+// run this exact code.
+func TestDirMatchDecisionTable(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		dir  string
+		cwd  string
+		want bool
+	}{
+		{"exact match", base, base, true},
+		{"subdirectory", base, sub, true},
+		{"false prefix sibling excluded", base, base + "extra", false},
+		{"unrelated path excluded", base, "/somewhere/else", false},
+		{"empty cwd excluded", base, "", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			variants, err := DirMatchVariants(c.dir)
+			if err != nil {
+				t.Fatalf("DirMatchVariants(%q): %v", c.dir, err)
+			}
+			if got := CWDMatchesDir(c.cwd, variants); got != c.want {
+				t.Errorf("CWDMatchesDir(%q, variants of %q) = %v, want %v", c.cwd, c.dir, got, c.want)
+			}
+		})
+	}
+}
+
+// TestDirMatchVariantsSymlinkedTarget: matching a symlinked target dir must
+// resolve it, so e.g. /tmp also matches sessions recorded under
+// /private/tmp on macOS.
+func TestDirMatchVariantsSymlinkedTarget(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	variants, err := DirMatchVariants(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !CWDMatchesDir(real, variants) {
+		t.Fatal("symlinked target should match the resolved cwd")
+	}
+}
+
+// TestDirMatchSessionUnderSymlinkedSubdir: a session recorded under a
+// symlinked subdirectory of the target (which resolves to somewhere else
+// entirely) must still match, because the recorded path itself lies under
+// the target on a string/path-boundary basis.
+func TestDirMatchSessionUnderSymlinkedSubdir(t *testing.T) {
+	target := t.TempDir()
+	external := t.TempDir()
+	subLink := filepath.Join(target, "sub-link")
+	if err := os.Symlink(external, subLink); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	variants, err := DirMatchVariants(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !CWDMatchesDir(subLink, variants) {
+		t.Fatal("session recorded under a symlinked subdir of the target must match")
+	}
+}
+
+// TestDirMatchVariantsNonexistentDir documents the API's relaxation vs. the
+// CLI: DirMatchVariants itself never requires dir to exist on disk (it's
+// pure path arithmetic — filepath.Abs + filepath.Clean — with a best-effort
+// symlink resolution that's silently skipped when EvalSymlinks fails, e.g.
+// because the path doesn't exist). The CLI's existence requirement is
+// enforced by sessions.Run's own os.Stat check, a layer above this
+// function, so it is not exercised here.
+func TestDirMatchVariantsNonexistentDir(t *testing.T) {
+	base := t.TempDir()
+	nonexistent := filepath.Join(base, "does-not-exist")
+	variants, err := DirMatchVariants(nonexistent)
+	if err != nil {
+		t.Fatalf("DirMatchVariants on a nonexistent dir must not error: %v", err)
+	}
+	if !CWDMatchesDir(nonexistent, variants) {
+		t.Fatal("a session recorded under the nonexistent-but-cleaned path must still match")
+	}
+}
+
+// TestDirMatchVariantsRelativeDir: a relative dir resolves against the
+// process's current working directory, same as filepath.Abs. The API
+// handler rejects non-absolute dir values before ever calling this
+// function; this test documents that the function itself still supports
+// relative input, which the CLI (--dir) relies on.
+func TestDirMatchVariantsRelativeDir(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(base)
+
+	variants, err := DirMatchVariants(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !CWDMatchesDir(sub, variants) {
+		t.Fatal("relative dir '.' should resolve against the process cwd, matching its subdirectories")
+	}
+}

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -135,6 +135,13 @@ func (p *CursorProvider) WatchDirs() []string {
 	return nil
 }
 
+// DirScopedProvider is implemented by providers that can discover sessions
+// for a single directory more cheaply than a full scan (e.g. by head-reading
+// each file's cwd before fully parsing it).
+type DirScopedProvider interface {
+	DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error)
+}
+
 // CodexProvider discovers Codex CLI sessions from JSONL transcripts.
 type CodexProvider struct {
 	cache *model.SessionCache
@@ -147,6 +154,12 @@ func NewCodexProvider() *CodexProvider {
 
 func (p *CodexProvider) DiscoverSessions() ([]*model.Session, error) {
 	return codex.DiscoverSessions(p.cache)
+}
+
+// DiscoverSessionsMatching implements DirScopedProvider: it scopes discovery
+// to files whose cwd matches cwdMatch, skipping full parses of the rest.
+func (p *CodexProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
+	return codex.DiscoverSessionsFiltered(p.cache, cwdMatch)
 }
 
 func (p *CodexProvider) UseWatcher() bool               { return false }
@@ -344,4 +357,61 @@ func (m MultiProvider) WatchDirs() []string {
 		dirs = append(dirs, p.WatchDirs()...)
 	}
 	return dirs
+}
+
+// DiscoverMatching discovers sessions from p, using the dir-scoped fast path
+// (DirScopedProvider) where p (or, for a MultiProvider, a member) implements
+// it. If p is a MultiProvider, its members are queried concurrently, with
+// the same best-effort error handling as MultiProvider.DiscoverSessions: a
+// failing member contributes nothing.
+//
+// Note: results from a member that does NOT implement DirScopedProvider come
+// from a plain DiscoverSessions call and are NOT pre-filtered by cwdMatch —
+// filtering those remains the caller's responsibility (e.g. via a downstream
+// FilterByDir pass).
+func DiscoverMatching(p SessionProvider, cwdMatch func(string) bool) ([]*model.Session, error) {
+	if mp, ok := p.(MultiProvider); ok {
+		return discoverMatchingMulti(mp, cwdMatch)
+	}
+	return discoverMatchingOne(p, cwdMatch)
+}
+
+func discoverMatchingOne(p SessionProvider, cwdMatch func(string) bool) ([]*model.Session, error) {
+	if dsp, ok := p.(DirScopedProvider); ok {
+		return dsp.DiscoverSessionsMatching(cwdMatch)
+	}
+	return p.DiscoverSessions()
+}
+
+func discoverMatchingMulti(mp MultiProvider, cwdMatch func(string) bool) ([]*model.Session, error) {
+	if len(mp.Providers) <= 1 {
+		// Fast path: no need for goroutines.
+		for _, p := range mp.Providers {
+			return discoverMatchingOne(p, cwdMatch)
+		}
+		return nil, nil
+	}
+
+	type result struct {
+		sessions []*model.Session
+	}
+	results := make([]result, len(mp.Providers))
+	var wg sync.WaitGroup
+	for i, p := range mp.Providers {
+		wg.Add(1)
+		go func(idx int, prov SessionProvider) {
+			defer wg.Done()
+			sessions, err := discoverMatchingOne(prov, cwdMatch)
+			if err == nil {
+				results[idx] = result{sessions: sessions}
+			}
+		}(i, p)
+	}
+	wg.Wait()
+
+	var all []*model.Session
+	for _, r := range results {
+		all = append(all, r.sessions...)
+	}
+	return all, nil
 }

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -79,6 +79,8 @@ type OpenCodeProvider struct {
 	cache *opencode.SessionCache
 }
 
+var _ DirScopedProvider = (*OpenCodeProvider)(nil)
+
 // NewOpenCodeProvider creates an OpenCodeProvider.
 func NewOpenCodeProvider() *OpenCodeProvider {
 	return &OpenCodeProvider{cache: opencode.NewSessionCache()}
@@ -86,6 +88,13 @@ func NewOpenCodeProvider() *OpenCodeProvider {
 
 func (p *OpenCodeProvider) DiscoverSessions() ([]*model.Session, error) {
 	return opencode.DiscoverSessions(p.cache)
+}
+
+// DiscoverSessionsMatching implements DirScopedProvider: it scopes discovery
+// to sessions whose directory matches cwdMatch, skipping message loads for
+// the rest (see opencodefamily.DiscoverSessionsForFiltered).
+func (p *OpenCodeProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
+	return opencode.DiscoverSessionsFiltered(p.cache, cwdMatch)
 }
 
 func (p *OpenCodeProvider) UseWatcher() bool               { return false }
@@ -102,6 +111,8 @@ type KiloProvider struct {
 	cache *kilo.SessionCache
 }
 
+var _ DirScopedProvider = (*KiloProvider)(nil)
+
 // NewKiloProvider creates a KiloProvider.
 func NewKiloProvider() *KiloProvider {
 	return &KiloProvider{cache: kilo.NewSessionCache()}
@@ -109,6 +120,13 @@ func NewKiloProvider() *KiloProvider {
 
 func (p *KiloProvider) DiscoverSessions() ([]*model.Session, error) {
 	return kilo.DiscoverSessions(p.cache)
+}
+
+// DiscoverSessionsMatching implements DirScopedProvider: it scopes discovery
+// to sessions whose directory matches cwdMatch, skipping message loads for
+// the rest (see opencodefamily.DiscoverSessionsForFiltered).
+func (p *KiloProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
+	return kilo.DiscoverSessionsFiltered(p.cache, cwdMatch)
 }
 
 func (p *KiloProvider) UseWatcher() bool               { return false }

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -21,6 +23,7 @@ type LiveProvider struct {
 	cache        *model.SessionCache
 	desktopCache *claude.DesktopCache
 	claudeDirs   []string
+	cwdIdx       *claude.CWDIndex
 }
 
 // NewLiveProvider creates a LiveProvider with mtime-based caches.
@@ -31,10 +34,14 @@ func NewLiveProvider(claudeDirs []string) *LiveProvider {
 		cache:        model.NewSessionCache(),
 		desktopCache: claude.NewDesktopCache(),
 		claudeDirs:   claudeDirs,
+		cwdIdx:       claude.NewCWDIndex(),
 	}
 }
 
-var _ DirScopedProvider = (*LiveProvider)(nil)
+var (
+	_ DirScopedProvider = (*LiveProvider)(nil)
+	_ CachePersister    = (*LiveProvider)(nil)
+)
 
 func (p *LiveProvider) DiscoverSessions() ([]*model.Session, error) {
 	return claude.DiscoverSessions(p.cache, p.desktopCache, p.claudeDirs)
@@ -43,7 +50,24 @@ func (p *LiveProvider) DiscoverSessions() ([]*model.Session, error) {
 // DiscoverSessionsMatching implements DirScopedProvider: it scopes discovery
 // to files whose cwd matches cwdMatch, skipping full parses of the rest.
 func (p *LiveProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
-	return claude.DiscoverSessionsFiltered(p.cache, p.desktopCache, p.claudeDirs, cwdMatch)
+	return claude.DiscoverSessionsFilteredIndexed(p.cache, p.desktopCache, p.claudeDirs, cwdMatch, p.cwdIdx)
+}
+
+// LoadCaches implements CachePersister.
+func (p *LiveProvider) LoadCaches(dir string) error {
+	err1 := p.cache.LoadFrom(filepath.Join(dir, "discovery-claude.json"))
+	err2 := p.cwdIdx.LoadFrom(filepath.Join(dir, "cwdindex-claude.json"))
+	return firstErr(err1, err2)
+}
+
+// SaveCaches implements CachePersister.
+func (p *LiveProvider) SaveCaches(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	err1 := p.cache.SaveTo(filepath.Join(dir, "discovery-claude.json"))
+	err2 := p.cwdIdx.SaveTo(filepath.Join(dir, "cwdindex-claude.json"))
+	return firstErr(err1, err2)
 }
 
 func (p *LiveProvider) UseWatcher() bool               { return true }
@@ -66,8 +90,23 @@ func NewPiProvider() *PiProvider {
 	return &PiProvider{cache: model.NewSessionCache()}
 }
 
+var _ CachePersister = (*PiProvider)(nil)
+
 func (p *PiProvider) DiscoverSessions() ([]*model.Session, error) {
 	return pi.DiscoverSessions(p.cache)
+}
+
+// LoadCaches implements CachePersister.
+func (p *PiProvider) LoadCaches(dir string) error {
+	return p.cache.LoadFrom(filepath.Join(dir, "discovery-pi.json"))
+}
+
+// SaveCaches implements CachePersister.
+func (p *PiProvider) SaveCaches(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return p.cache.SaveTo(filepath.Join(dir, "discovery-pi.json"))
 }
 
 func (p *PiProvider) UseWatcher() bool               { return true }
@@ -170,14 +209,18 @@ type DirScopedProvider interface {
 
 // CodexProvider discovers Codex CLI sessions from JSONL transcripts.
 type CodexProvider struct {
-	cache *model.SessionCache
+	cache  *model.SessionCache
+	cwdIdx *codex.CWDIndex
 }
 
-var _ DirScopedProvider = (*CodexProvider)(nil)
+var (
+	_ DirScopedProvider = (*CodexProvider)(nil)
+	_ CachePersister    = (*CodexProvider)(nil)
+)
 
 // NewCodexProvider creates a CodexProvider.
 func NewCodexProvider() *CodexProvider {
-	return &CodexProvider{cache: model.NewSessionCache()}
+	return &CodexProvider{cache: model.NewSessionCache(), cwdIdx: codex.NewCWDIndex()}
 }
 
 func (p *CodexProvider) DiscoverSessions() ([]*model.Session, error) {
@@ -187,7 +230,24 @@ func (p *CodexProvider) DiscoverSessions() ([]*model.Session, error) {
 // DiscoverSessionsMatching implements DirScopedProvider: it scopes discovery
 // to files whose cwd matches cwdMatch, skipping full parses of the rest.
 func (p *CodexProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
-	return codex.DiscoverSessionsFiltered(p.cache, cwdMatch)
+	return codex.DiscoverSessionsFilteredIndexed(p.cache, cwdMatch, p.cwdIdx)
+}
+
+// LoadCaches implements CachePersister.
+func (p *CodexProvider) LoadCaches(dir string) error {
+	err1 := p.cache.LoadFrom(filepath.Join(dir, "discovery-codex.json"))
+	err2 := p.cwdIdx.LoadFrom(filepath.Join(dir, "cwdindex-codex.json"))
+	return firstErr(err1, err2)
+}
+
+// SaveCaches implements CachePersister.
+func (p *CodexProvider) SaveCaches(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	err1 := p.cache.SaveTo(filepath.Join(dir, "discovery-codex.json"))
+	err2 := p.cwdIdx.SaveTo(filepath.Join(dir, "cwdindex-codex.json"))
+	return firstErr(err1, err2)
 }
 
 func (p *CodexProvider) UseWatcher() bool               { return false }
@@ -209,8 +269,23 @@ func NewAmpProvider() *AmpProvider {
 	return &AmpProvider{cache: model.NewSessionCache()}
 }
 
+var _ CachePersister = (*AmpProvider)(nil)
+
 func (p *AmpProvider) DiscoverSessions() ([]*model.Session, error) {
 	return amp.DiscoverSessions(p.cache)
+}
+
+// LoadCaches implements CachePersister.
+func (p *AmpProvider) LoadCaches(dir string) error {
+	return p.cache.LoadFrom(filepath.Join(dir, "discovery-amp.json"))
+}
+
+// SaveCaches implements CachePersister.
+func (p *AmpProvider) SaveCaches(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return p.cache.SaveTo(filepath.Join(dir, "discovery-amp.json"))
 }
 
 func (p *AmpProvider) UseWatcher() bool               { return false }
@@ -232,8 +307,23 @@ func NewGrokProvider() *GrokProvider {
 	return &GrokProvider{cache: model.NewSessionCache()}
 }
 
+var _ CachePersister = (*GrokProvider)(nil)
+
 func (p *GrokProvider) DiscoverSessions() ([]*model.Session, error) {
 	return grok.DiscoverSessions(p.cache)
+}
+
+// LoadCaches implements CachePersister.
+func (p *GrokProvider) LoadCaches(dir string) error {
+	return p.cache.LoadFrom(filepath.Join(dir, "discovery-grok.json"))
+}
+
+// SaveCaches implements CachePersister.
+func (p *GrokProvider) SaveCaches(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return p.cache.SaveTo(filepath.Join(dir, "discovery-grok.json"))
 }
 
 func (p *GrokProvider) UseWatcher() bool               { return true }
@@ -250,8 +340,23 @@ func NewKimiProvider() *KimiProvider {
 	return &KimiProvider{cache: model.NewSessionCache()}
 }
 
+var _ CachePersister = (*KimiProvider)(nil)
+
 func (p *KimiProvider) DiscoverSessions() ([]*model.Session, error) {
 	return kimi.DiscoverSessions(p.cache)
+}
+
+// LoadCaches implements CachePersister.
+func (p *KimiProvider) LoadCaches(dir string) error {
+	return p.cache.LoadFrom(filepath.Join(dir, "discovery-kimi.json"))
+}
+
+// SaveCaches implements CachePersister.
+func (p *KimiProvider) SaveCaches(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return p.cache.SaveTo(filepath.Join(dir, "discovery-kimi.json"))
 }
 
 func (p *KimiProvider) UseWatcher() bool               { return true }

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -147,6 +147,8 @@ type CodexProvider struct {
 	cache *model.SessionCache
 }
 
+var _ DirScopedProvider = (*CodexProvider)(nil)
+
 // NewCodexProvider creates a CodexProvider.
 func NewCodexProvider() *CodexProvider {
 	return &CodexProvider{cache: model.NewSessionCache()}

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -34,8 +34,16 @@ func NewLiveProvider(claudeDirs []string) *LiveProvider {
 	}
 }
 
+var _ DirScopedProvider = (*LiveProvider)(nil)
+
 func (p *LiveProvider) DiscoverSessions() ([]*model.Session, error) {
 	return claude.DiscoverSessions(p.cache, p.desktopCache, p.claudeDirs)
+}
+
+// DiscoverSessionsMatching implements DirScopedProvider: it scopes discovery
+// to files whose cwd matches cwdMatch, skipping full parses of the rest.
+func (p *LiveProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
+	return claude.DiscoverSessionsFiltered(p.cache, p.desktopCache, p.claudeDirs, cwdMatch)
 }
 
 func (p *LiveProvider) UseWatcher() bool               { return true }

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -516,6 +516,56 @@ func discoverMatchingOne(p SessionProvider, cwdMatch func(string) bool) ([]*mode
 	return p.DiscoverSessions()
 }
 
+// DiscoverMatchingStream discovers sessions like DiscoverMatching but
+// delivers each provider member's results as they complete via emit
+// (called from the discovery goroutines; the caller must make emit safe for
+// concurrent use — see sync.Mutex or an equivalent). done is closed once
+// every member has finished (after its goroutine's emit call, if any, has
+// already returned). Best-effort like MultiProvider: a failing member emits
+// nothing, but still counts toward done closing.
+//
+// Granularity matches DiscoverMatching's fan-out (see streamMembers): a
+// MultiProvider's Providers are its members (zero members, and an
+// immediately-closed done, for an empty MultiProvider); any other provider
+// is a single member. Each member's fast-path-vs-plain decision reuses
+// discoverMatchingOne, the same function DiscoverMatching itself uses, so
+// there is one implementation of that decision.
+func DiscoverMatchingStream(p SessionProvider, cwdMatch func(string) bool, emit func([]*model.Session)) (done <-chan struct{}) {
+	doneCh := make(chan struct{})
+	members := streamMembers(p)
+	if len(members) == 0 {
+		close(doneCh)
+		return doneCh
+	}
+	var wg sync.WaitGroup
+	for _, member := range members {
+		wg.Add(1)
+		go func(prov SessionProvider) {
+			defer wg.Done()
+			sessions, err := discoverMatchingOne(prov, cwdMatch)
+			if err == nil {
+				emit(sessions)
+			}
+		}(member)
+	}
+	go func() {
+		wg.Wait()
+		close(doneCh)
+	}()
+	return doneCh
+}
+
+// streamMembers returns p's independent discovery members for
+// DiscoverMatchingStream: a MultiProvider's Providers slice (possibly
+// empty), or a single-element slice containing p itself for any other
+// provider.
+func streamMembers(p SessionProvider) []SessionProvider {
+	if mp, ok := p.(MultiProvider); ok {
+		return mp.Providers
+	}
+	return []SessionProvider{p}
+}
+
 func discoverMatchingMulti(mp MultiProvider, cwdMatch func(string) bool) ([]*model.Session, error) {
 	if len(mp.Providers) <= 1 {
 		// Fast path: no need for goroutines.

--- a/internal/core/provider.go
+++ b/internal/core/provider.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/claude"
 	"github.com/illegalstudio/lazyagent/internal/codex"
 	"github.com/illegalstudio/lazyagent/internal/cursor"
+	"github.com/illegalstudio/lazyagent/internal/diskcache"
 	"github.com/illegalstudio/lazyagent/internal/grok"
 	"github.com/illegalstudio/lazyagent/internal/kilo"
 	"github.com/illegalstudio/lazyagent/internal/kimi"
@@ -62,7 +62,7 @@ func (p *LiveProvider) LoadCaches(dir string) error {
 
 // SaveCaches implements CachePersister.
 func (p *LiveProvider) SaveCaches(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := diskcache.EnsureDir(dir); err != nil {
 		return err
 	}
 	err1 := p.cache.SaveTo(filepath.Join(dir, "discovery-claude.json"))
@@ -103,7 +103,7 @@ func (p *PiProvider) LoadCaches(dir string) error {
 
 // SaveCaches implements CachePersister.
 func (p *PiProvider) SaveCaches(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := diskcache.EnsureDir(dir); err != nil {
 		return err
 	}
 	return p.cache.SaveTo(filepath.Join(dir, "discovery-pi.json"))
@@ -242,7 +242,7 @@ func (p *CodexProvider) LoadCaches(dir string) error {
 
 // SaveCaches implements CachePersister.
 func (p *CodexProvider) SaveCaches(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := diskcache.EnsureDir(dir); err != nil {
 		return err
 	}
 	err1 := p.cache.SaveTo(filepath.Join(dir, "discovery-codex.json"))
@@ -282,7 +282,7 @@ func (p *AmpProvider) LoadCaches(dir string) error {
 
 // SaveCaches implements CachePersister.
 func (p *AmpProvider) SaveCaches(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := diskcache.EnsureDir(dir); err != nil {
 		return err
 	}
 	return p.cache.SaveTo(filepath.Join(dir, "discovery-amp.json"))
@@ -320,7 +320,7 @@ func (p *GrokProvider) LoadCaches(dir string) error {
 
 // SaveCaches implements CachePersister.
 func (p *GrokProvider) SaveCaches(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := diskcache.EnsureDir(dir); err != nil {
 		return err
 	}
 	return p.cache.SaveTo(filepath.Join(dir, "discovery-grok.json"))
@@ -353,7 +353,7 @@ func (p *KimiProvider) LoadCaches(dir string) error {
 
 // SaveCaches implements CachePersister.
 func (p *KimiProvider) SaveCaches(dir string) error {
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := diskcache.EnsureDir(dir); err != nil {
 		return err
 	}
 	return p.cache.SaveTo(filepath.Join(dir, "discovery-kimi.json"))

--- a/internal/core/provider_test.go
+++ b/internal/core/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -355,4 +356,107 @@ func writeOpenCodeFamilyFixtureDB(t *testing.T, dbPath, dirA, dirB string) {
 	}
 	insert("ses_dir_a", dirA, 1700000001000)
 	insert("ses_dir_b", dirB, 1700000002000)
+}
+
+// --- DiscoverMatchingStream ---
+
+// collectStream runs DiscoverMatchingStream, gathers every emitted batch
+// (protected by a mutex, since emit is called concurrently from the
+// discovery goroutines) and blocks until done closes or a timeout elapses,
+// then returns the batches in emission order plus their count.
+func collectStream(t *testing.T, p SessionProvider, cwdMatch func(string) bool) (batches [][]*model.Session) {
+	t.Helper()
+	var mu sync.Mutex
+	done := DiscoverMatchingStream(p, cwdMatch, func(sessions []*model.Session) {
+		mu.Lock()
+		defer mu.Unlock()
+		batches = append(batches, sessions)
+	})
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("DiscoverMatchingStream: done never closed")
+	}
+	return batches
+}
+
+func TestDiscoverMatchingStream_PerMemberEmission(t *testing.T) {
+	p1 := fakeProvider{sessions: []*model.Session{{SessionID: "s1"}}}
+	p2 := fakeProvider{sessions: []*model.Session{{SessionID: "s2"}, {SessionID: "s3"}}}
+	mp := MultiProvider{Providers: []SessionProvider{p1, p2}}
+
+	batches := collectStream(t, mp, func(string) bool { return true })
+	if len(batches) != 2 {
+		t.Fatalf("got %d batches, want 2 (one per member)", len(batches))
+	}
+	ids := make(map[string]bool)
+	for _, batch := range batches {
+		for _, s := range batch {
+			ids[s.SessionID] = true
+		}
+	}
+	if !ids["s1"] || !ids["s2"] || !ids["s3"] {
+		t.Fatalf("batches = %#v, want s1, s2, s3 all present", batches)
+	}
+}
+
+func TestDiscoverMatchingStream_FailingMemberEmitsNothing(t *testing.T) {
+	failing := fakeProvider{err: errTest}
+	working := fakeProvider{sessions: []*model.Session{{SessionID: "s1"}}}
+	mp := MultiProvider{Providers: []SessionProvider{failing, working}}
+
+	batches := collectStream(t, mp, func(string) bool { return true })
+	if len(batches) != 1 {
+		t.Fatalf("got %d batches, want 1 (the failing member emits nothing)", len(batches))
+	}
+	if len(batches[0]) != 1 || batches[0][0].SessionID != "s1" {
+		t.Fatalf("batches = %#v, want [[s1]]", batches)
+	}
+}
+
+func TestDiscoverMatchingStream_SingleProviderNonMulti(t *testing.T) {
+	p := &dirScopedFakeProvider{sessions: []*model.Session{{SessionID: "scoped"}}}
+
+	batches := collectStream(t, p, func(string) bool { return true })
+	if len(batches) != 1 {
+		t.Fatalf("got %d batches, want 1 (a non-multi provider is one member)", len(batches))
+	}
+	if len(batches[0]) != 1 || batches[0][0].SessionID != "scoped" {
+		t.Fatalf("batches = %#v, want [[scoped]]", batches)
+	}
+	if !p.receivedMatcher {
+		t.Error("expected the single member to receive the matcher (dir-scoped fast path reused)")
+	}
+}
+
+func TestDiscoverMatchingStream_EmptyMultiProviderClosesDoneImmediately(t *testing.T) {
+	mp := MultiProvider{}
+
+	batches := collectStream(t, mp, func(string) bool { return true })
+	if len(batches) != 0 {
+		t.Fatalf("got %d batches, want 0 (no members)", len(batches))
+	}
+}
+
+func TestDiscoverMatchingStream_DoneNotClosedBeforeEmitReturns(t *testing.T) {
+	// A slow member must not let done close before its emit has actually
+	// been delivered -- done is only closed after every member's goroutine
+	// (which calls emit synchronously before returning) has finished.
+	slow := fakeProvider{sessions: []*model.Session{{SessionID: "slow"}}}
+	fast := fakeProvider{sessions: []*model.Session{{SessionID: "fast"}}}
+	mp := MultiProvider{Providers: []SessionProvider{slow, fast}}
+
+	var mu sync.Mutex
+	var emitted int
+	done := DiscoverMatchingStream(mp, func(string) bool { return true }, func(sessions []*model.Session) {
+		mu.Lock()
+		emitted++
+		mu.Unlock()
+	})
+	<-done
+	mu.Lock()
+	defer mu.Unlock()
+	if emitted != 2 {
+		t.Fatalf("emitted = %d, want 2 emits to have happened by the time done closed", emitted)
+	}
 }

--- a/internal/core/provider_test.go
+++ b/internal/core/provider_test.go
@@ -414,6 +414,25 @@ func TestDiscoverMatchingStream_FailingMemberEmitsNothing(t *testing.T) {
 	}
 }
 
+// TestDiscoverMatchingStream_SingleFailingProviderEmitsNothingButCloses
+// covers the non-multi counterpart to
+// TestDiscoverMatchingStream_FailingMemberEmitsNothing: a single provider
+// (not wrapped in a MultiProvider) that errors is exactly one member, and
+// that member failing must behave the same way a failing member of a
+// larger fan-out does -- no emit, but done still closes. This is the
+// scenario behind the picker's accepted divergence for a single
+// misconfigured provider in interactive mode (see internal/sessions.Run):
+// since DiscoverMatchingStream has no error channel by design, this failure
+// is indistinguishable from "found nothing" to any caller.
+func TestDiscoverMatchingStream_SingleFailingProviderEmitsNothingButCloses(t *testing.T) {
+	p := fakeProvider{err: errTest}
+
+	batches := collectStream(t, p, func(string) bool { return true })
+	if len(batches) != 0 {
+		t.Fatalf("got %d batches, want 0 (the single failing provider emits nothing)", len(batches))
+	}
+}
+
 func TestDiscoverMatchingStream_SingleProviderNonMulti(t *testing.T) {
 	p := &dirScopedFakeProvider{sessions: []*model.Session{{SessionID: "scoped"}}}
 
@@ -439,12 +458,15 @@ func TestDiscoverMatchingStream_EmptyMultiProviderClosesDoneImmediately(t *testi
 }
 
 func TestDiscoverMatchingStream_DoneNotClosedBeforeEmitReturns(t *testing.T) {
-	// A slow member must not let done close before its emit has actually
-	// been delivered -- done is only closed after every member's goroutine
-	// (which calls emit synchronously before returning) has finished.
-	slow := fakeProvider{sessions: []*model.Session{{SessionID: "slow"}}}
-	fast := fakeProvider{sessions: []*model.Session{{SessionID: "fast"}}}
-	mp := MultiProvider{Providers: []SessionProvider{slow, fast}}
+	// Neither member here is actually slow (fakeProvider returns
+	// instantly) -- what this asserts is the ordering guarantee itself:
+	// done must not close before every member's emit call has actually
+	// been delivered, since it's only closed after every member's
+	// goroutine (which calls emit synchronously before returning) has
+	// finished, regardless of how long any given member takes in practice.
+	memberA := fakeProvider{sessions: []*model.Session{{SessionID: "a"}}}
+	memberB := fakeProvider{sessions: []*model.Session{{SessionID: "b"}}}
+	mp := MultiProvider{Providers: []SessionProvider{memberA, memberB}}
 
 	var mu sync.Mutex
 	var emitted int

--- a/internal/core/provider_test.go
+++ b/internal/core/provider_test.go
@@ -143,3 +143,95 @@ var errTest = errorString("test error")
 type errorString string
 
 func (e errorString) Error() string { return string(e) }
+
+// dirScopedFakeProvider is a test-local provider that implements
+// DirScopedProvider so DiscoverMatching's fast path can be exercised. It
+// records the matcher it received and returns its own preconfigured, already
+// filtered sessions (ignoring the matcher's actual verdicts) so the test can
+// assert DiscoverMatching used the fast-path result rather than falling back
+// to DiscoverSessions.
+type dirScopedFakeProvider struct {
+	sessions        []*model.Session
+	err             error
+	unfiltered      []*model.Session // returned by DiscoverSessions if called (should not be, when fast path is used)
+	receivedMatcher bool
+	watcher         bool
+	interval        time.Duration
+	dirs            []string
+}
+
+func (f *dirScopedFakeProvider) DiscoverSessions() ([]*model.Session, error) {
+	return f.unfiltered, nil
+}
+
+func (f *dirScopedFakeProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
+	f.receivedMatcher = cwdMatch != nil
+	return f.sessions, f.err
+}
+
+func (f *dirScopedFakeProvider) UseWatcher() bool               { return f.watcher }
+func (f *dirScopedFakeProvider) RefreshInterval() time.Duration { return f.interval }
+func (f *dirScopedFakeProvider) WatchDirs() []string            { return f.dirs }
+
+func TestDiscoverMatching_UsesDirScopedFastPath(t *testing.T) {
+	p := &dirScopedFakeProvider{
+		sessions:   []*model.Session{{SessionID: "matched"}},
+		unfiltered: []*model.Session{{SessionID: "should-not-be-used"}},
+	}
+	matcher := func(cwd string) bool { return true }
+
+	sessions, err := DiscoverMatching(p, matcher)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !p.receivedMatcher {
+		t.Error("expected DiscoverSessionsMatching to receive a non-nil matcher")
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != "matched" {
+		t.Fatalf("sessions = %#v, want the fast-path result", sessions)
+	}
+}
+
+func TestDiscoverMatching_FallsBackToPlainDiscoverSessions(t *testing.T) {
+	p := fakeProvider{sessions: []*model.Session{
+		{SessionID: "s1"},
+	}}
+
+	sessions, err := DiscoverMatching(p, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].SessionID != "s1" {
+		t.Fatalf("sessions = %#v, want plain DiscoverSessions result", sessions)
+	}
+}
+
+func TestDiscoverMatching_MultiProviderFanOut(t *testing.T) {
+	scoped := &dirScopedFakeProvider{
+		sessions: []*model.Session{{SessionID: "scoped-hit"}},
+	}
+	plain := fakeProvider{sessions: []*model.Session{
+		{SessionID: "plain-hit"},
+	}}
+	failing := fakeProvider{err: errTest}
+
+	mp := MultiProvider{Providers: []SessionProvider{scoped, plain, failing}}
+	sessions, err := DiscoverMatching(mp, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !scoped.receivedMatcher {
+		t.Error("expected the dir-scoped member to receive the matcher")
+	}
+
+	ids := make(map[string]bool)
+	for _, s := range sessions {
+		ids[s.SessionID] = true
+	}
+	if !ids["scoped-hit"] || !ids["plain-hit"] {
+		t.Fatalf("sessions = %#v, want scoped-hit and plain-hit present", sessions)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2 (failing member contributes nothing)", len(sessions))
+	}
+}

--- a/internal/core/provider_test.go
+++ b/internal/core/provider_test.go
@@ -1,10 +1,14 @@
 package core
 
 import (
+	"database/sql"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
+	_ "modernc.org/sqlite"
 )
 
 // fakeProvider is a test helper that returns pre-configured sessions.
@@ -234,4 +238,121 @@ func TestDiscoverMatching_MultiProviderFanOut(t *testing.T) {
 	if len(sessions) != 2 {
 		t.Fatalf("got %d sessions, want 2 (failing member contributes nothing)", len(sessions))
 	}
+}
+
+// TestOpenCodeProvider_DiscoverSessionsMatching_FiltersByDirectory is a
+// wiring test proving core.OpenCodeProvider.DiscoverSessionsMatching is
+// reachable through the DirScopedProvider interface end-to-end (down
+// through internal/opencode into internal/opencodefamily) and that it
+// actually filters by directory.
+func TestOpenCodeProvider_DiscoverSessionsMatching_FiltersByDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OPENCODE_DATA_DIR", dir)
+	writeOpenCodeFamilyFixtureDB(t, filepath.Join(dir, "opencode.db"), "/tmp/core-opencode-a", "/tmp/core-opencode-b")
+
+	p := NewOpenCodeProvider()
+	var dsp DirScopedProvider = p
+	sessions, err := dsp.DiscoverSessionsMatching(func(cwd string) bool { return cwd == "/tmp/core-opencode-a" })
+	if err != nil {
+		t.Fatalf("DiscoverSessionsMatching() error = %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].CWD != "/tmp/core-opencode-a" {
+		t.Fatalf("sessions = %#v, want one session in /tmp/core-opencode-a", sessions)
+	}
+
+	all, err := p.DiscoverSessions()
+	if err != nil {
+		t.Fatalf("DiscoverSessions() error = %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("len(all) = %d, want 2 (unfiltered discovery must still return everything)", len(all))
+	}
+}
+
+// TestKiloProvider_DiscoverSessionsMatching_FiltersByDirectory mirrors
+// TestOpenCodeProvider_DiscoverSessionsMatching_FiltersByDirectory for
+// core.KiloProvider, which wraps the same opencodefamily engine.
+func TestKiloProvider_DiscoverSessionsMatching_FiltersByDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KILO_DATA_DIR", dir)
+	writeOpenCodeFamilyFixtureDB(t, filepath.Join(dir, "kilo.db"), "/tmp/core-kilo-a", "/tmp/core-kilo-b")
+
+	p := NewKiloProvider()
+	var dsp DirScopedProvider = p
+	sessions, err := dsp.DiscoverSessionsMatching(func(cwd string) bool { return cwd == "/tmp/core-kilo-a" })
+	if err != nil {
+		t.Fatalf("DiscoverSessionsMatching() error = %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].CWD != "/tmp/core-kilo-a" {
+		t.Fatalf("sessions = %#v, want one session in /tmp/core-kilo-a", sessions)
+	}
+
+	all, err := p.DiscoverSessions()
+	if err != nil {
+		t.Fatalf("DiscoverSessions() error = %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("len(all) = %d, want 2 (unfiltered discovery must still return everything)", len(all))
+	}
+}
+
+// writeOpenCodeFamilyFixtureDB creates two sessions, one in each of dirA and
+// dirB, using the minimal OpenCode-family schema (session/message/part).
+func writeOpenCodeFamilyFixtureDB(t *testing.T, dbPath, dirA, dirB string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stmts := []string{
+		`CREATE TABLE session (
+			id text PRIMARY KEY,
+			project_id text NOT NULL,
+			parent_id text,
+			directory text NOT NULL,
+			title text NOT NULL,
+			version text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			time_compacting integer,
+			time_archived integer
+		)`,
+		`CREATE TABLE message (
+			id text PRIMARY KEY,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+		`CREATE TABLE part (
+			id text PRIMARY KEY,
+			message_id text NOT NULL,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+
+	insert := func(id, directory string, timeUpdated int64) {
+		if _, err := db.Exec(
+			`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+			 VALUES (?, ?, NULL, ?, ?, '1.0.0', 1700000000000, ?, NULL, NULL)`,
+			id, id+"_proj", directory, id, timeUpdated,
+		); err != nil {
+			t.Fatalf("insert session %s: %v", id, err)
+		}
+	}
+	insert("ses_dir_a", dirA, 1700000001000)
+	insert("ses_dir_b", dirB, 1700000002000)
 }

--- a/internal/core/resume.go
+++ b/internal/core/resume.go
@@ -29,3 +29,27 @@ func ResumeCommand(agent, sessionID string) string {
 		return ""
 	}
 }
+
+// ResumeArgv returns the executable argv to resume a session, or nil when
+// the agent has no resume command lazyagent is willing to exec (grok has
+// none; opencode/kilo/cursor have a display string only — see ResumeCommand).
+// "Openable" everywhere in the codebase means ResumeArgv != nil.
+func ResumeArgv(agent, sessionID string) []string {
+	if sessionID == "" {
+		return nil
+	}
+	switch agent {
+	case "claude":
+		return []string{"claude", "--resume", sessionID}
+	case "codex":
+		return []string{"codex", "resume", sessionID}
+	case "amp":
+		return []string{"amp", "threads", "continue", sessionID}
+	case "pi":
+		return []string{"pi", "--session", sessionID}
+	case "kimi":
+		return []string{"kimi", "--resume", sessionID}
+	default:
+		return nil
+	}
+}

--- a/internal/core/resume_test.go
+++ b/internal/core/resume_test.go
@@ -1,6 +1,9 @@
 package core
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestResumeCommand(t *testing.T) {
 	tests := []struct {
@@ -22,5 +25,32 @@ func TestResumeCommand(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("ResumeCommand(%q, %q) = %q, want %q", tt.agent, tt.sessionID, got, tt.want)
 		}
+	}
+}
+
+func TestResumeArgv(t *testing.T) {
+	cases := []struct {
+		agent string
+		want  []string
+	}{
+		{"claude", []string{"claude", "--resume", "abc"}},
+		{"codex", []string{"codex", "resume", "abc"}},
+		{"amp", []string{"amp", "threads", "continue", "abc"}},
+		{"pi", []string{"pi", "--session", "abc"}},
+		{"kimi", []string{"kimi", "--resume", "abc"}},
+		// Display-only agents: copyable via ResumeCommand but not executable.
+		{"opencode", nil},
+		{"kilo", nil},
+		{"cursor", nil},
+		{"grok", nil},
+		{"unknown", nil},
+	}
+	for _, c := range cases {
+		if got := ResumeArgv(c.agent, "abc"); !slices.Equal(got, c.want) {
+			t.Errorf("ResumeArgv(%q) = %v, want %v", c.agent, got, c.want)
+		}
+	}
+	if got := ResumeArgv("claude", ""); got != nil {
+		t.Errorf("empty session ID: want nil, got %v", got)
 	}
 }

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -229,10 +229,37 @@ func (m *SessionManager) WatcherEvents() <-chan struct{} {
 // When cache persistence is enabled (EnableCachePersistence), this is also
 // where the persisted cache gets loaded (once, before the first discovery)
 // and saved (see loadPersistedCacheOnce / savePersistedCacheIfDue).
+//
+// When exclude_cwd_substrings patterns are configured, discovery itself is
+// scoped via DiscoverMatching(m.provider, excludeCWDPredicate(patterns)):
+// dir-scoped providers (DirScopedProvider) skip parsing excluded sessions
+// entirely instead of discovering-then-hiding them at the view layer. With
+// no patterns set, Reload calls the provider's plain DiscoverSessions(),
+// exactly as before this pushdown existed — zero behavior change for the
+// common case. Either way, the view-level filter (filterSessionsLocked)
+// still re-applies the same exclusion: DiscoverMatching's contract leaves
+// non-dir-scoped providers' results unfiltered, so the view filter remains
+// the only thing guaranteeing exclusion for those.
+//
+// Runtime pattern changes: SetExcludeCWDSubstrings can be called at any
+// time, and Reload re-reads m.excludeCWDSubstrings fresh on every call, so
+// the very next Reload() automatically discovers under the new patterns —
+// no extra plumbing is needed. (As of this change, no caller actually
+// changes patterns after startup; see the report for that investigation.)
 func (m *SessionManager) Reload() error {
 	m.loadPersistedCacheOnce()
 
-	sessions, err := m.provider.DiscoverSessions()
+	m.mu.RLock()
+	patterns := m.excludeCWDSubstrings
+	m.mu.RUnlock()
+
+	var sessions []*model.Session
+	var err error
+	if len(patterns) == 0 {
+		sessions, err = m.provider.DiscoverSessions()
+	} else {
+		sessions, err = DiscoverMatching(m.provider, excludeCWDPredicate(patterns))
+	}
 	if err != nil {
 		return err
 	}
@@ -352,6 +379,35 @@ func (m *SessionManager) QuerySessions(search string, filter ActivityKind) []*mo
 	return m.filterSessionsLocked(search, filter)
 }
 
+// excludedByCWD reports whether cwd matches any of patterns, using
+// case-sensitive substring containment (strings.Contains). An empty-string
+// pattern never matches anything (otherwise it would match every CWD).
+//
+// This is the single implementation of exclude_cwd_substrings matching
+// semantics: both the view-level filter (filterSessionsLocked) and the
+// discovery-time pushdown predicate (excludeCWDPredicate, used by Reload)
+// call it, so the two layers can never disagree about what's excluded.
+func excludedByCWD(cwd string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if pattern != "" && strings.Contains(cwd, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// excludeCWDPredicate returns a DiscoverMatching cwdMatch predicate — it
+// returns true to KEEP a cwd — that keeps exactly the CWDs excludedByCWD
+// would not exclude. Because it's built directly from excludedByCWD, it can
+// only ever match what the view-level filter would keep: a dir-scoped
+// provider can never be made to skip, via this predicate, a session the
+// view filter would have shown.
+func excludeCWDPredicate(patterns []string) func(cwd string) bool {
+	return func(cwd string) bool {
+		return !excludedByCWD(cwd, patterns)
+	}
+}
+
 // filterSessionsLocked applies time window, activity, and search filters.
 // Must be called with m.mu held (at least RLock).
 func (m *SessionManager) filterSessionsLocked(search string, filter ActivityKind) []*model.Session {
@@ -359,15 +415,13 @@ func (m *SessionManager) filterSessionsLocked(search string, filter ActivityKind
 	lowerQuery := strings.ToLower(search)
 	var visible []*model.Session
 	for _, s := range m.sessions {
-		// CWD-based exclusion: skip sessions whose CWD contains any excluded substring.
-		excluded := false
-		for _, pattern := range m.excludeCWDSubstrings {
-			if pattern != "" && strings.Contains(s.CWD, pattern) {
-				excluded = true
-				break
-			}
-		}
-		if excluded {
+		// CWD-based exclusion: skip sessions whose CWD contains any excluded
+		// substring. Defense in depth: Reload already pushes this same
+		// exclusion into discovery for dir-scoped providers (see
+		// excludeCWDPredicate), but this check must stay here too since
+		// DiscoverMatching leaves non-dir-scoped providers' results
+		// unfiltered.
+		if excludedByCWD(s.CWD, m.excludeCWDSubstrings) {
 			continue
 		}
 		if s.IsSidechain || !s.LastActivity.After(cutoff) {

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -59,13 +59,33 @@ type SessionManager struct {
 	excludeCWDSubstrings []string
 
 	// streamInFlight is the guard for the progressive-first-load /
-	// steady-state interplay: true for the duration of a ReloadStreaming
-	// call (set before DiscoverMatchingStream starts, cleared after it and
-	// the completion save finish), false the rest of the time. Reload and
-	// UpdateActivities' periodic re-discovery both check it and back off
-	// rather than racing a stream's own accumulating per-batch merges --
-	// see their doc comments for exactly how each responds.
+	// steady-state interplay: true for the duration of a streaming reload,
+	// false the rest of the time. Set synchronously by BeginReloadStreaming,
+	// before ANY of the streaming reload's own work begins -- not merely
+	// "before DiscoverMatchingStream starts": loadPersistedCacheOnce (a
+	// multi-MB JSON parse when a persisted cache exists) runs first and can
+	// easily take longer than a watcher event or a 1s ticker takes to fire,
+	// so the flag must already be true before that step, or a Reload/
+	// UpdateActivities call landing during it would pass the guard, run its
+	// own full discovery, and race the stream's own per-batch appends into
+	// duplicate SessionIDs. Cleared once DiscoverMatchingStream's done
+	// channel closes, before any catch-up Reload (see pendingReload) or the
+	// completion save. Reload and UpdateActivities' periodic re-discovery
+	// both check it and back off rather than racing the stream's own
+	// accumulating per-batch merges -- see their doc comments for exactly
+	// how each responds.
 	streamInFlight bool
+
+	// pendingReload latches a Reload() call that Reload absorbed while
+	// streamInFlight was true (see Reload's doc comment): set under the
+	// same lock as the absorb check, cleared and acted on once the stream
+	// completes (see runReloadStreaming), which runs exactly one catch-up
+	// Reload if this was ever set. Without this, a watcher-triggered Reload
+	// for an all-watcher-provider setup with no periodic RefreshInterval
+	// (e.g. claude/pi/grok/kimi) that lands mid-stream would be silently
+	// lost until some future, unrelated watcher event -- which might never
+	// come for that exact change.
+	pendingReload bool
 
 	// Persisted discovery cache (opt-in, see EnableCachePersistence). All
 	// guarded by mu like everything else above; the actual Load/Save disk
@@ -307,30 +327,32 @@ func (m *SessionManager) exclusionMatcher() func(cwd string) bool {
 // discoverHonoringExclusions for how the exclude_cwd_substrings pushdown is
 // applied.
 //
-// While the manager's progressive first load (ReloadStreaming) is still in
-// flight (streamInFlight), Reload is a no-op that returns nil immediately
-// instead of running a second, independent discovery concurrently with the
-// stream's own accumulating per-batch merges. This absorbs watcher/
-// ticker-driven Reload calls that land mid-stream: the TUI's
+// While the manager's progressive first load is still in flight
+// (streamInFlight), Reload is a no-op that returns nil immediately instead
+// of running a second, independent discovery concurrently with the
+// stream's own accumulating per-batch merges, and latches pendingReload so
+// the call isn't lost (see runReloadStreaming's catch-up). This absorbs
+// watcher/ticker-driven Reload calls that land mid-stream: the TUI's
 // fileWatchMsg/tickMsg handlers and the tray/API's watchLoop all call
 // Reload unconditionally on every watcher event or fallback tick, with no
 // way to know a stream is running. The stream is already the freshest full
 // discovery in progress, and letting a concurrent Reload replace m.sessions
 // mid-stream would either lose sessions a later batch alone would have
-// merged in, or -- since ReloadStreaming's batches are appended, not
-// replaced -- let a later batch duplicate sessions Reload's own complete
-// discovery already included. Absorbing the call is the simplest sound
-// rule: nothing is lost, since the event that triggered it isn't
-// discarded either (callers still re-arm their watcher for the next real
-// event), and the in-flight stream's own completion is guaranteed to
-// reflect at least as much as that Reload would have.
+// merged in, or -- since the stream's batches are appended, not replaced --
+// let a later batch duplicate sessions Reload's own complete discovery
+// already included. Absorbing the call (rather than blocking until the
+// stream finishes, or queueing it to run concurrently anyway) is the
+// simplest rule that's provably safe under concurrency; pendingReload is
+// what keeps "absorbed" from also meaning "silently dropped forever" for a
+// provider with no periodic RefreshInterval to naturally retry on.
 func (m *SessionManager) Reload() error {
-	m.mu.RLock()
-	streaming := m.streamInFlight
-	m.mu.RUnlock()
-	if streaming {
+	m.mu.Lock()
+	if m.streamInFlight {
+		m.pendingReload = true
+		m.mu.Unlock()
 		return nil
 	}
+	m.mu.Unlock()
 
 	m.loadPersistedCacheOnce()
 
@@ -349,54 +371,91 @@ func (m *SessionManager) Reload() error {
 	return nil
 }
 
+// BeginReloadStreaming synchronously marks the manager's progressive first
+// load as in-flight (streamInFlight -- see the field doc) and returns a
+// func that performs the actual streaming discovery; the caller must run
+// that func (typically in its own goroutine, for progressive rendering) to
+// perform the load, passing the onUpdate callback ReloadStreaming's doc
+// describes.
+//
+// This split exists because a caller that does
+// `go mgr.ReloadStreaming(onUpdate)` and then immediately starts a watcher
+// or poll loop cannot guarantee streamInFlight is already true by the time
+// that loop's first event/tick fires: Go makes no promise a spawned
+// goroutine's first statement runs before the spawning goroutine's next
+// one, and even if it did, ReloadStreaming's own first real step
+// (loadPersistedCacheOnce) can easily take longer than a 1s ticker or an
+// already-queued watcher event needs to fire anyway. Both real production
+// callers (internal/ui's Init, internal/tray's ServiceStartup) call
+// BeginReloadStreaming synchronously -- before starting anything else that
+// could race a Reload/UpdateActivities call -- and only run the returned
+// func in a goroutine; see their doc comments for how each wires this up.
+func (m *SessionManager) BeginReloadStreaming() (run func(onUpdate func())) {
+	m.mu.Lock()
+	m.streamInFlight = true
+	m.mu.Unlock()
+	return m.runReloadStreaming
+}
+
 // ReloadStreaming performs the manager's progressive FIRST load: instead of
 // waiting for every provider to finish (the barrier
 // MultiProvider.DiscoverSessions imposes) before showing anything, each
 // provider member's sessions are merged into the snapshot -- and onUpdate
 // (if non-nil) is called -- as soon as that member completes, via
-// core.DiscoverMatchingStream. It blocks until every member has finished;
-// callers that want progressive rendering run it in their own goroutine
-// (see internal/ui's streaming glue and internal/tray's ServiceStartup) and
-// use onUpdate to notify themselves a new batch landed. onUpdate is always
-// called with m.mu NOT held, so it's safe for onUpdate to call back into the
-// manager (Sessions(), VisibleSessions(), etc.) without deadlocking; it may
-// also be called concurrently by more than one member's goroutine, so it
-// must itself be safe for concurrent use.
+// core.DiscoverMatchingStream. It blocks until every member has finished
+// (and, if a Reload was absorbed while it ran, until the resulting
+// catch-up Reload finishes too -- see runReloadStreaming). onUpdate is
+// always called with m.mu NOT held, so it's safe for onUpdate to call back
+// into the manager (Sessions(), VisibleSessions(), etc.) without
+// deadlocking; it may also be called concurrently by more than one
+// member's goroutine, so it must itself be safe for concurrent use.
+//
+// This is exactly BeginReloadStreaming immediately followed by running the
+// returned func in the current goroutine -- a convenience for callers
+// (including most tests) that don't need streamInFlight to be guaranteed
+// true before they do anything else concurrently. See BeginReloadStreaming
+// when that ordering matters, which it does for both real production
+// callers.
 //
 // Uses exclusionMatcher -- the SAME predicate-selection logic
 // discoverHonoringExclusions uses -- so the exclude_cwd_substrings pushdown
 // applies identically on the streaming path.
 //
 // Intended to be called exactly once, as the very first load, before any
-// Reload(). While it runs, streamInFlight is true: Reload() and
-// UpdateActivities' periodic re-discovery both back off (see their doc
-// comments) rather than racing this call's per-batch merges.
+// Reload().
 //
 // Persistence (when EnableCachePersistence was called): the persisted cache
 // is loaded once before discovery starts, exactly like Reload's first call
 // (loadPersistedCacheOnce is idempotent, so whichever of Reload/
 // ReloadStreaming runs first "wins" the load). On completion, the cache is
-// saved exactly once -- never per batch -- via savePersistedCacheIfDue,
-// regardless of whether any member actually found sessions:
-// DiscoverMatchingStream has no error channel (best-effort per member, by
-// design, same as MultiProvider.DiscoverSessions), so "every member failed"
-// is indistinguishable from "every member genuinely found nothing" at this
-// level. Unlike Reload (which skips the save entirely on a hard discovery
-// error), ReloadStreaming therefore always saves on completion, since
-// "the stream finished" -- not "discovery succeeded" -- is its completion
-// signal. If every member fails or emits nothing, the manager simply ends
-// with an empty snapshot: the same observable outcome Reload's own error
-// path already produces via empty views today, and the resulting save is
-// advisory and harmless (see CachePersister) -- no new error surface is
-// introduced.
+// normally saved exactly once -- never per batch -- via
+// savePersistedCacheIfDue, regardless of whether any member actually found
+// sessions: DiscoverMatchingStream has no error channel (best-effort per
+// member, by design, same as MultiProvider.DiscoverSessions), so "every
+// member failed" is indistinguishable from "every member genuinely found
+// nothing" at this level. Unlike Reload (which skips the save entirely on a
+// hard discovery error), ReloadStreaming therefore always saves on
+// completion, since "the stream finished" -- not "discovery succeeded" --
+// is its completion signal. (The one exception: if a Reload was absorbed
+// mid-stream, the catch-up Reload's own save covers completion instead --
+// see runReloadStreaming.) If every member fails or emits nothing, the
+// manager simply ends with an empty snapshot: the same observable outcome
+// Reload's own error path already produces via empty views today, and the
+// resulting save is advisory and harmless (see CachePersister) -- no new
+// error surface is introduced.
 func (m *SessionManager) ReloadStreaming(onUpdate func()) {
+	m.BeginReloadStreaming()(onUpdate)
+}
+
+// runReloadStreaming is BeginReloadStreaming's returned func -- see both
+// its doc and ReloadStreaming's for the full contract. streamInFlight is
+// already true by the time this runs (BeginReloadStreaming set it
+// synchronously before returning it), so everything here can safely take
+// as long as it needs to.
+func (m *SessionManager) runReloadStreaming(onUpdate func()) {
 	m.loadPersistedCacheOnce()
 
 	matcher := m.exclusionMatcher()
-
-	m.mu.Lock()
-	m.streamInFlight = true
-	m.mu.Unlock()
 
 	done := DiscoverMatchingStream(m.provider, matcher, func(batch []*model.Session) {
 		m.mu.Lock()
@@ -414,7 +473,32 @@ func (m *SessionManager) ReloadStreaming(onUpdate func()) {
 
 	m.mu.Lock()
 	m.streamInFlight = false
+	pending := m.pendingReload
+	m.pendingReload = false
 	m.mu.Unlock()
+
+	if pending {
+		// A watcher/ticker-driven Reload was absorbed while the stream was
+		// in flight (see Reload's doc comment) -- catch up now with one
+		// full, ordinary Reload, rather than risk silently losing whatever
+		// it would have picked up until some future watcher event (which,
+		// for an all-watcher provider setup with no periodic
+		// RefreshInterval, e.g. claude/pi/grok/kimi, might never come again
+		// for that exact change). Reload replaces m.sessions with a fresh,
+		// complete, non-duplicated discovery -- superseding the stream's
+		// own accumulated batches entirely -- and already calls
+		// savePersistedCacheIfDue as part of its own normal flow, so that
+		// IS this call's completion save; skip the explicit one below to
+		// avoid a redundant (harmless, but pointless) second save attempt
+		// back to back. onUpdate is called again so a progressive-rendering
+		// caller notices the catch-up's effect too, not just whatever the
+		// stream's own batches produced.
+		_ = m.Reload()
+		if onUpdate != nil {
+			onUpdate()
+		}
+		return
+	}
 
 	m.savePersistedCacheIfDue()
 }
@@ -625,9 +709,30 @@ func (m *SessionManager) SessionDetail(id string) *SessionDetailView {
 	return nil
 }
 
-// SortSessions sorts sessions by last activity (most recent first).
+// SortSessions sorts sessions by last activity (most recent first),
+// breaking ties by SessionID ascending for a fully deterministic order.
+// The tiebreak matters for ReloadStreaming: batches from different
+// provider members can merge in a nondeterministic arrival order, so two
+// sessions that happen to share an exact LastActivity must still land in
+// the same relative position no matter which batch each came from or when
+// it arrived -- a plain LastActivity-only comparator would leave that pair
+// in whatever order slices.SortFunc's internal algorithm happened to
+// produce. Uses SortStableFunc (not SortFunc) as defense in depth on top of
+// that: even a literal duplicate SessionID (which should never legitimately
+// occur, but is exactly the shape a guard bug like the one this stable sort
+// was added alongside would produce) sorts into a predictable, inspectable
+// order rather than getting shuffled.
+//
+// Mirrors internal/sessions' bySessionRecency (same rule: LastActivity
+// descending, SessionID ascending) -- checked and confirmed NOT importable
+// here instead of duplicated: internal/sessions already imports
+// internal/core, so importing back would be a cycle. Keep the two in sync
+// by hand if the ordering rule ever changes.
 func SortSessions(sessions []*model.Session) {
-	slices.SortFunc(sessions, func(a, b *model.Session) int {
-		return cmp.Compare(b.LastActivity.UnixNano(), a.LastActivity.UnixNano())
+	slices.SortStableFunc(sessions, func(a, b *model.Session) int {
+		if c := cmp.Compare(b.LastActivity.UnixNano(), a.LastActivity.UnixNano()); c != 0 {
+			return c
+		}
+		return strings.Compare(a.SessionID, b.SessionID)
 	})
 }

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -58,6 +58,15 @@ type SessionManager struct {
 	lastPollDiscover     time.Time
 	excludeCWDSubstrings []string
 
+	// streamInFlight is the guard for the progressive-first-load /
+	// steady-state interplay: true for the duration of a ReloadStreaming
+	// call (set before DiscoverMatchingStream starts, cleared after it and
+	// the completion save finish), false the rest of the time. Reload and
+	// UpdateActivities' periodic re-discovery both check it and back off
+	// rather than racing a stream's own accumulating per-batch merges --
+	// see their doc comments for exactly how each responds.
+	streamInFlight bool
+
 	// Persisted discovery cache (opt-in, see EnableCachePersistence). All
 	// guarded by mu like everything else above; the actual Load/Save disk
 	// I/O always happens outside the lock (see loadPersistedCacheOnce /
@@ -253,14 +262,42 @@ func (m *SessionManager) WatcherEvents() <-chan struct{} {
 // this change, no caller actually changes patterns after startup; see the
 // report for that investigation.)
 func (m *SessionManager) discoverHonoringExclusions() ([]*model.Session, error) {
+	matcher := m.exclusionMatcher()
+	if matcher == nil {
+		return m.provider.DiscoverSessions()
+	}
+	return DiscoverMatching(m.provider, matcher)
+}
+
+// exclusionMatcher returns the cwdMatch predicate for the
+// exclude_cwd_substrings pushdown: nil when no patterns are configured, or
+// excludeCWDPredicate(patterns) otherwise. This is the single place that
+// decides the predicate -- discoverHonoringExclusions (used by Reload and
+// UpdateActivities' periodic re-discovery) and ReloadStreaming (the
+// progressive first load) both call it, so the pushdown can never diverge
+// between the synchronous and streaming discovery paths.
+//
+// nil is a deliberate, meaningful value here, not merely "no filtering
+// needed": discoverHonoringExclusions treats it as "skip DiscoverMatching's
+// dir-scoped fast-path machinery entirely and call the provider's plain,
+// unscoped DiscoverSessions()" -- the exact zero-diff behavior Reload had
+// before the exclusion pushdown existed. ReloadStreaming, whose per-member
+// fan-out has no such top-level bypass (DiscoverMatchingStream always
+// dispatches through discoverMatchingOne per member), instead passes the
+// nil straight through to DiscoverMatchingStream: every DirScopedProvider
+// implementation in this codebase (claude, codex, opencode, kilo) documents
+// "cwdMatch may be nil, in which case every session matches", so a nil
+// matcher is output-equivalent to the plain-DiscoverSessions() bypass
+// either way -- just reached via a different call path, since streaming's
+// architecture requires going through the per-member dispatch regardless.
+func (m *SessionManager) exclusionMatcher() func(cwd string) bool {
 	m.mu.RLock()
 	patterns := m.excludeCWDSubstrings
 	m.mu.RUnlock()
-
 	if len(patterns) == 0 {
-		return m.provider.DiscoverSessions()
+		return nil
 	}
-	return DiscoverMatching(m.provider, excludeCWDPredicate(patterns))
+	return excludeCWDPredicate(patterns)
 }
 
 // Reload discovers sessions via the provider and updates activity states.
@@ -269,7 +306,32 @@ func (m *SessionManager) discoverHonoringExclusions() ([]*model.Session, error) 
 // and saved (see loadPersistedCacheOnce / savePersistedCacheIfDue). See
 // discoverHonoringExclusions for how the exclude_cwd_substrings pushdown is
 // applied.
+//
+// While the manager's progressive first load (ReloadStreaming) is still in
+// flight (streamInFlight), Reload is a no-op that returns nil immediately
+// instead of running a second, independent discovery concurrently with the
+// stream's own accumulating per-batch merges. This absorbs watcher/
+// ticker-driven Reload calls that land mid-stream: the TUI's
+// fileWatchMsg/tickMsg handlers and the tray/API's watchLoop all call
+// Reload unconditionally on every watcher event or fallback tick, with no
+// way to know a stream is running. The stream is already the freshest full
+// discovery in progress, and letting a concurrent Reload replace m.sessions
+// mid-stream would either lose sessions a later batch alone would have
+// merged in, or -- since ReloadStreaming's batches are appended, not
+// replaced -- let a later batch duplicate sessions Reload's own complete
+// discovery already included. Absorbing the call is the simplest sound
+// rule: nothing is lost, since the event that triggered it isn't
+// discarded either (callers still re-arm their watcher for the next real
+// event), and the in-flight stream's own completion is guaranteed to
+// reflect at least as much as that Reload would have.
 func (m *SessionManager) Reload() error {
+	m.mu.RLock()
+	streaming := m.streamInFlight
+	m.mu.RUnlock()
+	if streaming {
+		return nil
+	}
+
 	m.loadPersistedCacheOnce()
 
 	sessions, err := m.discoverHonoringExclusions()
@@ -287,6 +349,76 @@ func (m *SessionManager) Reload() error {
 	return nil
 }
 
+// ReloadStreaming performs the manager's progressive FIRST load: instead of
+// waiting for every provider to finish (the barrier
+// MultiProvider.DiscoverSessions imposes) before showing anything, each
+// provider member's sessions are merged into the snapshot -- and onUpdate
+// (if non-nil) is called -- as soon as that member completes, via
+// core.DiscoverMatchingStream. It blocks until every member has finished;
+// callers that want progressive rendering run it in their own goroutine
+// (see internal/ui's streaming glue and internal/tray's ServiceStartup) and
+// use onUpdate to notify themselves a new batch landed. onUpdate is always
+// called with m.mu NOT held, so it's safe for onUpdate to call back into the
+// manager (Sessions(), VisibleSessions(), etc.) without deadlocking; it may
+// also be called concurrently by more than one member's goroutine, so it
+// must itself be safe for concurrent use.
+//
+// Uses exclusionMatcher -- the SAME predicate-selection logic
+// discoverHonoringExclusions uses -- so the exclude_cwd_substrings pushdown
+// applies identically on the streaming path.
+//
+// Intended to be called exactly once, as the very first load, before any
+// Reload(). While it runs, streamInFlight is true: Reload() and
+// UpdateActivities' periodic re-discovery both back off (see their doc
+// comments) rather than racing this call's per-batch merges.
+//
+// Persistence (when EnableCachePersistence was called): the persisted cache
+// is loaded once before discovery starts, exactly like Reload's first call
+// (loadPersistedCacheOnce is idempotent, so whichever of Reload/
+// ReloadStreaming runs first "wins" the load). On completion, the cache is
+// saved exactly once -- never per batch -- via savePersistedCacheIfDue,
+// regardless of whether any member actually found sessions:
+// DiscoverMatchingStream has no error channel (best-effort per member, by
+// design, same as MultiProvider.DiscoverSessions), so "every member failed"
+// is indistinguishable from "every member genuinely found nothing" at this
+// level. Unlike Reload (which skips the save entirely on a hard discovery
+// error), ReloadStreaming therefore always saves on completion, since
+// "the stream finished" -- not "discovery succeeded" -- is its completion
+// signal. If every member fails or emits nothing, the manager simply ends
+// with an empty snapshot: the same observable outcome Reload's own error
+// path already produces via empty views today, and the resulting save is
+// advisory and harmless (see CachePersister) -- no new error surface is
+// introduced.
+func (m *SessionManager) ReloadStreaming(onUpdate func()) {
+	m.loadPersistedCacheOnce()
+
+	matcher := m.exclusionMatcher()
+
+	m.mu.Lock()
+	m.streamInFlight = true
+	m.mu.Unlock()
+
+	done := DiscoverMatchingStream(m.provider, matcher, func(batch []*model.Session) {
+		m.mu.Lock()
+		m.sessions = append(m.sessions, batch...)
+		m.tracker.Update(m.sessions, time.Now())
+		SortSessions(m.sessions)
+		m.lastPollDiscover = time.Now()
+		m.mu.Unlock()
+
+		if onUpdate != nil {
+			onUpdate()
+		}
+	})
+	<-done
+
+	m.mu.Lock()
+	m.streamInFlight = false
+	m.mu.Unlock()
+
+	m.savePersistedCacheIfDue()
+}
+
 // UpdateActivities refreshes activity states without reloading from disk.
 // Returns true if any activity state changed.
 // If the provider specifies a RefreshInterval, sessions are re-discovered
@@ -294,14 +426,26 @@ func (m *SessionManager) Reload() error {
 // exclude_cwd_substrings pushdown applies to this periodic re-discovery
 // too, not just the first one.
 // Also refreshes session names from disk if modified externally.
+//
+// While a progressive first load is in flight (streamInFlight -- see
+// ReloadStreaming), the periodic re-discovery branch below is skipped: a
+// 3s poll firing mid-stream must not replace the accumulating snapshot with
+// a full (or worse, partial-provider, since the poll could itself land
+// between two of the stream's own batches) re-discovery. The activity-only
+// recomputation further down (tracker.Update against whatever's currently
+// in m.sessions) still runs regardless -- it only reads the existing lock-
+// guarded snapshot, so it's safe to run concurrently with the stream's own
+// merges and keeps activity states from going stale for sessions that have
+// already streamed in.
 func (m *SessionManager) UpdateActivities() bool {
 	namesChanged := m.names.Refresh()
 	if interval := m.provider.RefreshInterval(); interval > 0 {
 		now := time.Now()
 		m.mu.RLock()
+		streaming := m.streamInFlight
 		needsRefresh := len(m.sessions) == 0 || now.Sub(m.lastPollDiscover) > interval
 		m.mu.RUnlock()
-		if needsRefresh {
+		if needsRefresh && !streaming {
 			sessions, err := m.discoverHonoringExclusions()
 			if err == nil {
 				m.mu.Lock()

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -16,6 +16,14 @@ const (
 	MaxWindowMinutes = 480
 )
 
+// cacheSaveInterval is the minimum time between persisted-discovery-cache
+// saves that a dirty (but not first) Reload() triggers. Long-lived surfaces
+// (TUI/GUI/API) reload on every watcher event, and each save rewrites a few
+// MB of JSON, so successful reloads after the first just mark the cache
+// dirty; an actual save happens at most this often. See
+// SessionManager.EnableCachePersistence.
+const cacheSaveInterval = 5 * time.Minute
+
 // SessionProvider abstracts how sessions are discovered.
 type SessionProvider interface {
 	// DiscoverSessions returns all available sessions.
@@ -49,6 +57,18 @@ type SessionManager struct {
 	searchQuery          string
 	lastPollDiscover     time.Time
 	excludeCWDSubstrings []string
+
+	// Persisted discovery cache (opt-in, see EnableCachePersistence). All
+	// guarded by mu like everything else above; the actual Load/Save disk
+	// I/O always happens outside the lock (see loadPersistedCacheOnce /
+	// savePersistedCacheIfDue / Close) so a slow write never blocks readers
+	// like Sessions()/VisibleSessions().
+	persistEnabled  bool
+	persistDir      string
+	persistLoaded   bool      // Load has been attempted (first Reload only)
+	persistDirty    bool      // a successful Reload happened since the last save
+	lastPersistSave time.Time // zero until the first save
+	persistNow      func() time.Time
 }
 
 // NewSessionManager creates a new SessionManager with the given provider.
@@ -58,7 +78,76 @@ func NewSessionManager(windowMinutes int, provider SessionProvider) *SessionMana
 		windowMinutes: windowMinutes,
 		provider:      provider,
 		names:         NewSessionNames(),
+		persistNow:    time.Now,
 	}
+}
+
+// EnableCachePersistence opts the manager into persisting the provider's
+// discovery caches under dir between process runs, via
+// core.CachePersister / LoadProviderCaches / SaveProviderCaches (the same
+// mechanism the `sessions` subcommand already uses). Call it before the
+// first Reload(). Once enabled:
+//   - the FIRST Reload() loads any previously persisted caches before
+//     discovering, and never loads again on later reloads;
+//   - after the first successful discovery, the caches are saved once;
+//   - later successful reloads mark the cache dirty; an actual save then
+//     happens at most once per cacheSaveInterval;
+//   - Close() performs a final save if the cache is still dirty at shutdown.
+//
+// Persistence is purely advisory: providers that don't implement
+// CachePersister (e.g. demo.Provider) make every Load/Save call a silent
+// no-op via the LoadProviderCaches/SaveProviderCaches helpers, and a load or
+// save failure never affects discovery.
+func (m *SessionManager) EnableCachePersistence(dir string) {
+	m.mu.Lock()
+	m.persistEnabled = true
+	m.persistDir = dir
+	m.mu.Unlock()
+}
+
+// loadPersistedCacheOnce loads the provider's persisted discovery caches on
+// the first call after EnableCachePersistence, and is a no-op on every call
+// after that (or when persistence was never enabled). Must run before the
+// provider's first DiscoverSessions call so that discovery reuses the prior
+// run's cache. The actual disk I/O happens without m.mu held.
+func (m *SessionManager) loadPersistedCacheOnce() {
+	m.mu.Lock()
+	if !m.persistEnabled || m.persistLoaded {
+		m.mu.Unlock()
+		return
+	}
+	m.persistLoaded = true
+	dir := m.persistDir
+	m.mu.Unlock()
+
+	LoadProviderCaches(m.provider, dir)
+}
+
+// savePersistedCacheIfDue runs after a successful Reload when persistence is
+// enabled. The very first save (lastPersistSave still zero) always happens,
+// so a persisted cache exists as early as possible; subsequent saves happen
+// at most once per cacheSaveInterval, with reloads in between just marking
+// the cache dirty for Close's final save. The actual disk I/O happens
+// without m.mu held.
+func (m *SessionManager) savePersistedCacheIfDue() {
+	m.mu.Lock()
+	if !m.persistEnabled {
+		m.mu.Unlock()
+		return
+	}
+	now := m.persistNow()
+	due := m.lastPersistSave.IsZero() || now.Sub(m.lastPersistSave) >= cacheSaveInterval
+	if !due {
+		m.persistDirty = true
+		m.mu.Unlock()
+		return
+	}
+	dir := m.persistDir
+	m.lastPersistSave = now
+	m.persistDirty = false
+	m.mu.Unlock()
+
+	SaveProviderCaches(m.provider, dir)
 }
 
 // SetEventBus attaches an event bus so activity transitions are published
@@ -107,6 +196,27 @@ func (m *SessionManager) StopWatcher() {
 	}
 }
 
+// Close is the shutdown hook the long-lived surfaces (TUI, GUI/tray, API)
+// should call in place of StopWatcher: it stops the file watcher and, if
+// cache persistence is enabled and a Reload happened since the last save
+// (the cache is dirty — see savePersistedCacheIfDue), performs one final
+// save so shutdown never loses more than the most recent in-flight reload.
+// A no-op final save (persistence disabled, or already clean) costs nothing
+// beyond the StopWatcher call it always makes.
+func (m *SessionManager) Close() {
+	m.StopWatcher()
+
+	m.mu.Lock()
+	due := m.persistEnabled && m.persistDirty
+	dir := m.persistDir
+	m.persistDirty = false
+	m.mu.Unlock()
+
+	if due {
+		SaveProviderCaches(m.provider, dir)
+	}
+}
+
 // WatcherEvents returns the channel for file change notifications, or nil.
 func (m *SessionManager) WatcherEvents() <-chan struct{} {
 	if m.watcher != nil {
@@ -116,7 +226,12 @@ func (m *SessionManager) WatcherEvents() <-chan struct{} {
 }
 
 // Reload discovers sessions via the provider and updates activity states.
+// When cache persistence is enabled (EnableCachePersistence), this is also
+// where the persisted cache gets loaded (once, before the first discovery)
+// and saved (see loadPersistedCacheOnce / savePersistedCacheIfDue).
 func (m *SessionManager) Reload() error {
+	m.loadPersistedCacheOnce()
+
 	sessions, err := m.provider.DiscoverSessions()
 	if err != nil {
 		return err
@@ -127,6 +242,8 @@ func (m *SessionManager) Reload() error {
 	SortSessions(m.sessions)
 	m.lastPollDiscover = time.Now()
 	m.mu.Unlock()
+
+	m.savePersistedCacheIfDue()
 	return nil
 }
 

--- a/internal/core/session.go
+++ b/internal/core/session.go
@@ -225,16 +225,21 @@ func (m *SessionManager) WatcherEvents() <-chan struct{} {
 	return nil
 }
 
-// Reload discovers sessions via the provider and updates activity states.
-// When cache persistence is enabled (EnableCachePersistence), this is also
-// where the persisted cache gets loaded (once, before the first discovery)
-// and saved (see loadPersistedCacheOnce / savePersistedCacheIfDue).
+// discoverHonoringExclusions discovers sessions via m.provider, applying the
+// exclude_cwd_substrings pushdown when patterns are configured, or the
+// provider's plain DiscoverSessions() when they aren't. This is the single
+// implementation of "discover, honoring exclusions" shared by every
+// re-discovery path — Reload (first load, watcher events) and
+// UpdateActivities (periodic re-discovery for providers with
+// RefreshInterval > 0, e.g. opencode/kilo/codex) — so the pushdown applies
+// uniformly no matter which path triggers a given discovery, not just the
+// first one.
 //
 // When exclude_cwd_substrings patterns are configured, discovery itself is
 // scoped via DiscoverMatching(m.provider, excludeCWDPredicate(patterns)):
 // dir-scoped providers (DirScopedProvider) skip parsing excluded sessions
 // entirely instead of discovering-then-hiding them at the view layer. With
-// no patterns set, Reload calls the provider's plain DiscoverSessions(),
+// no patterns set, this calls the provider's plain DiscoverSessions(),
 // exactly as before this pushdown existed — zero behavior change for the
 // common case. Either way, the view-level filter (filterSessionsLocked)
 // still re-applies the same exclusion: DiscoverMatching's contract leaves
@@ -242,24 +247,32 @@ func (m *SessionManager) WatcherEvents() <-chan struct{} {
 // the only thing guaranteeing exclusion for those.
 //
 // Runtime pattern changes: SetExcludeCWDSubstrings can be called at any
-// time, and Reload re-reads m.excludeCWDSubstrings fresh on every call, so
-// the very next Reload() automatically discovers under the new patterns —
-// no extra plumbing is needed. (As of this change, no caller actually
-// changes patterns after startup; see the report for that investigation.)
-func (m *SessionManager) Reload() error {
-	m.loadPersistedCacheOnce()
-
+// time, and this re-reads m.excludeCWDSubstrings fresh on every call, so
+// the very next discovery — via either Reload() or UpdateActivities() —
+// automatically applies the new patterns, no extra plumbing needed. (As of
+// this change, no caller actually changes patterns after startup; see the
+// report for that investigation.)
+func (m *SessionManager) discoverHonoringExclusions() ([]*model.Session, error) {
 	m.mu.RLock()
 	patterns := m.excludeCWDSubstrings
 	m.mu.RUnlock()
 
-	var sessions []*model.Session
-	var err error
 	if len(patterns) == 0 {
-		sessions, err = m.provider.DiscoverSessions()
-	} else {
-		sessions, err = DiscoverMatching(m.provider, excludeCWDPredicate(patterns))
+		return m.provider.DiscoverSessions()
 	}
+	return DiscoverMatching(m.provider, excludeCWDPredicate(patterns))
+}
+
+// Reload discovers sessions via the provider and updates activity states.
+// When cache persistence is enabled (EnableCachePersistence), this is also
+// where the persisted cache gets loaded (once, before the first discovery)
+// and saved (see loadPersistedCacheOnce / savePersistedCacheIfDue). See
+// discoverHonoringExclusions for how the exclude_cwd_substrings pushdown is
+// applied.
+func (m *SessionManager) Reload() error {
+	m.loadPersistedCacheOnce()
+
+	sessions, err := m.discoverHonoringExclusions()
 	if err != nil {
 		return err
 	}
@@ -276,7 +289,10 @@ func (m *SessionManager) Reload() error {
 
 // UpdateActivities refreshes activity states without reloading from disk.
 // Returns true if any activity state changed.
-// If the provider specifies a RefreshInterval, sessions are re-discovered periodically.
+// If the provider specifies a RefreshInterval, sessions are re-discovered
+// periodically — via discoverHonoringExclusions, same as Reload, so the
+// exclude_cwd_substrings pushdown applies to this periodic re-discovery
+// too, not just the first one.
 // Also refreshes session names from disk if modified externally.
 func (m *SessionManager) UpdateActivities() bool {
 	namesChanged := m.names.Refresh()
@@ -286,7 +302,7 @@ func (m *SessionManager) UpdateActivities() bool {
 		needsRefresh := len(m.sessions) == 0 || now.Sub(m.lastPollDiscover) > interval
 		m.mu.RUnlock()
 		if needsRefresh {
-			sessions, err := m.provider.DiscoverSessions()
+			sessions, err := m.discoverHonoringExclusions()
 			if err == nil {
 				m.mu.Lock()
 				m.sessions = sessions

--- a/internal/core/session_persist_test.go
+++ b/internal/core/session_persist_test.go
@@ -1,0 +1,267 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// --- EnableCachePersistence: load-once-before-first-discovery ---
+
+func TestEnableCachePersistence_LoadsOnceBeforeFirstDiscovery(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{
+		sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}},
+	}}
+	dir := t.TempDir()
+
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(dir)
+
+	if p.loadCalls != 0 {
+		t.Fatalf("loadCalls before any Reload = %d, want 0", p.loadCalls)
+	}
+
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 1: %v", err)
+	}
+	if p.loadCalls != 1 {
+		t.Fatalf("loadCalls after first Reload = %d, want 1", p.loadCalls)
+	}
+	if p.loadedDir != dir {
+		t.Fatalf("loadedDir = %q, want %q", p.loadedDir, dir)
+	}
+
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 2: %v", err)
+	}
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 3: %v", err)
+	}
+	if p.loadCalls != 1 {
+		t.Fatalf("loadCalls after 3 Reloads = %d, want 1 (load must happen only before the FIRST discovery)", p.loadCalls)
+	}
+}
+
+// --- EnableCachePersistence: save after first successful discovery ---
+
+func TestEnableCachePersistence_SavesAfterFirstSuccessfulDiscovery(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{
+		sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}},
+	}}
+	dir := t.TempDir()
+
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(dir)
+
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if p.saveCalls != 1 {
+		t.Fatalf("saveCalls after first successful Reload = %d, want 1", p.saveCalls)
+	}
+	if p.savedDir != dir {
+		t.Fatalf("savedDir = %q, want %q", p.savedDir, dir)
+	}
+}
+
+// --- EnableCachePersistence: no save on a failed first discovery ---
+
+func TestEnableCachePersistence_NoSaveOnFailedFirstDiscovery(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{err: errTest}}
+	dir := t.TempDir()
+
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(dir)
+
+	if err := mgr.Reload(); err == nil {
+		t.Fatal("Reload with a failing provider: got nil error, want errTest")
+	}
+	// Load still happens (it runs before discovery is even attempted)...
+	if p.loadCalls != 1 {
+		t.Fatalf("loadCalls after a failed Reload = %d, want 1", p.loadCalls)
+	}
+	// ...but Save must never run off the back of a failed discovery.
+	if p.saveCalls != 0 {
+		t.Fatalf("saveCalls after a failed Reload = %d, want 0", p.saveCalls)
+	}
+}
+
+// --- EnableCachePersistence: dirty + minimum-interval save logic ---
+
+func TestEnableCachePersistence_DirtyIntervalLogic(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{
+		sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}},
+	}}
+	dir := t.TempDir()
+
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(dir)
+
+	fakeNow := time.Now()
+	mgr.persistNow = func() time.Time { return fakeNow }
+
+	// First successful Reload always saves, regardless of the interval.
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 1: %v", err)
+	}
+	if p.saveCalls != 1 {
+		t.Fatalf("saveCalls after Reload 1 = %d, want 1 (first save is unconditional)", p.saveCalls)
+	}
+
+	// A Reload well within the minimum interval marks the cache dirty but
+	// must not trigger another disk write.
+	fakeNow = fakeNow.Add(1 * time.Minute)
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 2: %v", err)
+	}
+	if p.saveCalls != 1 {
+		t.Fatalf("saveCalls after Reload 2 (within interval) = %d, want 1 (still dirty, not due)", p.saveCalls)
+	}
+
+	// Once the interval has elapsed, the next successful Reload saves again.
+	fakeNow = fakeNow.Add(cacheSaveInterval)
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 3: %v", err)
+	}
+	if p.saveCalls != 2 {
+		t.Fatalf("saveCalls after Reload 3 (interval elapsed) = %d, want 2", p.saveCalls)
+	}
+}
+
+// --- Close(): final save if dirty, no-op otherwise ---
+
+func TestClose_FinalSaveWhenDirty(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{
+		sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}},
+	}}
+	dir := t.TempDir()
+
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(dir)
+
+	fakeNow := time.Now()
+	mgr.persistNow = func() time.Time { return fakeNow }
+
+	if err := mgr.Reload(); err != nil { // saves (first), dirty -> false
+		t.Fatalf("Reload 1: %v", err)
+	}
+	fakeNow = fakeNow.Add(1 * time.Minute)
+	if err := mgr.Reload(); err != nil { // within interval, dirty -> true
+		t.Fatalf("Reload 2: %v", err)
+	}
+	if p.saveCalls != 1 {
+		t.Fatalf("saveCalls before Close = %d, want 1", p.saveCalls)
+	}
+
+	mgr.Close()
+
+	if p.saveCalls != 2 {
+		t.Fatalf("saveCalls after Close (was dirty) = %d, want 2 (final save)", p.saveCalls)
+	}
+}
+
+func TestClose_NoFinalSaveWhenNotDirty(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{
+		sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}},
+	}}
+	dir := t.TempDir()
+
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(dir)
+
+	if err := mgr.Reload(); err != nil { // saves once, dirty -> false
+		t.Fatalf("Reload: %v", err)
+	}
+	if p.saveCalls != 1 {
+		t.Fatalf("saveCalls before Close = %d, want 1", p.saveCalls)
+	}
+
+	mgr.Close()
+
+	if p.saveCalls != 1 {
+		t.Fatalf("saveCalls after Close (was clean) = %d, want 1 (no redundant final save)", p.saveCalls)
+	}
+}
+
+func TestClose_NoopWhenPersistenceNeverEnabled(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{
+		sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}},
+	}}
+
+	mgr := NewSessionManager(60, p)
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	mgr.Close() // must not panic and must not save
+
+	if p.loadCalls != 0 || p.saveCalls != 0 {
+		t.Fatalf("loadCalls=%d saveCalls=%d, want 0/0 when persistence was never enabled", p.loadCalls, p.saveCalls)
+	}
+}
+
+// --- Persistence disabled entirely: no load, no save ---
+
+func TestPersistence_DisabledByDefault_NoLoadNoSave(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &fakeCachePersister{fakeProvider: fakeProvider{
+		sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}},
+	}}
+
+	mgr := NewSessionManager(60, p) // EnableCachePersistence never called
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	if p.loadCalls != 0 {
+		t.Fatalf("loadCalls = %d, want 0 (persistence never enabled)", p.loadCalls)
+	}
+	if p.saveCalls != 0 {
+		t.Fatalf("saveCalls = %d, want 0 (persistence never enabled)", p.saveCalls)
+	}
+}
+
+// --- Non-persister provider: enabling persistence is a clean no-op ---
+
+func TestEnableCachePersistence_NonPersisterProviderIsCleanNoop(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := fakeProvider{sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}}}
+	dir := t.TempDir()
+
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(dir) // p does not implement CachePersister
+
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 2: %v", err)
+	}
+	mgr.Close()
+
+	// Nothing to assert on p directly (it has no counters), but discovery
+	// must still have worked normally through all of this.
+	if got := mgr.Sessions(); len(got) != 1 || got[0].SessionID != "s1" {
+		t.Fatalf("Sessions() = %+v, want the single fakeProvider session untouched by persistence", got)
+	}
+}

--- a/internal/core/session_streaming_test.go
+++ b/internal/core/session_streaming_test.go
@@ -154,6 +154,14 @@ func TestReloadStreaming_EquivalentToSynchronousReload(t *testing.T) {
 			if !reflect.DeepEqual(gotVisible, wantVisible) {
 				t.Fatalf("patterns=%v: ReloadStreaming VisibleSessions() = %v, want %v", patterns, gotVisible, wantVisible)
 			}
+
+			// Per-session activity state must also agree, not just the
+			// session set/order (review fix round, minor 5).
+			for _, id := range gotAll {
+				if got, want := streamMgr.ActivityFor(id), syncMgr.ActivityFor(id); got != want {
+					t.Fatalf("patterns=%v: ActivityFor(%q) = %v, want %v (streaming vs synchronous Reload)", patterns, id, got, want)
+				}
+			}
 		})
 	}
 }
@@ -235,14 +243,24 @@ func TestReloadStreaming_SavesOnceEvenWhenAllMembersFail(t *testing.T) {
 // deterministically for "this call has started" without sleeping. calls
 // counts every invocation, letting tests prove a guarded caller never
 // triggers a second, concurrent discovery while one is already in flight.
+// If secondCallSessions is set, it is returned starting from the 2nd
+// DiscoverSessions call onward instead of sessions -- lets a test simulate
+// "the underlying data changed between the stream's own discovery and a
+// later catch-up Reload" (see TestReloadStreaming_CatchesUpAbsorbedReloadOnCompletion).
+// It also implements CachePersister (loadCalls/saveCalls counters, no-op
+// bodies) so persistence-focused tests can reuse this same
+// blocking-discovery stub instead of a separate type.
 type blockingProvider struct {
-	mu       sync.Mutex
-	calls    int
-	once     sync.Once
-	entered  chan struct{}
-	release  chan struct{}
-	sessions []*model.Session
-	interval time.Duration
+	mu                 sync.Mutex
+	calls              int
+	loadCalls          int
+	saveCalls          int
+	once               sync.Once
+	entered            chan struct{}
+	release            chan struct{}
+	sessions           []*model.Session
+	secondCallSessions []*model.Session
+	interval           time.Duration
 }
 
 func newBlockingProvider(sessions []*model.Session, interval time.Duration) *blockingProvider {
@@ -257,9 +275,13 @@ func newBlockingProvider(sessions []*model.Session, interval time.Duration) *blo
 func (p *blockingProvider) DiscoverSessions() ([]*model.Session, error) {
 	p.mu.Lock()
 	p.calls++
+	calls := p.calls
 	p.mu.Unlock()
 	p.once.Do(func() { close(p.entered) })
 	<-p.release
+	if calls >= 2 && p.secondCallSessions != nil {
+		return p.secondCallSessions, nil
+	}
 	return p.sessions, nil
 }
 
@@ -269,9 +291,33 @@ func (p *blockingProvider) callCount() int {
 	return p.calls
 }
 
+// LoadCaches/SaveCaches implement CachePersister as no-op counters, so
+// tests can assert save/load call counts on a blockingProvider directly.
+func (p *blockingProvider) LoadCaches(dir string) error {
+	p.mu.Lock()
+	p.loadCalls++
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *blockingProvider) SaveCaches(dir string) error {
+	p.mu.Lock()
+	p.saveCalls++
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *blockingProvider) saveCallCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.saveCalls
+}
+
 func (p *blockingProvider) UseWatcher() bool               { return false }
 func (p *blockingProvider) RefreshInterval() time.Duration { return p.interval }
 func (p *blockingProvider) WatchDirs() []string            { return nil }
+
+var _ CachePersister = (*blockingProvider)(nil)
 
 func TestUpdateActivities_SkipsRediscoveryWhileStreamInFlight(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -391,7 +437,7 @@ func TestReload_RunsNormallyAfterStreamCompletes(t *testing.T) {
 // TestClose_DuringInFlightStream_DoesNotSaveAndDoesNotRace documents and
 // pins "shutdown save behavior unchanged" for the specific new scenario
 // ReloadStreaming introduces: the TUI never joins the goroutine running
-// ReloadStreaming (see internal/ui's startStreamingLoadCmd -- the same
+// ReloadStreaming (see internal/ui's runStreamingLoadCmd -- the same
 // pattern Task 11's picker uses for its own background discovery
 // goroutine), so a user quitting mid-stream reaches Close() while
 // ReloadStreaming is genuinely still running concurrently in another
@@ -401,13 +447,16 @@ func TestReload_RunsNormallyAfterStreamCompletes(t *testing.T) {
 // saves when persistDirty is true, and ReloadStreaming's single
 // savePersistedCacheIfDue call happens after <-done, so persistDirty is
 // never set during the stream. An early quit therefore reaches Close()
-// before that call ever ran: no save happens for this run at all (not even
-// a partial one) -- the previous run's persisted cache, if any, is simply
-// left on disk untouched. That is safe and lossless (advisory cache, see
-// CachePersister), just not a speed win for the aborted run; this test
-// exists to pin that exact behavior and, under -race, prove Close() reading
-// persistEnabled/persistDirty concurrently with ReloadStreaming's own
-// locked mutations is race-free.
+// before that call ever ran, so Close() ITSELF never triggers a save here
+// -- verified below via a counting stub, not just by inspection. This is
+// specifically about what Close() does (nothing, while the stream is still
+// in flight): nothing cancels the still-running background stream
+// goroutine, so if it happens to reach its own natural completion (and
+// save) before the process actually exits, that save still fires
+// independently of Close() -- a completion save is not guaranteed to be
+// skipped for the run as a whole, only Close()'s own attempt is. Also
+// proves, under -race, that Close() reading persistEnabled/persistDirty
+// concurrently with ReloadStreaming's own locked mutations is race-free.
 func TestClose_DuringInFlightStream_DoesNotSaveAndDoesNotRace(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
@@ -432,10 +481,180 @@ func TestClose_DuringInFlightStream_DoesNotSaveAndDoesNotRace(t *testing.T) {
 	// guarantee the background ReloadStreaming goroutine has finished.
 	mgr.Close()
 
+	if got := p.saveCallCount(); got != 0 {
+		t.Fatalf("saveCalls after Close() during an in-flight stream = %d, want 0 (Close must not save while the stream's own completion save hasn't run yet)", got)
+	}
+
 	close(p.release)
 	select {
 	case <-streamDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("ReloadStreaming did not complete after release")
+	}
+}
+
+// TestReloadStreaming_CatchesUpAbsorbedReloadOnCompletion pins the
+// pendingReload latch (review fix round, Important 2): a Reload absorbed
+// while a stream is in flight must not be lost forever for an
+// all-watcher-provider setup with no periodic RefreshInterval (e.g.
+// claude/pi/grok/kimi) -- there, nothing else naturally retries it; the
+// next real watcher event might not arrive for a long time, or ever, for
+// that exact change. Uses blockingProvider.secondCallSessions so the
+// catch-up Reload's discovery (the 2nd DiscoverSessions call) can return a
+// genuinely different result than the stream's own (1st) call, proving the
+// catch-up actually re-discovered rather than just re-merging stale data.
+func TestReloadStreaming_CatchesUpAbsorbedReloadOnCompletion(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	p := newBlockingProvider([]*model.Session{{SessionID: "s1", LastActivity: now}}, 0)
+	p.secondCallSessions = []*model.Session{
+		{SessionID: "s1", LastActivity: now},
+		{SessionID: "s2", LastActivity: now.Add(time.Minute)},
+	}
+	mgr := NewSessionManager(60, p)
+
+	streamDone := make(chan struct{})
+	go func() {
+		mgr.ReloadStreaming(nil)
+		close(streamDone)
+	}()
+
+	select {
+	case <-p.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blockingProvider.DiscoverSessions was never entered")
+	}
+
+	// Absorbed mid-stream -- must be latched, not dropped.
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("absorbed Reload: %v", err)
+	}
+
+	close(p.release)
+	select {
+	case <-streamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReloadStreaming did not complete after release")
+	}
+
+	if got := p.callCount(); got != 2 {
+		t.Fatalf("provider.DiscoverSessions call count after completion = %d, want 2 (the stream's own call, plus one catch-up Reload for the absorbed watcher event)", got)
+	}
+	ids := sessionIDOrder(mgr.Sessions())
+	if len(ids) != 2 || ids[0] != "s2" || ids[1] != "s1" {
+		t.Fatalf("Sessions() after completion = %v, want [s2 s1] (the catch-up Reload's fresh discovery, most-recent-first) -- the absorbed Reload's change must not be lost", ids)
+	}
+}
+
+// --- Important 1 (review fix round): streamInFlight must be true through
+// the ENTIRE streaming reload, including loadPersistedCacheOnce (a
+// potentially slow, multi-MB JSON parse) -- not just once discovery itself
+// starts. blockingLoadProvider blocks LoadCaches (not DiscoverSessions)
+// until released, isolating that specific window.
+
+type blockingLoadProvider struct {
+	mu            sync.Mutex
+	discoverCalls int
+	once          sync.Once
+	entered       chan struct{}
+	release       chan struct{}
+	sessions      []*model.Session
+}
+
+func newBlockingLoadProvider(sessions []*model.Session) *blockingLoadProvider {
+	return &blockingLoadProvider{
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+		sessions: sessions,
+	}
+}
+
+func (p *blockingLoadProvider) DiscoverSessions() ([]*model.Session, error) {
+	p.mu.Lock()
+	p.discoverCalls++
+	p.mu.Unlock()
+	return p.sessions, nil
+}
+
+func (p *blockingLoadProvider) discoverCallCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.discoverCalls
+}
+
+func (p *blockingLoadProvider) LoadCaches(dir string) error {
+	p.once.Do(func() { close(p.entered) })
+	<-p.release
+	return nil
+}
+
+func (p *blockingLoadProvider) SaveCaches(dir string) error { return nil }
+
+func (p *blockingLoadProvider) UseWatcher() bool               { return false }
+func (p *blockingLoadProvider) RefreshInterval() time.Duration { return time.Millisecond }
+func (p *blockingLoadProvider) WatchDirs() []string            { return nil }
+
+var _ CachePersister = (*blockingLoadProvider)(nil)
+
+// TestReloadStreaming_GuardsHoldThroughCacheLoad is the Important-1 review
+// fix: with the pre-fix implementation, ReloadStreaming set streamInFlight
+// only AFTER calling loadPersistedCacheOnce, so a watcher event or
+// UpdateActivities tick landing during that (potentially slow) load would
+// pass the guard, run its own full discovery, and race the stream's own
+// per-batch appends into duplicate SessionIDs (which, over the Wails IPC
+// boundary, breaks the Svelte frontend's keyed session list).
+// BeginReloadStreaming fixes this by setting streamInFlight synchronously
+// before returning the run func -- before ANY of the streaming reload's own
+// work begins.
+func TestReloadStreaming_GuardsHoldThroughCacheLoad(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := newBlockingLoadProvider([]*model.Session{{SessionID: "s1", LastActivity: time.Now()}})
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(t.TempDir())
+
+	run := mgr.BeginReloadStreaming()
+	streamDone := make(chan struct{})
+	go func() {
+		run(nil)
+		close(streamDone)
+	}()
+
+	select {
+	case <-p.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("LoadCaches was never entered")
+	}
+
+	// We are inside the persisted-cache load, well before
+	// DiscoverMatchingStream's own discovery has even started -- both
+	// Reload and UpdateActivities must already be guarded here, not just
+	// once discovery begins.
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload during the cache-load window: %v", err)
+	}
+	_ = mgr.UpdateActivities()
+
+	if got := p.discoverCallCount(); got != 0 {
+		t.Fatalf("DiscoverSessions call count after Reload+UpdateActivities during the cache-load window = %d, want 0 (both must be guarded before discovery even starts, not just once it does)", got)
+	}
+
+	close(p.release)
+	select {
+	case <-streamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream did not complete after release")
+	}
+
+	// 2, not 1: the Reload() above was absorbed while streamInFlight was
+	// true, which also latches pendingReload (Important 2) -- so its own
+	// catch-up Reload legitimately runs one more discovery once the stream
+	// completes. This is the two fixes working together, not a leak: had
+	// the guard failed to hold through the cache-load window, the call
+	// count observed *during* the window (asserted above) would already
+	// have been > 0.
+	if got := p.discoverCallCount(); got != 2 {
+		t.Fatalf("final DiscoverSessions call count = %d, want 2 (the stream's own discovery, plus the absorbed Reload's catch-up)", got)
 	}
 }

--- a/internal/core/session_streaming_test.go
+++ b/internal/core/session_streaming_test.go
@@ -387,3 +387,55 @@ func TestReload_RunsNormallyAfterStreamCompletes(t *testing.T) {
 		t.Fatalf("Sessions() after post-stream Reload = %d, want 2 (streamInFlight must be cleared once the stream finishes)", len(got))
 	}
 }
+
+// TestClose_DuringInFlightStream_DoesNotSaveAndDoesNotRace documents and
+// pins "shutdown save behavior unchanged" for the specific new scenario
+// ReloadStreaming introduces: the TUI never joins the goroutine running
+// ReloadStreaming (see internal/ui's startStreamingLoadCmd -- the same
+// pattern Task 11's picker uses for its own background discovery
+// goroutine), so a user quitting mid-stream reaches Close() while
+// ReloadStreaming is genuinely still running concurrently in another
+// goroutine.
+//
+// Close() itself is untouched by this task (per the brief) -- it still only
+// saves when persistDirty is true, and ReloadStreaming's single
+// savePersistedCacheIfDue call happens after <-done, so persistDirty is
+// never set during the stream. An early quit therefore reaches Close()
+// before that call ever ran: no save happens for this run at all (not even
+// a partial one) -- the previous run's persisted cache, if any, is simply
+// left on disk untouched. That is safe and lossless (advisory cache, see
+// CachePersister), just not a speed win for the aborted run; this test
+// exists to pin that exact behavior and, under -race, prove Close() reading
+// persistEnabled/persistDirty concurrently with ReloadStreaming's own
+// locked mutations is race-free.
+func TestClose_DuringInFlightStream_DoesNotSaveAndDoesNotRace(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := newBlockingProvider([]*model.Session{{SessionID: "s1", LastActivity: time.Now()}}, 0)
+	mgr := NewSessionManager(60, p)
+	mgr.EnableCachePersistence(t.TempDir())
+
+	streamDone := make(chan struct{})
+	go func() {
+		mgr.ReloadStreaming(nil)
+		close(streamDone)
+	}()
+
+	select {
+	case <-p.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blockingProvider.DiscoverSessions was never entered")
+	}
+
+	// Simulate the TUI's shutdown path: p.Run() has returned (the user
+	// quit) and main.go calls Manager().Close() immediately, with no
+	// guarantee the background ReloadStreaming goroutine has finished.
+	mgr.Close()
+
+	close(p.release)
+	select {
+	case <-streamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReloadStreaming did not complete after release")
+	}
+}

--- a/internal/core/session_streaming_test.go
+++ b/internal/core/session_streaming_test.go
@@ -1,0 +1,389 @@
+package core
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// --- exclusionMatcher: the single place that decides the predicate shared
+// by discoverHonoringExclusions (Reload, UpdateActivities) and
+// ReloadStreaming ---
+
+func TestExclusionMatcher_NilWhenNoPatterns(t *testing.T) {
+	mgr := NewSessionManager(60, fakeProvider{})
+	if m := mgr.exclusionMatcher(); m != nil {
+		t.Fatal("exclusionMatcher() with no patterns configured = non-nil, want nil (the streaming path's DiscoverMatchingStream call must receive a literal nil, not a permissive predicate)")
+	}
+}
+
+func TestExclusionMatcher_PredicateMatchesExcludeCWDPredicateWhenPatternsSet(t *testing.T) {
+	mgr := NewSessionManager(60, fakeProvider{})
+	patterns := []string{"/tmp/scratch", ".claude-mem"}
+	mgr.SetExcludeCWDSubstrings(patterns)
+
+	got := mgr.exclusionMatcher()
+	if got == nil {
+		t.Fatal("exclusionMatcher() with patterns set = nil, want a predicate")
+	}
+	want := excludeCWDPredicate(patterns)
+	cases := []string{"/tmp/scratch/build", "/home/user/.claude-mem/x", "/home/user/project"}
+	for _, cwd := range cases {
+		if got(cwd) != want(cwd) {
+			t.Errorf("exclusionMatcher()(%q) = %v, want %v (excludeCWDPredicate(patterns)(%q))", cwd, got(cwd), want(cwd), cwd)
+		}
+	}
+}
+
+// --- ReloadStreaming: batches grow the snapshot, onUpdate fires per batch
+// outside the lock ---
+
+func TestReloadStreaming_BatchesGrowSnapshotAndFireOnUpdateOutsideLock(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	p1 := fakeProvider{sessions: []*model.Session{{SessionID: "s1", LastActivity: now}}}
+	p2 := fakeProvider{sessions: []*model.Session{
+		{SessionID: "s2", LastActivity: now},
+		{SessionID: "s3", LastActivity: now},
+	}}
+	mp := MultiProvider{Providers: []SessionProvider{p1, p2}}
+
+	mgr := NewSessionManager(60, mp)
+
+	var mu sync.Mutex
+	var updates int
+	var sizes []int
+
+	done := make(chan struct{})
+	go func() {
+		mgr.ReloadStreaming(func() {
+			// Calling back into the manager from onUpdate must not deadlock:
+			// this only returns if onUpdate is invoked with m.mu NOT held.
+			n := len(mgr.Sessions())
+			mu.Lock()
+			updates++
+			sizes = append(sizes, n)
+			mu.Unlock()
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReloadStreaming did not complete (onUpdate likely deadlocked while m.mu was held)")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if updates != 2 {
+		t.Fatalf("onUpdate called %d times, want 2 (one per provider member)", updates)
+	}
+	for i := 1; i < len(sizes); i++ {
+		if sizes[i] < sizes[i-1] {
+			t.Fatalf("snapshot sizes observed at each onUpdate = %v, want non-decreasing growth", sizes)
+		}
+	}
+	if sizes[len(sizes)-1] != 3 {
+		t.Fatalf("snapshot size at the last onUpdate = %d, want 3 (1 + 2 sessions merged)", sizes[len(sizes)-1])
+	}
+	if got := mgr.Sessions(); len(got) != 3 {
+		t.Fatalf("Sessions() after ReloadStreaming = %d, want 3", len(got))
+	}
+}
+
+// --- ReloadStreaming completion must equal a synchronous Reload: same set,
+// same sort, with and without exclusion patterns, over a DirScoped + plain
+// provider mix (property test) ---
+
+func TestReloadStreaming_EquivalentToSynchronousReload(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	base := time.Now()
+	dirScopedSessions := []*model.Session{
+		{SessionID: "ds-keep", CWD: "/home/user/project", LastActivity: base.Add(4 * time.Minute)},
+		{SessionID: "ds-excluded", CWD: "/home/user/.claude-mem/observer-sessions/x", LastActivity: base.Add(3 * time.Minute)},
+	}
+	plainSessions := []*model.Session{
+		{SessionID: "plain-keep", CWD: "/home/user/other-project", LastActivity: base.Add(2 * time.Minute)},
+		{SessionID: "plain-excluded", CWD: "/tmp/scratch/build", LastActivity: base.Add(1 * time.Minute)},
+	}
+
+	patternSets := [][]string{
+		nil,
+		{},
+		{".claude-mem/observer-sessions"},
+		{"/tmp/scratch"},
+		{".claude-mem/observer-sessions", "/tmp/scratch"},
+		{"no-match-anywhere"},
+	}
+
+	for _, patterns := range patternSets {
+		t.Run(strings.Join(patterns, "+"), func(t *testing.T) {
+			dirScoped := &filteringDirScopedProvider{sessions: cloneSessions(dirScopedSessions)}
+			plain := fakeProvider{sessions: cloneSessions(plainSessions)}
+			streamProvider := MultiProvider{Providers: []SessionProvider{dirScoped, plain}}
+
+			streamMgr := NewSessionManager(60, streamProvider)
+			streamMgr.SetExcludeCWDSubstrings(patterns)
+			streamMgr.ReloadStreaming(nil)
+
+			dirScoped2 := &filteringDirScopedProvider{sessions: cloneSessions(dirScopedSessions)}
+			plain2 := fakeProvider{sessions: cloneSessions(plainSessions)}
+			syncProvider := MultiProvider{Providers: []SessionProvider{dirScoped2, plain2}}
+
+			syncMgr := NewSessionManager(60, syncProvider)
+			syncMgr.SetExcludeCWDSubstrings(patterns)
+			if err := syncMgr.Reload(); err != nil {
+				t.Fatalf("synchronous Reload failed: %v", err)
+			}
+
+			gotAll := sessionIDOrder(streamMgr.Sessions())
+			wantAll := sessionIDOrder(syncMgr.Sessions())
+			if !reflect.DeepEqual(gotAll, wantAll) {
+				t.Fatalf("patterns=%v: ReloadStreaming Sessions() = %v, want (synchronous Reload) %v", patterns, gotAll, wantAll)
+			}
+
+			gotVisible := sessionIDOrder(streamMgr.VisibleSessions())
+			wantVisible := sessionIDOrder(syncMgr.VisibleSessions())
+			if !reflect.DeepEqual(gotVisible, wantVisible) {
+				t.Fatalf("patterns=%v: ReloadStreaming VisibleSessions() = %v, want %v", patterns, gotVisible, wantVisible)
+			}
+		})
+	}
+}
+
+func sessionIDOrder(sessions []*model.Session) []string {
+	ids := make([]string, len(sessions))
+	for i, s := range sessions {
+		ids[i] = s.SessionID
+	}
+	return ids
+}
+
+// --- Persistence: exactly one save on completion, never mid-stream ---
+
+func TestReloadStreaming_ExactlyOneSaveOnCompletion(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p1 := &fakeCachePersister{fakeProvider: fakeProvider{sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}}}}
+	p2 := &fakeCachePersister{fakeProvider: fakeProvider{sessions: []*model.Session{{SessionID: "s2", LastActivity: time.Now()}}}}
+	mp := MultiProvider{Providers: []SessionProvider{p1, p2}}
+
+	mgr := NewSessionManager(60, mp)
+	mgr.EnableCachePersistence(t.TempDir())
+
+	var mu sync.Mutex
+	var maxSaveCallsMidStream int
+	mgr.ReloadStreaming(func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if c := p1.saveCalls + p2.saveCalls; c > maxSaveCallsMidStream {
+			maxSaveCallsMidStream = c
+		}
+	})
+
+	if maxSaveCallsMidStream != 0 {
+		t.Fatalf("saveCalls observed during onUpdate (mid-stream) = %d, want 0 (no save before stream completion)", maxSaveCallsMidStream)
+	}
+	if p1.saveCalls != 1 || p2.saveCalls != 1 {
+		t.Fatalf("saveCalls after completion = p1:%d p2:%d, want 1/1 (exactly one save call, dispatched to every CachePersister member)", p1.saveCalls, p2.saveCalls)
+	}
+	if p1.loadCalls != 1 || p2.loadCalls != 1 {
+		t.Fatalf("loadCalls after completion = p1:%d p2:%d, want 1/1 (loaded once before discovery started)", p1.loadCalls, p2.loadCalls)
+	}
+}
+
+// TestReloadStreaming_SavesOnceEvenWhenAllMembersFail documents the accepted
+// divergence from Reload's error-gated save: DiscoverMatchingStream has no
+// error channel (best-effort per member, by design), so "every member
+// failed" is indistinguishable from "every member found nothing" at the
+// stream level. ReloadStreaming's completion signal is "the stream
+// finished", not "discovery succeeded" -- so it always saves once on
+// completion.
+func TestReloadStreaming_SavesOnceEvenWhenAllMembersFail(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p1 := &fakeCachePersister{fakeProvider: fakeProvider{err: errTest}}
+	p2 := &fakeCachePersister{fakeProvider: fakeProvider{err: errTest}}
+	mp := MultiProvider{Providers: []SessionProvider{p1, p2}}
+
+	mgr := NewSessionManager(60, mp)
+	mgr.EnableCachePersistence(t.TempDir())
+
+	mgr.ReloadStreaming(nil)
+
+	if got := mgr.Sessions(); len(got) != 0 {
+		t.Fatalf("Sessions() after an all-members-failed stream = %d, want 0 (empty snapshot, same observable outcome as Reload's error path)", len(got))
+	}
+	if p1.saveCalls != 1 || p2.saveCalls != 1 {
+		t.Fatalf("saveCalls = p1:%d p2:%d, want 1/1 (stream completion always saves once)", p1.saveCalls, p2.saveCalls)
+	}
+}
+
+// --- Guard: UpdateActivities must not re-discover while a stream is
+// in-flight; Reload must be absorbed rather than run a second, concurrent
+// discovery ---
+
+// blockingProvider's DiscoverSessions blocks on release until it is closed,
+// closing entered exactly once right before blocking so a test can wait
+// deterministically for "this call has started" without sleeping. calls
+// counts every invocation, letting tests prove a guarded caller never
+// triggers a second, concurrent discovery while one is already in flight.
+type blockingProvider struct {
+	mu       sync.Mutex
+	calls    int
+	once     sync.Once
+	entered  chan struct{}
+	release  chan struct{}
+	sessions []*model.Session
+	interval time.Duration
+}
+
+func newBlockingProvider(sessions []*model.Session, interval time.Duration) *blockingProvider {
+	return &blockingProvider{
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+		sessions: sessions,
+		interval: interval,
+	}
+}
+
+func (p *blockingProvider) DiscoverSessions() ([]*model.Session, error) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+	p.once.Do(func() { close(p.entered) })
+	<-p.release
+	return p.sessions, nil
+}
+
+func (p *blockingProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func (p *blockingProvider) UseWatcher() bool               { return false }
+func (p *blockingProvider) RefreshInterval() time.Duration { return p.interval }
+func (p *blockingProvider) WatchDirs() []string            { return nil }
+
+func TestUpdateActivities_SkipsRediscoveryWhileStreamInFlight(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := newBlockingProvider([]*model.Session{{SessionID: "s1", LastActivity: time.Now()}}, time.Millisecond)
+	mgr := NewSessionManager(60, p)
+
+	streamDone := make(chan struct{})
+	go func() {
+		mgr.ReloadStreaming(nil)
+		close(streamDone)
+	}()
+
+	select {
+	case <-p.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blockingProvider.DiscoverSessions was never entered")
+	}
+
+	// The stream's one member is now blocked mid-discovery -- streamInFlight
+	// must be true. UpdateActivities' periodic re-discovery branch would
+	// normally fire here (m.sessions is still empty, RefreshInterval > 0);
+	// it must instead skip re-discovery and fall through to the
+	// activity-only recompute (safe against an empty/partial snapshot).
+	_ = mgr.UpdateActivities()
+
+	if got := p.callCount(); got != 1 {
+		t.Fatalf("provider.DiscoverSessions call count after UpdateActivities during an in-flight stream = %d, want 1 (must not trigger a second, concurrent discovery)", got)
+	}
+
+	close(p.release)
+
+	select {
+	case <-streamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReloadStreaming did not complete after release")
+	}
+
+	if got := mgr.Sessions(); len(got) != 1 || got[0].SessionID != "s1" {
+		t.Fatalf("Sessions() after stream completion = %#v, want [s1]", got)
+	}
+	if got := p.callCount(); got != 1 {
+		t.Fatalf("final provider.DiscoverSessions call count = %d, want 1 (only the stream's own call)", got)
+	}
+}
+
+func TestReload_SkippedWhileStreamInFlight(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := newBlockingProvider([]*model.Session{{SessionID: "s1", LastActivity: time.Now()}}, 0)
+	mgr := NewSessionManager(60, p)
+
+	streamDone := make(chan struct{})
+	go func() {
+		mgr.ReloadStreaming(nil)
+		close(streamDone)
+	}()
+
+	select {
+	case <-p.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blockingProvider.DiscoverSessions was never entered")
+	}
+
+	// A watcher-triggered Reload landing mid-stream (TUI's
+	// fileWatchMsg/tickMsg and tray/API's watchLoop all call Reload
+	// unconditionally on every event, with no way to know a stream is
+	// running) must be absorbed: return immediately, without starting a
+	// second, independent discovery.
+	reloadReturned := make(chan error, 1)
+	go func() { reloadReturned <- mgr.Reload() }()
+
+	select {
+	case err := <-reloadReturned:
+		if err != nil {
+			t.Fatalf("Reload during an in-flight stream returned %v, want nil (absorbed)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reload during an in-flight stream blocked instead of being absorbed immediately")
+	}
+
+	if got := p.callCount(); got != 1 {
+		t.Fatalf("provider.DiscoverSessions call count after the absorbed Reload = %d, want 1 (Reload must not run its own discovery while a stream is in flight)", got)
+	}
+
+	close(p.release)
+	select {
+	case <-streamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReloadStreaming did not complete after release")
+	}
+
+	if got := mgr.Sessions(); len(got) != 1 || got[0].SessionID != "s1" {
+		t.Fatalf("Sessions() after stream completion = %#v, want [s1] (no corruption from the absorbed concurrent Reload)", got)
+	}
+}
+
+// TestReload_RunsNormallyAfterStreamCompletes proves the streamInFlight
+// guard is cleared once ReloadStreaming returns, so a later watcher- or
+// poll-driven Reload works exactly as it always has.
+func TestReload_RunsNormallyAfterStreamCompletes(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &mutableStubProvider{sessions: []*model.Session{{SessionID: "s1", LastActivity: time.Now()}}}
+	mgr := NewSessionManager(60, p)
+	mgr.ReloadStreaming(nil)
+
+	p.sessions = append(p.sessions, &model.Session{SessionID: "s2", LastActivity: time.Now()})
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload after stream completion: %v", err)
+	}
+	if got := mgr.Sessions(); len(got) != 2 {
+		t.Fatalf("Sessions() after post-stream Reload = %d, want 2 (streamInFlight must be cleared once the stream finishes)", len(got))
+	}
+}

--- a/internal/core/session_test.go
+++ b/internal/core/session_test.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -193,6 +195,227 @@ func TestFilterSessionsLocked_MultipleExcludePatterns(t *testing.T) {
 	if len(visible) > 0 && visible[0].SessionID != "normal" {
 		t.Errorf("expected 'normal' session, got %q", visible[0].SessionID)
 	}
+}
+
+// TestExcludedByCWD_MatchesViewFilterSemantics is the shared-helper test:
+// excludedByCWD is the single implementation both the view-level filter
+// (filterSessionsLocked) and the discovery-pushdown predicate
+// (excludeCWDPredicate, used by Reload) call, so this table is authoritative
+// for "is this CWD excluded" everywhere in the manager.
+func TestExcludedByCWD_MatchesViewFilterSemantics(t *testing.T) {
+	tests := []struct {
+		name     string
+		cwd      string
+		patterns []string
+		want     bool
+	}{
+		{"no patterns", "/home/user/project", nil, false},
+		{"empty patterns slice", "/home/user/project", []string{}, false},
+		{"single empty-string pattern never matches", "/home/user/project", []string{""}, false},
+		{"substring in middle matches", "/home/user/.claude-mem/observer-sessions/x", []string{".claude-mem/observer-sessions"}, true},
+		{"substring at start matches", "/tmp/scratch/build", []string{"/tmp/scratch"}, true},
+		{"substring at end matches", "/home/user/project/tmp", []string{"/tmp"}, true},
+		{"no substring match", "/home/user/project", []string{".claude-mem/observer-sessions"}, false},
+		{"case sensitive: differently-cased pattern does not match", "/home/user/Project", []string{"/home/user/project"}, false},
+		{"case sensitive: matching case matches", "/home/user/Project", []string{"/home/user/Project"}, true},
+		{"multiple patterns: first matches", "/tmp/scratch/build", []string{"/tmp/scratch", ".claude-mem"}, true},
+		{"multiple patterns: second matches", "/home/user/.claude-mem/x", []string{"/tmp/scratch", ".claude-mem"}, true},
+		{"multiple patterns: none match", "/home/user/other", []string{"/tmp/scratch", ".claude-mem"}, false},
+		{"empty pattern among real ones is ignored", "/home/user/project", []string{"", "/tmp/scratch"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := excludedByCWD(tt.cwd, tt.patterns); got != tt.want {
+				t.Errorf("excludedByCWD(%q, %v) = %v, want %v", tt.cwd, tt.patterns, got, tt.want)
+			}
+			// excludeCWDPredicate is Reload's discovery-time pushdown predicate
+			// (it returns true = "keep"). It must always be the exact logical
+			// negation of excludedByCWD, since it is built directly from it —
+			// this is what guarantees the pushdown predicate can never cause a
+			// dir-scoped provider to skip a session the view layer would show.
+			predicate := excludeCWDPredicate(tt.patterns)
+			if got := predicate(tt.cwd); got != !tt.want {
+				t.Errorf("excludeCWDPredicate(%v)(%q) = %v, want %v (negation of excludedByCWD)", tt.patterns, tt.cwd, got, !tt.want)
+			}
+		})
+	}
+}
+
+// TestReload_NoExcludePatterns_UsesPlainDiscoverSessions proves the "zero
+// behavior change when no exclude patterns are configured" binding
+// constraint at the mechanism level: with no patterns set, Reload must not
+// go through DiscoverMatching's dir-scoped fast path at all -- it must call
+// the provider's plain DiscoverSessions(), exactly like before this change.
+func TestReload_NoExcludePatterns_UsesPlainDiscoverSessions(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &dirScopedFakeProvider{
+		unfiltered: []*model.Session{{SessionID: "plain-path", LastActivity: time.Now()}},
+		sessions:   []*model.Session{{SessionID: "fast-path", LastActivity: time.Now()}},
+	}
+	mgr := NewSessionManager(60, p)
+	// No SetExcludeCWDSubstrings call -- patterns are nil/empty.
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+
+	if p.receivedMatcher {
+		t.Error("Reload with no exclude patterns must not invoke the dir-scoped fast path (DiscoverMatching)")
+	}
+	got := mgr.Sessions()
+	if len(got) != 1 || got[0].SessionID != "plain-path" {
+		t.Fatalf("Sessions() = %#v, want the plain DiscoverSessions() result (zero pushdown when no patterns)", got)
+	}
+}
+
+// TestReload_PatternChangeAppliesOnNextReload_DirScopedPushdown documents
+// and tests the mechanism relied on for "runtime pattern changes": Reload()
+// re-reads m.excludeCWDSubstrings on every call, so calling
+// SetExcludeCWDSubstrings followed by Reload() picks up the new patterns
+// with no extra plumbing. It also proves the exclusion now happens at
+// discovery time for a dir-scoped provider: even Sessions() (the "raw",
+// unfiltered accessor) shrinks once the pattern is set and a Reload runs --
+// not just VisibleSessions()/QuerySessions().
+func TestReload_PatternChangeAppliesOnNextReload_DirScopedPushdown(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	p := &filteringDirScopedProvider{sessions: []*model.Session{
+		{SessionID: "keep", CWD: "/home/user/project", LastActivity: now},
+		{SessionID: "heavy", CWD: "/home/user/.claude-mem/observer-sessions/x", LastActivity: now},
+	}}
+	mgr := NewSessionManager(60, p)
+
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 1 failed: %v", err)
+	}
+	if len(mgr.Sessions()) != 2 {
+		t.Fatalf("before exclusion: Sessions() = %d, want 2 (raw discovery unfiltered)", len(mgr.Sessions()))
+	}
+
+	mgr.SetExcludeCWDSubstrings([]string{".claude-mem/observer-sessions"})
+	if err := mgr.Reload(); err != nil {
+		t.Fatalf("Reload 2 failed: %v", err)
+	}
+
+	raw := mgr.Sessions()
+	if len(raw) != 1 || raw[0].SessionID != "keep" {
+		t.Fatalf("after SetExcludeCWDSubstrings + Reload: Sessions() = %#v, want only 'keep' (pushdown applied at discovery time)", raw)
+	}
+}
+
+// TestReload_ExcludePushdown_EquivalentToViewFilter is the manager-level
+// equivalence property test: for any pattern set, the visible sessions
+// (post view-filter) must be identical whether or not discovery-time
+// pushdown happened. It uses a fixture provider mix -- one DirScopedProvider
+// stub (which genuinely filters using cwdMatch, unlike dirScopedFakeProvider
+// in provider_test.go) and one plain stub (which DiscoverMatching cannot
+// pre-filter at all) -- to exercise both of DiscoverMatching's code paths at
+// once.
+func TestReload_ExcludePushdown_EquivalentToViewFilter(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	dirScopedSessions := []*model.Session{
+		{SessionID: "ds-keep", CWD: "/home/user/project", LastActivity: now},
+		{SessionID: "ds-excluded", CWD: "/home/user/.claude-mem/observer-sessions/x", LastActivity: now},
+	}
+	plainSessions := []*model.Session{
+		{SessionID: "plain-keep", CWD: "/home/user/other-project", LastActivity: now},
+		{SessionID: "plain-excluded", CWD: "/tmp/scratch/build", LastActivity: now},
+	}
+
+	patternSets := [][]string{
+		nil,
+		{},
+		{".claude-mem/observer-sessions"},
+		{"/tmp/scratch"},
+		{".claude-mem/observer-sessions", "/tmp/scratch"},
+		{"no-match-anywhere"},
+	}
+
+	for _, patterns := range patternSets {
+		t.Run(strings.Join(patterns, "+"), func(t *testing.T) {
+			// Actual: real pushdown, via a MultiProvider mixing a dir-scoped
+			// member (fast-path filtering happens at discovery) and a plain
+			// member (DiscoverMatching falls back to unfiltered discovery
+			// for it, per its documented contract).
+			dirScoped := &filteringDirScopedProvider{sessions: cloneSessions(dirScopedSessions)}
+			plain := fakeProvider{sessions: cloneSessions(plainSessions)}
+			mp := MultiProvider{Providers: []SessionProvider{dirScoped, plain}}
+
+			actualMgr := NewSessionManager(60, mp)
+			actualMgr.SetExcludeCWDSubstrings(patterns)
+			if err := actualMgr.Reload(); err != nil {
+				t.Fatalf("actual Reload failed: %v", err)
+			}
+			actual := sessionIDSet(actualMgr.VisibleSessions())
+
+			// Expected: no pushdown possible at all (plain provider only,
+			// wrapping the exact same full session set) -- so the view
+			// filter alone determines what's visible. If pushdown changed
+			// the outcome, this would diverge from actual.
+			var all []*model.Session
+			all = append(all, cloneSessions(dirScopedSessions)...)
+			all = append(all, cloneSessions(plainSessions)...)
+			wantMgr := NewSessionManager(60, fakeProvider{sessions: all})
+			wantMgr.SetExcludeCWDSubstrings(patterns)
+			if err := wantMgr.Reload(); err != nil {
+				t.Fatalf("want Reload failed: %v", err)
+			}
+			want := sessionIDSet(wantMgr.VisibleSessions())
+
+			if !reflect.DeepEqual(actual, want) {
+				t.Fatalf("patterns=%v: pushdown-visible=%v, view-filter-only-visible=%v (must be identical)", patterns, actual, want)
+			}
+		})
+	}
+}
+
+// filteringDirScopedProvider is a DirScopedProvider stub whose
+// DiscoverSessionsMatching genuinely applies cwdMatch to its session list
+// (unlike dirScopedFakeProvider in provider_test.go, which returns a fixed
+// canned result regardless of the matcher it receives). Used to exercise
+// the real discovery-time pushdown behavior.
+type filteringDirScopedProvider struct {
+	sessions []*model.Session
+}
+
+func (p *filteringDirScopedProvider) DiscoverSessions() ([]*model.Session, error) {
+	return p.sessions, nil
+}
+
+func (p *filteringDirScopedProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
+	var out []*model.Session
+	for _, s := range p.sessions {
+		if cwdMatch(s.CWD) {
+			out = append(out, s)
+		}
+	}
+	return out, nil
+}
+
+func (p *filteringDirScopedProvider) UseWatcher() bool               { return false }
+func (p *filteringDirScopedProvider) RefreshInterval() time.Duration { return 0 }
+func (p *filteringDirScopedProvider) WatchDirs() []string            { return nil }
+
+// cloneSessions returns a shallow copy of the slice (not the pointed-to
+// Session structs) so each subtest's providers own an independent slice
+// header, even though sessions are shared read-only fixtures.
+func cloneSessions(sessions []*model.Session) []*model.Session {
+	out := make([]*model.Session, len(sessions))
+	copy(out, sessions)
+	return out
+}
+
+// sessionIDSet returns the set of session IDs present in sessions, for
+// order-independent comparison.
+func sessionIDSet(sessions []*model.Session) map[string]bool {
+	set := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		set[s.SessionID] = true
+	}
+	return set
 }
 
 func TestSessionManager_SetEventBus_PropagatesToTracker(t *testing.T) {

--- a/internal/core/session_test.go
+++ b/internal/core/session_test.go
@@ -476,11 +476,18 @@ func (p *filteringDirScopedProvider) DiscoverSessions() ([]*model.Session, error
 	return p.sessions, nil
 }
 
+// DiscoverSessionsMatching honors the same "cwdMatch may be nil, in which
+// case every session matches" contract every real DirScopedProvider
+// implementation documents (claude, codex, opencode, kilo) -- needed since
+// SessionManager.ReloadStreaming's per-member fan-out (unlike Reload, which
+// bypasses DiscoverMatching entirely when there are no exclude patterns)
+// always calls DiscoverSessionsMatching, passing a literal nil matcher for
+// "no patterns configured" rather than skipping the call.
 func (p *filteringDirScopedProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
 	p.receivedMatcher = true
 	var out []*model.Session
 	for _, s := range p.sessions {
-		if cwdMatch(s.CWD) {
+		if cwdMatch == nil || cwdMatch(s.CWD) {
 			out = append(out, s)
 		}
 	}

--- a/internal/core/session_test.go
+++ b/internal/core/session_test.go
@@ -304,6 +304,69 @@ func TestReload_PatternChangeAppliesOnNextReload_DirScopedPushdown(t *testing.T)
 	}
 }
 
+// TestUpdateActivities_AppliesExcludePushdown proves the periodic
+// re-discovery path in UpdateActivities (used for providers with
+// RefreshInterval > 0, e.g. opencode/kilo/codex) applies the same
+// discovery-time pushdown as Reload -- not just at startup. Without the
+// fix, mixed setups where a watcher-based provider (e.g. claude) keeps the
+// Reload-driven 30s ticker from ever firing would see UpdateActivities'
+// ~3s polling loop re-discover unfiltered indefinitely.
+func TestUpdateActivities_AppliesExcludePushdown(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	now := time.Now()
+	p := &filteringDirScopedProvider{
+		sessions: []*model.Session{
+			{SessionID: "keep", CWD: "/home/user/project", LastActivity: now},
+			{SessionID: "heavy", CWD: "/home/user/.claude-mem/observer-sessions/x", LastActivity: now},
+		},
+		interval: time.Millisecond,
+	}
+	mgr := NewSessionManager(60, p)
+	mgr.SetExcludeCWDSubstrings([]string{".claude-mem/observer-sessions"})
+
+	// First call: m.sessions is empty, so needsRefresh is true regardless of
+	// the interval/lastPollDiscover -- this exercises UpdateActivities'
+	// periodic-refresh discovery branch on a cold start.
+	if !mgr.UpdateActivities() {
+		t.Fatal("expected UpdateActivities to report a change on first discovery")
+	}
+	if !p.receivedMatcher {
+		t.Error("UpdateActivities' periodic re-discovery must go through the dir-scoped pushdown path (DiscoverSessionsMatching), not plain DiscoverSessions")
+	}
+	raw := mgr.Sessions()
+	if len(raw) != 1 || raw[0].SessionID != "keep" {
+		t.Fatalf("Sessions() = %#v, want only 'keep' (pushdown applied by UpdateActivities)", raw)
+	}
+}
+
+// TestUpdateActivities_NoExcludePatterns_UsesPlainDiscoverSessions mirrors
+// TestReload_NoExcludePatterns_UsesPlainDiscoverSessions for
+// UpdateActivities' periodic re-discovery path: with no patterns set, it
+// must not invoke the dir-scoped fast path at all.
+func TestUpdateActivities_NoExcludePatterns_UsesPlainDiscoverSessions(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	p := &dirScopedFakeProvider{
+		unfiltered: []*model.Session{{SessionID: "plain-path", LastActivity: time.Now()}},
+		sessions:   []*model.Session{{SessionID: "fast-path", LastActivity: time.Now()}},
+		interval:   time.Millisecond,
+	}
+	mgr := NewSessionManager(60, p)
+	// No SetExcludeCWDSubstrings call -- patterns are nil/empty.
+	if !mgr.UpdateActivities() {
+		t.Fatal("expected UpdateActivities to report a change on first discovery")
+	}
+
+	if p.receivedMatcher {
+		t.Error("UpdateActivities with no exclude patterns must not invoke the dir-scoped fast path (DiscoverMatching)")
+	}
+	got := mgr.Sessions()
+	if len(got) != 1 || got[0].SessionID != "plain-path" {
+		t.Fatalf("Sessions() = %#v, want the plain DiscoverSessions() result (zero pushdown when no patterns)", got)
+	}
+}
+
 // TestReload_ExcludePushdown_EquivalentToViewFilter is the manager-level
 // equivalence property test: for any pattern set, the visible sessions
 // (post view-filter) must be identical whether or not discovery-time
@@ -368,6 +431,27 @@ func TestReload_ExcludePushdown_EquivalentToViewFilter(t *testing.T) {
 			if !reflect.DeepEqual(actual, want) {
 				t.Fatalf("patterns=%v: pushdown-visible=%v, view-filter-only-visible=%v (must be identical)", patterns, actual, want)
 			}
+
+			// Same equivalence, but driven through UpdateActivities' periodic
+			// re-discovery path instead of Reload -- cheap to add since it
+			// reuses the same fixtures and the same "want" baseline: only the
+			// providers' RefreshInterval needs to be positive (dirScoped2's 1ms)
+			// so UpdateActivities' needsRefresh gate re-discovers at all, and
+			// the manager's first call always re-discovers (m.sessions starts
+			// empty) regardless of interval/lastPollDiscover timing.
+			dirScoped2 := &filteringDirScopedProvider{sessions: cloneSessions(dirScopedSessions), interval: time.Millisecond}
+			plain2 := fakeProvider{sessions: cloneSessions(plainSessions)}
+			mp2 := MultiProvider{Providers: []SessionProvider{dirScoped2, plain2}}
+
+			actualMgr2 := NewSessionManager(60, mp2)
+			actualMgr2.SetExcludeCWDSubstrings(patterns)
+			if !actualMgr2.UpdateActivities() {
+				t.Fatalf("expected UpdateActivities to report a change on first discovery (patterns=%v)", patterns)
+			}
+			actualUA := sessionIDSet(actualMgr2.VisibleSessions())
+			if !reflect.DeepEqual(actualUA, want) {
+				t.Fatalf("patterns=%v: UpdateActivities-pushdown-visible=%v, view-filter-only-visible=%v (must be identical)", patterns, actualUA, want)
+			}
 		})
 	}
 }
@@ -376,16 +460,24 @@ func TestReload_ExcludePushdown_EquivalentToViewFilter(t *testing.T) {
 // DiscoverSessionsMatching genuinely applies cwdMatch to its session list
 // (unlike dirScopedFakeProvider in provider_test.go, which returns a fixed
 // canned result regardless of the matcher it receives). Used to exercise
-// the real discovery-time pushdown behavior.
+// the real discovery-time pushdown behavior. interval configures
+// RefreshInterval() so it can also exercise UpdateActivities' periodic
+// re-discovery path; receivedMatcher/plainCalls record which discovery
+// method was actually invoked.
 type filteringDirScopedProvider struct {
-	sessions []*model.Session
+	sessions        []*model.Session
+	interval        time.Duration
+	receivedMatcher bool
+	plainCalls      int
 }
 
 func (p *filteringDirScopedProvider) DiscoverSessions() ([]*model.Session, error) {
+	p.plainCalls++
 	return p.sessions, nil
 }
 
 func (p *filteringDirScopedProvider) DiscoverSessionsMatching(cwdMatch func(string) bool) ([]*model.Session, error) {
+	p.receivedMatcher = true
 	var out []*model.Session
 	for _, s := range p.sessions {
 		if cwdMatch(s.CWD) {
@@ -396,7 +488,7 @@ func (p *filteringDirScopedProvider) DiscoverSessionsMatching(cwdMatch func(stri
 }
 
 func (p *filteringDirScopedProvider) UseWatcher() bool               { return false }
-func (p *filteringDirScopedProvider) RefreshInterval() time.Duration { return 0 }
+func (p *filteringDirScopedProvider) RefreshInterval() time.Duration { return p.interval }
 func (p *filteringDirScopedProvider) WatchDirs() []string            { return nil }
 
 // cloneSessions returns a shallow copy of the slice (not the pointed-to

--- a/internal/diskcache/diskcache.go
+++ b/internal/diskcache/diskcache.go
@@ -11,6 +11,27 @@ import (
 	"path/filepath"
 )
 
+// EnsureDir makes sure dir exists with 0700 permissions, for a cache
+// directory that may end up holding files with transcript snippets
+// (AtomicWriteJSON already writes each file itself at 0600; this covers the
+// containing directory). MkdirAll alone only sets permissions when it
+// actually creates the directory — it never tightens a directory that
+// already exists at looser permissions, which matters here specifically
+// because lazyagent's cache root (os.UserCacheDir()/lazyagent) is shared
+// with other features (e.g. internal/search's index, which creates the same
+// directory at 0755) that may have created it first. The Chmod's own error
+// is swallowed: it's advisory hardening on top of MkdirAll's own error
+// (returned, and the one that actually determines whether the caller can
+// proceed) — if Chmod fails, the directory is still usable, just not
+// necessarily as tightly permissioned as intended.
+func EnsureDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	_ = os.Chmod(dir, 0o700)
+	return nil
+}
+
 // AtomicWriteJSON marshals v to JSON and writes it to path atomically: the
 // data is first written to a unique temporary file in the same directory as
 // path (so the final rename is same-filesystem and therefore atomic), then

--- a/internal/diskcache/diskcache.go
+++ b/internal/diskcache/diskcache.go
@@ -1,0 +1,69 @@
+// Package diskcache provides small, shared primitives for persisting
+// advisory discovery caches to disk between one-shot CLI runs. Callers
+// (internal/model's SessionCache, internal/codex's and internal/claude's
+// CWDIndex) own their own on-disk shape and format-versioning; this package
+// only handles the mechanics of getting bytes on and off disk safely.
+package diskcache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// AtomicWriteJSON marshals v to JSON and writes it to path atomically: the
+// data is first written to a unique temporary file in the same directory as
+// path (so the final rename is same-filesystem and therefore atomic), then
+// renamed into place. A reader opening path concurrently always sees either
+// the previous complete file or the new complete file, never a torn one. If
+// any step fails, the temp file is removed and path is left untouched. The
+// final file is created with 0600 permissions, since these caches can
+// contain transcript snippets.
+func AtomicWriteJSON(path string, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-"+filepath.Base(path)+"-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+// ReadJSON reads and unmarshals the JSON file at path into v. It returns an
+// error for any failure (missing file, unreadable, malformed JSON) and
+// leaves v untouched on a top-level decode failure. Callers implementing
+// "advisory cache, never fail discovery" semantics should treat any
+// non-nil error as "no persisted cache" and continue cold.
+func ReadJSON(path string, v any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}

--- a/internal/diskcache/diskcache_test.go
+++ b/internal/diskcache/diskcache_test.go
@@ -1,0 +1,122 @@
+package diskcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type sample struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func TestAtomicWriteJSON_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	want := sample{Name: "hello", Count: 3}
+	if err := AtomicWriteJSON(path, want); err != nil {
+		t.Fatalf("AtomicWriteJSON: %v", err)
+	}
+
+	var got sample
+	if err := ReadJSON(path, &got); err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestAtomicWriteJSON_FilePermissions0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	if err := AtomicWriteJSON(path, sample{Name: "x"}); err != nil {
+		t.Fatalf("AtomicWriteJSON: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("file perms = %o, want 0600", perm)
+	}
+}
+
+// TestAtomicWriteJSON_NoTempFileLeftBehind confirms a successful write
+// leaves exactly the target file in the directory -- no stray temp file --
+// proving the temp-file-then-rename dance cleans up after itself.
+func TestAtomicWriteJSON_NoTempFileLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	if err := AtomicWriteJSON(path, sample{Name: "x"}); err != nil {
+		t.Fatalf("AtomicWriteJSON: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "cache.json" {
+		t.Fatalf("dir entries = %v, want exactly [cache.json]", entries)
+	}
+}
+
+// TestAtomicWriteJSON_LeavesOldFileIntactOnMarshalError simulates a failed
+// write (an unmarshalable value) and confirms the previously-written
+// complete file is left untouched -- the atomic-write contract: a reader
+// only ever sees the old complete file or the new complete file, never a
+// torn one, and a failed write must not corrupt the old file.
+func TestAtomicWriteJSON_LeavesOldFileIntactOnMarshalError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+
+	if err := AtomicWriteJSON(path, sample{Name: "original"}); err != nil {
+		t.Fatalf("AtomicWriteJSON (first write): %v", err)
+	}
+
+	// A Go channel cannot be marshaled to JSON -- forces json.Marshal to
+	// fail before any temp file is even created.
+	if err := AtomicWriteJSON(path, make(chan int)); err == nil {
+		t.Fatal("AtomicWriteJSON with unmarshalable value: want error, got nil")
+	}
+
+	var got sample
+	if err := ReadJSON(path, &got); err != nil {
+		t.Fatalf("ReadJSON after failed write: %v", err)
+	}
+	if got.Name != "original" {
+		t.Fatalf("file after failed write = %+v, want original untouched", got)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("dir entries after failed write = %v, want exactly [cache.json] (no leftover temp file)", entries)
+	}
+}
+
+func TestReadJSON_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	var got sample
+	if err := ReadJSON(filepath.Join(dir, "missing.json"), &got); err == nil {
+		t.Fatal("ReadJSON on missing file: want error, got nil")
+	}
+}
+
+func TestReadJSON_CorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var got sample
+	if err := ReadJSON(path, &got); err == nil {
+		t.Fatal("ReadJSON on corrupt JSON: want error, got nil")
+	}
+}

--- a/internal/diskcache/diskcache_test.go
+++ b/internal/diskcache/diskcache_test.go
@@ -11,6 +11,54 @@ type sample struct {
 	Count int    `json:"count"`
 }
 
+func TestEnsureDir_CreatesAt0700(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "lazyagent")
+	if err := EnsureDir(dir); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("perms = %o, want 0700", perm)
+	}
+}
+
+// TestEnsureDir_TightensPreExisting0755Dir covers the real scenario this
+// function exists for: another lazyagent feature sharing the same cache
+// root (e.g. internal/search's index, which creates os.UserCacheDir()/
+// lazyagent at 0755) may have already created the directory at looser
+// permissions before a discovery cache is ever saved. Plain os.MkdirAll
+// would silently leave those loose permissions in place, since it only
+// applies the given mode when it actually creates the directory. EnsureDir
+// must tighten it regardless of who created it first.
+func TestEnsureDir_TightensPreExisting0755Dir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "lazyagent")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o755 {
+		t.Fatalf("fixture setup: dir perms = %o, want 0755 before EnsureDir runs", perm)
+	}
+
+	if err := EnsureDir(dir); err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+
+	info, err = os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("perms after EnsureDir = %o, want 0700 (tightened from the pre-existing 0755)", perm)
+	}
+}
+
 func TestAtomicWriteJSON_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cache.json")

--- a/internal/kilo/process.go
+++ b/internal/kilo/process.go
@@ -38,3 +38,11 @@ func DBPath() string {
 func DiscoverSessions(cache *SessionCache) ([]*model.Session, error) {
 	return opencodefamily.DiscoverSessionsFor(source, cache)
 }
+
+// DiscoverSessionsFiltered reads the Kilo SQLite database like
+// DiscoverSessions, but skips loading messages for sessions whose directory
+// doesn't match cwdMatch (see opencodefamily.DiscoverSessionsForFiltered).
+// cwdMatch may be nil, in which case every session matches.
+func DiscoverSessionsFiltered(cache *SessionCache, cwdMatch func(string) bool) ([]*model.Session, error) {
+	return opencodefamily.DiscoverSessionsForFiltered(source, cache, cwdMatch)
+}

--- a/internal/kilo/process_test.go
+++ b/internal/kilo/process_test.go
@@ -103,6 +103,100 @@ func TestDiscoverSessions_KiloFixture(t *testing.T) {
 	}
 }
 
+// TestDiscoverSessionsFiltered_WiringReachesOpenCodeFamilyAndFilters is a
+// wiring test: it proves DiscoverSessionsFiltered is reachable through the
+// kilo package's thin Source declaration and that it actually filters by
+// directory, not just that it compiles. The heavy-lifting (row-level
+// prefilter exactness, skip-optimization, equivalence property) is tested
+// once, at the shared opencodefamily engine level.
+func TestDiscoverSessionsFiltered_WiringReachesOpenCodeFamilyAndFilters(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("KILO_DATA_DIR", dir)
+	writeTwoDirFixtureDB(t, filepath.Join(dir, "kilo.db"))
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/kilo-project-a" }
+	sessions, err := DiscoverSessionsFiltered(NewSessionCache(), matchA)
+	if err != nil {
+		t.Fatalf("DiscoverSessionsFiltered() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(sessions) = %d, want 1", len(sessions))
+	}
+	if got := sessions[0]; got.SessionID != "ses_kilo_a" || got.Agent != "kilo" || got.CWD != "/tmp/kilo-project-a" {
+		t.Errorf("session = %+v, want ses_kilo_a in /tmp/kilo-project-a agent kilo", got)
+	}
+
+	all, err := DiscoverSessionsFiltered(NewSessionCache(), nil)
+	if err != nil {
+		t.Fatalf("DiscoverSessionsFiltered(nil) error = %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("len(all) = %d, want 2 (nil matcher must return everything)", len(all))
+	}
+}
+
+// writeTwoDirFixtureDB creates two sessions in two different directories,
+// each with a single well-formed message, using the minimal OpenCode-family
+// schema (see opencodefamily's writeCompatDB for the source of this shape).
+func writeTwoDirFixtureDB(t *testing.T, dbPath string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stmts := []string{
+		`CREATE TABLE session (
+			id text PRIMARY KEY,
+			project_id text NOT NULL,
+			parent_id text,
+			directory text NOT NULL,
+			title text NOT NULL,
+			version text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			time_compacting integer,
+			time_archived integer
+		)`,
+		`CREATE TABLE message (
+			id text PRIMARY KEY,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+		`CREATE TABLE part (
+			id text PRIMARY KEY,
+			message_id text NOT NULL,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+		`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+		 VALUES ('ses_kilo_a', 'proj_a', NULL, '/tmp/kilo-project-a', 'A', '7.3.12', 1700000000000, 1700000001000, NULL, NULL)`,
+		`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+		 VALUES ('ses_kilo_b', 'proj_b', NULL, '/tmp/kilo-project-b', 'B', '7.3.12', 1700000000000, 1700000002000, NULL, NULL)`,
+		`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		 VALUES ('msg_kilo_a', 'ses_kilo_a', 1700000000000, 1700000000000, '{"role":"user","time":{"created":1700000000000}}')`,
+		`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		 VALUES ('part_kilo_a', 'msg_kilo_a', 'ses_kilo_a', 1700000000000, 1700000000000, '{"type":"text","text":"hi from a"}')`,
+		`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		 VALUES ('msg_kilo_b', 'ses_kilo_b', 1700000000000, 1700000000000, '{"role":"user","time":{"created":1700000000000}}')`,
+		`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		 VALUES ('part_kilo_b', 'msg_kilo_b', 'ses_kilo_b', 1700000000000, 1700000000000, '{"type":"text","text":"hi from b"}')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+}
+
 func loadSQLFixture(t *testing.T, dbPath, fixture string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(dbPath), 0o755); err != nil {

--- a/internal/model/cache_persist.go
+++ b/internal/model/cache_persist.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/diskcache"
+)
+
+// sessionCacheFormatVersion is bumped whenever the persisted shape changes
+// in a backward-incompatible way. LoadFrom refuses to merge a snapshot
+// whose version doesn't match, so an old or future binary reading a cache
+// file it doesn't understand starts cold instead of misinterpreting it.
+const sessionCacheFormatVersion = 1
+
+// persistedSessionCache is the on-disk shape of a SessionCache snapshot.
+type persistedSessionCache struct {
+	FormatVersion int                              `json:"formatVersion"`
+	Entries       map[string]persistedSessionEntry `json:"entries"`
+}
+
+// persistedSessionEntry is the on-disk shape of one SessionCache entry.
+// Session is a plain, fully-exported data struct (see Session in types.go)
+// with no unexported fields or custom marshaling needs, so it round-trips
+// through encoding/json byte-for-byte.
+type persistedSessionEntry struct {
+	MTime   time.Time `json:"mtime"`
+	Size    int64     `json:"size"`
+	Session *Session  `json:"session"`
+}
+
+// SaveTo atomically writes the cache's current contents to path (temp file
+// in path's directory, then rename), with 0600 permissions -- the cache can
+// contain transcript snippets. Safe to call while other goroutines read/
+// write the cache; the snapshot is taken under the same lock GetIncremental/
+// Put/Prune use.
+func (c *SessionCache) SaveTo(path string) error {
+	c.mu.Lock()
+	snapshot := persistedSessionCache{
+		FormatVersion: sessionCacheFormatVersion,
+		Entries:       make(map[string]persistedSessionEntry, len(c.entries)),
+	}
+	for k, e := range c.entries {
+		snapshot.Entries[k] = persistedSessionEntry{MTime: e.mtime, Size: e.size, Session: e.session}
+	}
+	c.mu.Unlock()
+
+	return diskcache.AtomicWriteJSON(path, snapshot)
+}
+
+// LoadFrom best-effort loads a persisted snapshot from path and merges its
+// entries into the cache, so a subsequent GetIncremental(path) behaves
+// exactly as if the entry had been Put by an earlier call in this same
+// process: a full hit (mtime unchanged) returns the loaded *Session
+// directly, and an incremental hit (file grew) returns Clone() of it plus
+// the persisted byte offset -- Clone()'s deep-copy semantics apply
+// identically to a loaded entry, since json.Unmarshal always allocates
+// fresh slices, so no loaded entry can ever alias another's backing arrays.
+//
+// Any file-level problem -- the file is missing or unreadable, the JSON is
+// malformed, or the format version doesn't match -- is reported via the
+// returned error and leaves the cache completely untouched (nothing is
+// merged), so the caller can safely ignore the error and continue with a
+// cold-but-valid cache; discovery is never failed by a bad cache file. An
+// individual entry whose "session" field decoded as null (a partial/corrupt
+// per-entry decode) is silently skipped rather than merged as a nil
+// session, which would otherwise crash the very first GetIncremental/Clone
+// call that reached it.
+func (c *SessionCache) LoadFrom(path string) error {
+	var snapshot persistedSessionCache
+	if err := diskcache.ReadJSON(path, &snapshot); err != nil {
+		return err
+	}
+	if snapshot.FormatVersion != sessionCacheFormatVersion {
+		return fmt.Errorf("session cache %s: format version %d, want %d", path, snapshot.FormatVersion, sessionCacheFormatVersion)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, e := range snapshot.Entries {
+		if e.Session == nil {
+			continue
+		}
+		c.entries[k] = sessionCacheEntry{mtime: e.MTime, size: e.Size, session: e.Session}
+	}
+	return nil
+}

--- a/internal/model/cache_persist.go
+++ b/internal/model/cache_persist.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/illegalstudio/lazyagent/internal/diskcache"
@@ -66,6 +67,39 @@ func (c *SessionCache) SaveTo(path string) error {
 // per-entry decode) is silently skipped rather than merged as a nil
 // session, which would otherwise crash the very first GetIncremental/Clone
 // call that reached it.
+//
+// Each entry is also checked, right now, for the one specific way a
+// persisted-and-reloaded entry can be unsafe in a way an in-process one
+// never is: if the file it names currently has the SAME mtime as recorded
+// but a DIFFERENT size, the entry is dropped rather than merged, so a fresh
+// parse happens for that file this run instead of silently serving stale
+// content. GetIncremental's own full-hit check trusts mtime alone (by
+// design -- some providers that always fully re-parse rather than resume
+// incrementally deliberately store a placeholder size and rely on exactly
+// that trust, see e.g. internal/grok), which is safe within a single
+// process: nothing can rewrite a file between two GetIncremental calls with
+// its mtime coincidentally restored to its old value in between. That
+// assumption doesn't hold across separate CLI invocations: a tool that
+// rewrites a file while deliberately preserving its mtime (cp -p, some
+// sync/backup tools) between two runs would otherwise load in an entry
+// whose mtime matches but whose content doesn't, and GetIncremental would
+// then serve it forever as a "full hit" without ever re-reading the file.
+// Every other combination -- mtime differs (whether the file grew, for a
+// legitimate incremental resume, or shrank), or the file is gone entirely
+// -- is left for GetIncremental's existing logic to handle exactly as it
+// would for an in-process entry; only this one specific, provably-stale
+// combination is filtered here, precisely where persistence introduces it,
+// without touching GetIncremental's contract that other callers depend on.
+//
+// The check only applies when the recorded size is non-zero. A stored size
+// of 0 is grok's (and any similar always-fully-reparse provider's)
+// deliberate placeholder -- see internal/grok's cache.Put call -- used
+// purely to force a full re-parse on the NEXT mtime change; on an unchanged
+// mtime it relies on GetIncremental's mtime-only trust exactly like this
+// check does for any other provider, so treating "size 0 vs real file size"
+// as evidence of staleness here would wrongly drop every one of that
+// provider's entries and silently defeat its persistence, even though
+// nothing has actually changed.
 func (c *SessionCache) LoadFrom(path string) error {
 	var snapshot persistedSessionCache
 	if err := diskcache.ReadJSON(path, &snapshot); err != nil {
@@ -80,6 +114,11 @@ func (c *SessionCache) LoadFrom(path string) error {
 	for k, e := range snapshot.Entries {
 		if e.Session == nil {
 			continue
+		}
+		if e.Size != 0 {
+			if info, err := os.Stat(k); err == nil && info.ModTime().Equal(e.MTime) && info.Size() != e.Size {
+				continue
+			}
 		}
 		c.entries[k] = sessionCacheEntry{mtime: e.MTime, size: e.Size, session: e.Session}
 	}

--- a/internal/model/cache_persist_test.go
+++ b/internal/model/cache_persist_test.go
@@ -1,0 +1,281 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSessionCache_SaveLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+
+	// GetIncremental stats the session file itself (to compare mtimes), so
+	// the fixture needs a real file on disk, not just a cache entry.
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime := info.ModTime()
+
+	c := NewSessionCache()
+	session := &Session{
+		SessionID:       "s1",
+		CWD:             "/tmp/project-a",
+		Agent:           "claude",
+		TotalMessages:   2,
+		RecentTools:     []ToolCall{{Name: "Read", Timestamp: mtime}},
+		RecentMessages:  []ConversationMessage{{Role: "user", Text: "hi", Timestamp: mtime}},
+		EntryTimestamps: []time.Time{mtime},
+	}
+	c.Put(sessionPath, mtime, 10, session)
+
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded := NewSessionCache()
+	if err := loaded.LoadFrom(path); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	// A full hit (mtime unchanged) must return the identical session data,
+	// with offset 0 -- exactly as GetIncremental would for an entry that
+	// was Put in-process, never touched by persistence at all.
+	got, offset, gotMtime := loaded.GetIncremental(sessionPath)
+	if got == nil {
+		t.Fatal("GetIncremental after LoadFrom: got nil session, want a full hit")
+	}
+	if offset != 0 {
+		t.Fatalf("offset = %d, want 0 (full hit)", offset)
+	}
+	if !gotMtime.Equal(mtime) {
+		t.Fatalf("mtime = %v, want %v", gotMtime, mtime)
+	}
+	if got.SessionID != "s1" || got.CWD != "/tmp/project-a" || got.TotalMessages != 2 {
+		t.Fatalf("got = %+v, want SessionID=s1 CWD=/tmp/project-a TotalMessages=2", got)
+	}
+	if len(got.RecentTools) != 1 || got.RecentTools[0].Name != "Read" {
+		t.Fatalf("RecentTools = %+v, want [{Read ...}]", got.RecentTools)
+	}
+	if len(got.RecentMessages) != 1 || got.RecentMessages[0].Text != "hi" {
+		t.Fatalf("RecentMessages = %+v, want [{user hi ...}]", got.RecentMessages)
+	}
+}
+
+// TestSessionCache_LoadFrom_PreservesIncrementalOffset confirms the
+// persisted entry's byte offset (the "size" field: how much of the file was
+// consumed by the parse this entry reflects) survives the round-trip, so a
+// file that grew since the snapshot was saved is still resumed
+// incrementally rather than fully re-parsed.
+func TestSessionCache_LoadFrom_PreservesIncrementalOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-codex.json")
+	filePath := filepath.Join(dir, "session.jsonl")
+
+	if err := os.WriteFile(filePath, []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldMtime := info.ModTime()
+
+	c := NewSessionCache()
+	c.Put(filePath, oldMtime, 5, &Session{SessionID: "s1", CWD: "/tmp/a"})
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	// Grow the file (simulating an append between runs) and give it a new
+	// mtime, so the loaded entry's offset (5) should trigger an incremental
+	// resume, not a full hit and not a full re-parse.
+	newMtime := oldMtime.Add(time.Second)
+	if err := os.WriteFile(filePath, []byte("0123456789ABCDEF"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filePath, newMtime, newMtime); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := NewSessionCache()
+	if err := loaded.LoadFrom(path); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	base, offset, mtime := loaded.GetIncremental(filePath)
+	if base == nil {
+		t.Fatal("GetIncremental: got nil base, want the loaded entry as an incremental base")
+	}
+	if offset != 5 {
+		t.Fatalf("offset = %d, want 5 (the persisted entry's byte offset)", offset)
+	}
+	if !mtime.Equal(newMtime) {
+		t.Fatalf("mtime = %v, want the file's current (new) mtime %v", mtime, newMtime)
+	}
+	if base.SessionID != "s1" {
+		t.Fatalf("base.SessionID = %q, want s1", base.SessionID)
+	}
+}
+
+// TestSessionCache_LoadFrom_CloneIsIndependent confirms a loaded entry's
+// Clone() (as used internally by GetIncremental's incremental-resume path)
+// produces a deep copy that doesn't alias the cached entry's slices --
+// exactly the same guarantee an in-process-populated entry provides.
+func TestSessionCache_LoadFrom_CloneIsIndependent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+
+	mtime := time.Now().Truncate(time.Second)
+	c := NewSessionCache()
+	c.Put("/tmp/session.jsonl", mtime, 10, &Session{
+		SessionID:   "s1",
+		RecentTools: []ToolCall{{Name: "Read"}},
+	})
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	loaded := NewSessionCache()
+	if err := loaded.LoadFrom(path); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	entry, ok := loaded.entries["/tmp/session.jsonl"]
+	if !ok {
+		t.Fatal("loaded entry missing")
+	}
+	clone := entry.session.Clone()
+	clone.RecentTools[0].Name = "Mutated"
+	if entry.session.RecentTools[0].Name != "Read" {
+		t.Fatalf("mutating the clone changed the cached entry: %q, want unaffected (Read)", entry.session.RecentTools[0].Name)
+	}
+}
+
+func TestSessionCache_SaveTo_FilePermissions0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+
+	c := NewSessionCache()
+	c.Put("/tmp/session.jsonl", time.Now(), 10, &Session{SessionID: "s1"})
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("perms = %o, want 0600", perm)
+	}
+}
+
+// TestSessionCache_SaveTo_AtomicNoTempFileLeftBehind is the SessionCache-
+// level instance of the atomic-write behavior test the brief calls for:
+// after a successful Save, the directory contains only the target file --
+// no leftover temp file -- confirming the write really did go through the
+// temp-file-then-rename path rather than writing path directly (which could
+// leave a torn file on a crash mid-write).
+func TestSessionCache_SaveTo_AtomicNoTempFileLeftBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+
+	c := NewSessionCache()
+	c.Put("/tmp/session.jsonl", time.Now(), 10, &Session{SessionID: "s1"})
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "discovery-claude.json" {
+		t.Fatalf("dir entries = %v, want exactly [discovery-claude.json]", entries)
+	}
+}
+
+func TestSessionCache_LoadFrom_MissingFile(t *testing.T) {
+	c := NewSessionCache()
+	if err := c.LoadFrom(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Fatal("LoadFrom missing file: want error, got nil")
+	}
+}
+
+func TestSessionCache_LoadFrom_CorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewSessionCache()
+	if err := c.LoadFrom(path); err == nil {
+		t.Fatal("LoadFrom corrupt JSON: want error, got nil")
+	}
+	// Cache must be left usable (cold), not poisoned.
+	got, _, _ := c.GetIncremental("/tmp/anything.jsonl")
+	if got != nil {
+		t.Fatalf("cache after corrupt load = %+v, want nil (cold, untouched)", got)
+	}
+}
+
+func TestSessionCache_LoadFrom_WrongFormatVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+	if err := os.WriteFile(path, []byte(`{"formatVersion":999999,"entries":{"/tmp/x.jsonl":{"mtime":"2026-01-01T00:00:00Z","size":10,"session":{"SessionID":"s1"}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewSessionCache()
+	if err := c.LoadFrom(path); err == nil {
+		t.Fatal("LoadFrom wrong format version: want error, got nil")
+	}
+	got, _, _ := c.GetIncremental("/tmp/x.jsonl")
+	if got != nil {
+		t.Fatalf("cache after version-mismatch load = %+v, want nil (cold, untouched)", got)
+	}
+}
+
+// TestSessionCache_LoadFrom_SkipsNilSessionEntry covers a partially decoded
+// entry (valid JSON, but a null "session" field) -- it must be skipped, not
+// crash or poison the cache with a nil *Session that GetIncremental/Clone
+// would panic on.
+func TestSessionCache_LoadFrom_SkipsNilSessionEntry(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+	if err := os.WriteFile(path, []byte(`{"formatVersion":1,"entries":{"/tmp/x.jsonl":{"mtime":"2026-01-01T00:00:00Z","size":10,"session":null}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := NewSessionCache()
+	if err := c.LoadFrom(path); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	got, _, _ := c.GetIncremental("/tmp/x.jsonl")
+	if got != nil {
+		t.Fatalf("cache after nil-session entry load = %+v, want nil (entry skipped, not a hit)", got)
+	}
+}
+
+func TestSessionCache_SaveTo_EmptyCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "discovery-claude.json")
+
+	c := NewSessionCache()
+	if err := c.SaveTo(path); err != nil {
+		t.Fatalf("SaveTo empty cache: %v", err)
+	}
+
+	loaded := NewSessionCache()
+	if err := loaded.LoadFrom(path); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+}

--- a/internal/model/cache_persist_test.go
+++ b/internal/model/cache_persist_test.go
@@ -68,6 +68,177 @@ func TestSessionCache_SaveLoad_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestSessionCache_LoadFrom_DropsEntryWhenSameMtimeButDifferentSize covers
+// the gap the comprehensive discovery-level equivalence test (in
+// internal/codex) surfaced: a tool that rewrites a file while deliberately
+// preserving its mtime (cp -p, some sync/backup tools) between two separate
+// `sessions` CLI invocations must not be loaded back in as if unchanged.
+// GetIncremental's own full-hit check trusts mtime alone by design (see its
+// doc comment -- some providers, e.g. grok, deliberately store a
+// placeholder size and rely on exactly that trust for their own full-hit
+// semantics), which is safe in-process since nothing can rewrite a file
+// between two calls with its mtime coincidentally restored -- but that
+// assumption doesn't hold across process runs. LoadFrom must catch this one
+// specific, provably-stale combination (same mtime, different size, right
+// now) itself, rather than loosening GetIncremental's contract that other
+// callers depend on.
+func TestSessionCache_LoadFrom_DropsEntryWhenSameMtimeButDifferentSize(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "discovery-codex.json")
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("0123456789ABCDEF"), 0o644); err != nil { // 16 bytes
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime := info.ModTime()
+
+	c := NewSessionCache()
+	c.Put(sessionPath, mtime, 16, &Session{SessionID: "stale", CWD: "/tmp/old"})
+	if err := c.SaveTo(cachePath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	// Replace with shorter content, forcibly preserving the exact same
+	// mtime -- the pathological case LoadFrom must not trust.
+	if err := os.WriteFile(sessionPath, []byte("short"), 0o644); err != nil { // 5 bytes
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(sessionPath, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := NewSessionCache()
+	if err := loaded.LoadFrom(cachePath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	got, offset, gotMtime := loaded.GetIncremental(sessionPath)
+	if got != nil {
+		t.Fatalf("GetIncremental = %+v, want nil (full miss forcing re-parse) -- LoadFrom must have dropped the stale entry, not merged it", got)
+	}
+	if offset != 0 {
+		t.Fatalf("offset = %d, want 0 (full miss)", offset)
+	}
+	if !gotMtime.Equal(mtime) {
+		t.Fatalf("mtime = %v, want %v", gotMtime, mtime)
+	}
+}
+
+// TestSessionCache_LoadFrom_PlaceholderZeroSizeEntrySurvivesUnchangedFile
+// covers a provider like grok that never does incremental parsing and
+// deliberately Puts a placeholder size of 0 for every entry (see
+// internal/grok's cache.Put call and its "size 0 forces a full re-parse on
+// any future mtime change" comment). On an UNCHANGED file (same mtime),
+// that entry must still be loaded and still produce a full hit, exactly as
+// it would in-process -- the staleness check added for the "same mtime,
+// different size" case must not treat a real file's nonzero size as
+// evidence of staleness against a deliberately-placeholder 0, or it would
+// silently defeat persistence for this whole class of provider without
+// anything having actually changed.
+func TestSessionCache_LoadFrom_PlaceholderZeroSizeEntrySurvivesUnchangedFile(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "discovery-grok.json")
+	sessionPath := filepath.Join(dir, "chat_history.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"some":"real content, well over zero bytes"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime := info.ModTime()
+
+	c := NewSessionCache()
+	c.Put(sessionPath, mtime, 0, &Session{SessionID: "s1", Agent: "grok"}) // grok's placeholder size
+	if err := c.SaveTo(cachePath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	// File is NOT touched at all between save and load.
+	loaded := NewSessionCache()
+	if err := loaded.LoadFrom(cachePath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	got, offset, gotMtime := loaded.GetIncremental(sessionPath)
+	if got == nil {
+		t.Fatal("GetIncremental after LoadFrom: got nil, want a full hit (placeholder-size entry on an unchanged file must survive persistence)")
+	}
+	if offset != 0 {
+		t.Fatalf("offset = %d, want 0 (full hit)", offset)
+	}
+	if !gotMtime.Equal(mtime) {
+		t.Fatalf("mtime = %v, want %v", gotMtime, mtime)
+	}
+	if got.SessionID != "s1" {
+		t.Fatalf("SessionID = %q, want s1", got.SessionID)
+	}
+}
+
+// TestSessionCache_LoadFrom_StillLoadsIncrementalEntryWhenFileGrew is the
+// companion/contrast test to the one above: it proves the size-vs-mtime
+// staleness check is narrowly scoped to the "same mtime" case only. A file
+// that grew since the entry was saved (the ordinary, expected incremental-
+// append scenario) has a DIFFERENT mtime and a LARGER size -- that entry
+// must still be loaded and still drive a proper incremental resume
+// (Clone() of the base session, offset at the old size), exactly like
+// TestSessionCache_LoadFrom_PreservesIncrementalOffset already covers
+// end-to-end; this test isolates the LoadFrom step itself to guard against
+// a future, overly-broad tightening of the staleness check swallowing this
+// legitimate case (an earlier draft of this fix did exactly that, by
+// requiring size to match GetIncremental-side for every entry regardless of
+// whether mtime changed, which broke grok's placeholder-size full-reparse
+// design and any legitimate incremental-append entry).
+func TestSessionCache_LoadFrom_StillLoadsIncrementalEntryWhenFileGrew(t *testing.T) {
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "discovery-codex.json")
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("0123456789"), 0o644); err != nil { // 10 bytes
+		t.Fatal(err)
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldMtime := info.ModTime()
+
+	c := NewSessionCache()
+	c.Put(sessionPath, oldMtime, 10, &Session{SessionID: "base", CWD: "/tmp/a"})
+	if err := c.SaveTo(cachePath); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+
+	newMtime := oldMtime.Add(time.Second)
+	if err := os.WriteFile(sessionPath, []byte("0123456789ABCDEF"), 0o644); err != nil { // 16 bytes
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(sessionPath, newMtime, newMtime); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded := NewSessionCache()
+	if err := loaded.LoadFrom(cachePath); err != nil {
+		t.Fatalf("LoadFrom: %v", err)
+	}
+
+	base, offset, mtime := loaded.GetIncremental(sessionPath)
+	if base == nil {
+		t.Fatal("GetIncremental: got nil base, want the loaded entry to still drive an incremental resume")
+	}
+	if offset != 10 {
+		t.Fatalf("offset = %d, want 10", offset)
+	}
+	if !mtime.Equal(newMtime) {
+		t.Fatalf("mtime = %v, want %v", mtime, newMtime)
+	}
+	if base.SessionID != "base" {
+		t.Fatalf("base.SessionID = %q, want base", base.SessionID)
+	}
+}
+
 // TestSessionCache_LoadFrom_PreservesIncrementalOffset confirms the
 // persisted entry's byte offset (the "size" field: how much of the file was
 // consumed by the parse this entry reflects) survives the round-trip, so a

--- a/internal/opencode/process.go
+++ b/internal/opencode/process.go
@@ -39,3 +39,11 @@ func DBPath() string {
 func DiscoverSessions(cache *SessionCache) ([]*model.Session, error) {
 	return opencodefamily.DiscoverSessionsFor(source, cache)
 }
+
+// DiscoverSessionsFiltered reads the OpenCode SQLite database like
+// DiscoverSessions, but skips loading messages for sessions whose directory
+// doesn't match cwdMatch (see opencodefamily.DiscoverSessionsForFiltered).
+// cwdMatch may be nil, in which case every session matches.
+func DiscoverSessionsFiltered(cache *SessionCache, cwdMatch func(string) bool) ([]*model.Session, error) {
+	return opencodefamily.DiscoverSessionsForFiltered(source, cache, cwdMatch)
+}

--- a/internal/opencode/process_test.go
+++ b/internal/opencode/process_test.go
@@ -1,0 +1,113 @@
+package opencode
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestDBPath_UsesOpenCodeDataDir(t *testing.T) {
+	t.Setenv("OPENCODE_DATA_DIR", "/tmp/opencode-data")
+	got := DBPath()
+	want := filepath.Join("/tmp/opencode-data", "opencode.db")
+	if got != want {
+		t.Fatalf("DBPath() = %q, want %q", got, want)
+	}
+}
+
+// TestDiscoverSessionsFiltered_WiringReachesOpenCodeFamilyAndFilters is a
+// wiring test: it proves DiscoverSessionsFiltered is reachable through the
+// opencode package's thin Source declaration and that it actually filters
+// by directory, not just that it compiles. The heavy-lifting (row-level
+// prefilter exactness, skip-optimization, equivalence property) is tested
+// once, at the shared opencodefamily engine level.
+func TestDiscoverSessionsFiltered_WiringReachesOpenCodeFamilyAndFilters(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("OPENCODE_DATA_DIR", dir)
+	writeTwoDirFixtureDB(t, DBPath())
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/opencode-project-a" }
+	sessions, err := DiscoverSessionsFiltered(NewSessionCache(), matchA)
+	if err != nil {
+		t.Fatalf("DiscoverSessionsFiltered() error = %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("len(sessions) = %d, want 1", len(sessions))
+	}
+	if got := sessions[0]; got.SessionID != "ses_oc_a" || got.Agent != "opencode" || got.CWD != "/tmp/opencode-project-a" {
+		t.Errorf("session = %+v, want ses_oc_a in /tmp/opencode-project-a agent opencode", got)
+	}
+
+	all, err := DiscoverSessionsFiltered(NewSessionCache(), nil)
+	if err != nil {
+		t.Fatalf("DiscoverSessionsFiltered(nil) error = %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("len(all) = %d, want 2 (nil matcher must return everything)", len(all))
+	}
+}
+
+// writeTwoDirFixtureDB creates two sessions in two different directories,
+// each with a single well-formed message, using the minimal OpenCode-family
+// schema (see opencodefamily's writeCompatDB for the source of this shape).
+func writeTwoDirFixtureDB(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stmts := []string{
+		`CREATE TABLE session (
+			id text PRIMARY KEY,
+			project_id text NOT NULL,
+			parent_id text,
+			directory text NOT NULL,
+			title text NOT NULL,
+			version text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			time_compacting integer,
+			time_archived integer
+		)`,
+		`CREATE TABLE message (
+			id text PRIMARY KEY,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+		`CREATE TABLE part (
+			id text PRIMARY KEY,
+			message_id text NOT NULL,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+		`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+		 VALUES ('ses_oc_a', 'proj_a', NULL, '/tmp/opencode-project-a', 'A', '0.1.0', 1700000000000, 1700000001000, NULL, NULL)`,
+		`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+		 VALUES ('ses_oc_b', 'proj_b', NULL, '/tmp/opencode-project-b', 'B', '0.1.0', 1700000000000, 1700000002000, NULL, NULL)`,
+		`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		 VALUES ('msg_oc_a', 'ses_oc_a', 1700000000000, 1700000000000, '{"role":"user","time":{"created":1700000000000}}')`,
+		`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		 VALUES ('part_oc_a', 'msg_oc_a', 'ses_oc_a', 1700000000000, 1700000000000, '{"type":"text","text":"hi from a"}')`,
+		`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		 VALUES ('msg_oc_b', 'ses_oc_b', 1700000000000, 1700000000000, '{"role":"user","time":{"created":1700000000000}}')`,
+		`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		 VALUES ('part_oc_b', 'msg_oc_b', 'ses_oc_b', 1700000000000, 1700000000000, '{"type":"text","text":"hi from b"}')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+}

--- a/internal/opencodefamily/process.go
+++ b/internal/opencodefamily/process.go
@@ -85,6 +85,29 @@ func DBPathFor(source Source) string {
 
 // DiscoverSessionsFor reads an OpenCode-compatible SQLite database and returns sessions.
 func DiscoverSessionsFor(source Source, cache *SessionCache) ([]*model.Session, error) {
+	return DiscoverSessionsForFiltered(source, cache, nil)
+}
+
+// DiscoverSessionsForFiltered reads an OpenCode-compatible SQLite database
+// like DiscoverSessionsFor, but skips loading a session's messages — the
+// expensive part of building a session, see buildSession's joined
+// message/part query — for any session whose row-level `directory` value
+// cwdMatch rules out.
+//
+// Investigation (see buildSession, which sets session.CWD = ds.Directory and
+// never touches it again): the returned Session.CWD comes solely from the
+// session row's `directory` column — no message or part data can change it.
+// So filtering on a row's Directory value before loading its messages is
+// exact: it can produce neither a false positive nor a false negative
+// relative to running DiscoverSessionsFor unfiltered and filtering the
+// result by the same matcher afterwards. The post-build recheck below is
+// kept anyway, as a cheap, always-true invariant here, for symmetry with
+// other dir-scoped providers (codex, claude) whose CWD isn't fixed at the
+// row level and so need such a recheck for correctness, not just symmetry.
+//
+// cwdMatch may be nil, in which case every session matches (equivalent to
+// DiscoverSessionsFor).
+func DiscoverSessionsForFiltered(source Source, cache *SessionCache, cwdMatch func(string) bool) ([]*model.Session, error) {
 	source = normalizeSource(source)
 	if cache == nil {
 		cache = NewSessionCache()
@@ -117,12 +140,24 @@ func DiscoverSessionsFor(source Source, cache *SessionCache) ([]*model.Session, 
 	seen := make(map[string]struct{})
 	var sessions []*model.Session
 	for _, ds := range dbSessions {
+		// Always mark the row seen (even when the prefilter below skips it)
+		// so cache.Prune doesn't evict cache entries belonging to sessions
+		// outside this call's directory scope.
 		seen[ds.ID] = struct{}{}
+
+		if cwdMatch != nil && !cwdMatch(ds.Directory) {
+			// Skip-optimization: exact, per the doc comment above — safe to
+			// skip the expensive message/part query entirely.
+			continue
+		}
 
 		// Check cache using time_updated as staleness indicator.
 		cache.mu.Lock()
 		if e, ok := cache.entries[ds.ID]; ok && e.timeUpdated == ds.TimeUpdated {
 			cache.mu.Unlock()
+			if cwdMatch != nil && !cwdMatch(e.session.CWD) {
+				continue
+			}
 			sessions = append(sessions, e.session)
 			continue
 		}
@@ -148,6 +183,11 @@ func DiscoverSessionsFor(source Source, cache *SessionCache) ([]*model.Session, 
 		cache.entries[ds.ID] = cacheEntry{timeUpdated: ds.TimeUpdated, session: session}
 		cache.mu.Unlock()
 
+		// Uniform post-build filter: an always-true invariant given the row
+		// prefilter above is exact — see doc comment — kept for symmetry.
+		if cwdMatch != nil && !cwdMatch(session.CWD) {
+			continue
+		}
 		sessions = append(sessions, session)
 	}
 

--- a/internal/opencodefamily/process_test.go
+++ b/internal/opencodefamily/process_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
@@ -145,6 +146,258 @@ func writeCompatDB(t *testing.T, path string) {
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+}
+
+// filterFixtureSource is the Source used by the DiscoverSessionsForFiltered
+// tests below; it's independent of the OpenCode/Kilo defaults so these tests
+// don't collide with real OPENCODE_DATA_DIR/KILO_DATA_DIR env state.
+var filterFixtureSource = Source{
+	Agent:      "testfilter",
+	EnvVar:     "TEST_FILTER_DATA_DIR",
+	DataSubdir: "testfilter",
+	DBFile:     "testfilter.db",
+}
+
+// writeFilterFixtureDB creates a session table with three sessions across
+// two directories:
+//   - ses_a1, ses_a2 live in /tmp/project-a, each with one well-formed
+//     user message/part.
+//   - ses_b1 lives in /tmp/project-b and carries a message row whose data
+//     column is malformed JSON — a payload that would fail parsing loudly
+//     if buildSession ever attempted to load it. Combined with the
+//     cache-population check the tests below perform (see
+//     TestDiscoverSessionsForFiltered_SkipsMessageLoadForNonMatchingSessions),
+//     this proves the skipped session's messages were never read: the
+//     malformed payload documents intent, and the cache assertion is the
+//     actual mechanism proving buildSession (and its message query) was
+//     never invoked for ses_b1.
+func writeFilterFixtureDB(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stmts := []string{
+		`CREATE TABLE session (
+			id text PRIMARY KEY,
+			project_id text NOT NULL,
+			parent_id text,
+			directory text NOT NULL,
+			title text NOT NULL,
+			version text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			time_compacting integer,
+			time_archived integer
+		)`,
+		`CREATE TABLE message (
+			id text PRIMARY KEY,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+		`CREATE TABLE part (
+			id text PRIMARY KEY,
+			message_id text NOT NULL,
+			session_id text NOT NULL,
+			time_created integer NOT NULL,
+			time_updated integer NOT NULL,
+			data text NOT NULL
+		)`,
+		`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+		 VALUES ('ses_a1', 'proj_a', NULL, '/tmp/project-a', 'A1', '1.0.0', 1700000000000, 1700000001000, NULL, NULL)`,
+		`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+		 VALUES ('ses_a2', 'proj_a', NULL, '/tmp/project-a', 'A2', '1.0.0', 1700000000000, 1700000002000, NULL, NULL)`,
+		`INSERT INTO session (id, project_id, parent_id, directory, title, version, time_created, time_updated, time_compacting, time_archived)
+		 VALUES ('ses_b1', 'proj_b', NULL, '/tmp/project-b', 'B1', '1.0.0', 1700000000000, 1700000003000, NULL, NULL)`,
+		`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		 VALUES ('msg_a1', 'ses_a1', 1700000000000, 1700000000000, '{"role":"user","time":{"created":1700000000000}}')`,
+		`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		 VALUES ('part_a1', 'msg_a1', 'ses_a1', 1700000000000, 1700000000000, '{"type":"text","text":"hello from a1"}')`,
+		`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		 VALUES ('msg_a2', 'ses_a2', 1700000000000, 1700000000000, '{"role":"user","time":{"created":1700000000000}}')`,
+		`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+		 VALUES ('part_a2', 'msg_a2', 'ses_a2', 1700000000000, 1700000000000, '{"type":"text","text":"hello from a2"}')`,
+		// Malformed JSON on purpose — see doc comment above.
+		`INSERT INTO message (id, session_id, time_created, time_updated, data)
+		 VALUES ('msg_b1', 'ses_b1', 1700000000000, 1700000000000, '{"role":"user", this is not valid json')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("exec %q: %v", stmt, err)
+		}
+	}
+}
+
+func TestDiscoverSessionsForFiltered_NilMatcherReturnsAll(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(filterFixtureSource.EnvVar, dir)
+	writeFilterFixtureDB(t, DBPathFor(filterFixtureSource))
+
+	got, err := DiscoverSessionsForFiltered(filterFixtureSource, NewSessionCache(), nil)
+	if err != nil {
+		t.Fatalf("DiscoverSessionsForFiltered() error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(sessions) = %d, want 3", len(got))
+	}
+
+	want, err := DiscoverSessionsFor(filterFixtureSource, NewSessionCache())
+	if err != nil {
+		t.Fatalf("DiscoverSessionsFor() error = %v", err)
+	}
+	if len(want) != len(got) {
+		t.Fatalf("nil-matcher filtered discovery returned %d sessions, DiscoverSessionsFor returned %d", len(got), len(want))
+	}
+}
+
+func TestDiscoverSessionsForFiltered_ScopesToMatchingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(filterFixtureSource.EnvVar, dir)
+	writeFilterFixtureDB(t, DBPathFor(filterFixtureSource))
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	sessions, err := DiscoverSessionsForFiltered(filterFixtureSource, NewSessionCache(), matchA)
+	if err != nil {
+		t.Fatalf("DiscoverSessionsForFiltered() error = %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("len(sessions) = %d, want 2", len(sessions))
+	}
+	for _, s := range sessions {
+		if s.CWD != "/tmp/project-a" {
+			t.Errorf("session %s CWD = %q, want /tmp/project-a", s.SessionID, s.CWD)
+		}
+		if s.SessionID == "ses_b1" {
+			t.Error("ses_b1 (directory /tmp/project-b) must not be returned when matching /tmp/project-a")
+		}
+	}
+}
+
+// TestDiscoverSessionsForFiltered_SkipsMessageLoadForNonMatchingSessions
+// proves the row-level directory prefilter skips the expensive message/part
+// load entirely for non-matching sessions, rather than merely dropping them
+// from the result after loading. The sentinel mechanism: buildSession only
+// ever populates cache.entries for a session ID after successfully running
+// its message/part query (see DiscoverSessionsForFiltered's cache.Put
+// call), so a filtered call that never adds an entry for ses_b1 (directory
+// /tmp/project-b, excluded by matchA) proves buildSession — and therefore
+// the message query, including the malformed-JSON row seeded by
+// writeFilterFixtureDB — was never invoked for it. This test lives in
+// package opencodefamily specifically so it can reach the unexported
+// cache.entries map.
+func TestDiscoverSessionsForFiltered_SkipsMessageLoadForNonMatchingSessions(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(filterFixtureSource.EnvVar, dir)
+	writeFilterFixtureDB(t, DBPathFor(filterFixtureSource))
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	cache := NewSessionCache()
+	if _, err := DiscoverSessionsForFiltered(filterFixtureSource, cache, matchA); err != nil {
+		t.Fatalf("DiscoverSessionsForFiltered() error = %v", err)
+	}
+
+	cache.mu.Lock()
+	_, built := cache.entries["ses_b1"]
+	_, builtA1 := cache.entries["ses_a1"]
+	_, builtA2 := cache.entries["ses_a2"]
+	cache.mu.Unlock()
+
+	if built {
+		t.Error("ses_b1 was built (cached) despite not matching the directory filter — its messages should never have been loaded")
+	}
+	if !builtA1 || !builtA2 {
+		t.Error("expected ses_a1 and ses_a2 (matching sessions) to be built and cached")
+	}
+}
+
+// TestDiscoverSessionsForFiltered_EquivalentToManualFilterOfFullDiscovery is
+// an equivalence-property test: for a fixture spanning two directories,
+// DiscoverSessionsForFiltered's result must equal filtering a full
+// (unfiltered) DiscoverSessionsFor pass by the same matcher, for several
+// matchers — proving the fast path never silently drops a session the slow
+// path would have returned, nor includes one it wouldn't.
+func TestDiscoverSessionsForFiltered_EquivalentToManualFilterOfFullDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(filterFixtureSource.EnvVar, dir)
+	writeFilterFixtureDB(t, DBPathFor(filterFixtureSource))
+
+	matchers := map[string]func(string) bool{
+		"project-a":      func(cwd string) bool { return cwd == "/tmp/project-a" },
+		"project-b":      func(cwd string) bool { return cwd == "/tmp/project-b" },
+		"nothing-at-all": func(cwd string) bool { return cwd == "/tmp/does-not-exist" },
+		"everything":     func(string) bool { return true },
+	}
+
+	for name, matcher := range matchers {
+		t.Run(name, func(t *testing.T) {
+			full, err := DiscoverSessionsFor(filterFixtureSource, NewSessionCache())
+			if err != nil {
+				t.Fatalf("full discovery: unexpected error: %v", err)
+			}
+			var want []string
+			for _, s := range full {
+				if matcher(s.CWD) {
+					want = append(want, s.SessionID)
+				}
+			}
+			sort.Strings(want)
+
+			got, err := DiscoverSessionsForFiltered(filterFixtureSource, NewSessionCache(), matcher)
+			if err != nil {
+				t.Fatalf("filtered discovery: unexpected error: %v", err)
+			}
+			var gotIDs []string
+			for _, s := range got {
+				gotIDs = append(gotIDs, s.SessionID)
+			}
+			sort.Strings(gotIDs)
+
+			if len(want) != len(gotIDs) {
+				t.Fatalf("filtered discovery = %v, want %v (must equal manual filter of full discovery)", gotIDs, want)
+			}
+			for i := range want {
+				if want[i] != gotIDs[i] {
+					t.Fatalf("filtered discovery = %v, want %v (must equal manual filter of full discovery)", gotIDs, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDiscoverSessionsForFiltered_CacheHitRespectsMatcher confirms that a
+// session served from cache (time_updated unchanged since the prior call)
+// is still checked against cwdMatch before being returned.
+func TestDiscoverSessionsForFiltered_CacheHitRespectsMatcher(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(filterFixtureSource.EnvVar, dir)
+	writeFilterFixtureDB(t, DBPathFor(filterFixtureSource))
+
+	cache := NewSessionCache()
+	// Prime the cache with an unfiltered pass.
+	if _, err := DiscoverSessionsFor(filterFixtureSource, cache); err != nil {
+		t.Fatalf("priming pass: unexpected error: %v", err)
+	}
+
+	matchA := func(cwd string) bool { return cwd == "/tmp/project-a" }
+	sessions, err := DiscoverSessionsForFiltered(filterFixtureSource, cache, matchA)
+	if err != nil {
+		t.Fatalf("DiscoverSessionsForFiltered() error = %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("len(sessions) = %d, want 2 (cache hits must still respect the matcher)", len(sessions))
+	}
+	for _, s := range sessions {
+		if s.CWD != "/tmp/project-a" {
+			t.Errorf("session %s CWD = %q, want /tmp/project-a", s.SessionID, s.CWD)
 		}
 	}
 }

--- a/internal/search/run.go
+++ b/internal/search/run.go
@@ -237,21 +237,9 @@ func openResult(result sessionResult) int {
 }
 
 func resumeCommand(agent, sessionID string) (*exec.Cmd, string) {
-	if sessionID == "" {
+	argv := core.ResumeArgv(agent, sessionID)
+	if argv == nil {
 		return nil, ""
 	}
-	switch agent {
-	case "claude":
-		return exec.Command("claude", "--resume", sessionID), core.ResumeCommand(agent, sessionID)
-	case "codex":
-		return exec.Command("codex", "resume", sessionID), core.ResumeCommand(agent, sessionID)
-	case "amp":
-		return exec.Command("amp", "threads", "continue", sessionID), core.ResumeCommand(agent, sessionID)
-	case "pi":
-		return exec.Command("pi", "--session", sessionID), core.ResumeCommand(agent, sessionID)
-	case "kimi":
-		return exec.Command("kimi", "--resume", sessionID), core.ResumeCommand(agent, sessionID)
-	default:
-		return nil, ""
-	}
+	return exec.Command(argv[0], argv[1:]...), core.ResumeCommand(agent, sessionID)
 }

--- a/internal/sessions/cache.go
+++ b/internal/sessions/cache.go
@@ -10,13 +10,18 @@ import (
 // the real environment's cache directory.
 var userCacheDir = os.UserCacheDir
 
-// resolveCacheDir returns the directory `lazyagent sessions` should persist
-// its discovery caches under (os.UserCacheDir()/lazyagent, e.g.
+// ResolveCacheDir returns the directory lazyagent should persist its
+// discovery caches under (os.UserCacheDir()/lazyagent, e.g.
 // ~/Library/Caches/lazyagent on macOS) and whether persistence is available
 // at all. When UserCacheDir fails or returns an empty string, ok is false
 // and the caller must run without persistence -- discovery itself is never
 // affected, only whether its caches get saved/reused across runs.
-func resolveCacheDir() (dir string, ok bool) {
+//
+// Exported so the long-lived surfaces (TUI, GUI/tray, API server) resolve
+// the cache directory the exact same way the `sessions` subcommand does,
+// without duplicating the logic -- see core.SessionManager.
+// EnableCachePersistence, which they pass this to.
+func ResolveCacheDir() (dir string, ok bool) {
 	base, err := userCacheDir()
 	if err != nil || base == "" {
 		return "", false

--- a/internal/sessions/cache.go
+++ b/internal/sessions/cache.go
@@ -1,0 +1,25 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// userCacheDir is os.UserCacheDir, stubbable in tests so the "UserCacheDir
+// fails" path (run without persistence) can be exercised without altering
+// the real environment's cache directory.
+var userCacheDir = os.UserCacheDir
+
+// resolveCacheDir returns the directory `lazyagent sessions` should persist
+// its discovery caches under (os.UserCacheDir()/lazyagent, e.g.
+// ~/Library/Caches/lazyagent on macOS) and whether persistence is available
+// at all. When UserCacheDir fails or returns an empty string, ok is false
+// and the caller must run without persistence -- discovery itself is never
+// affected, only whether its caches get saved/reused across runs.
+func resolveCacheDir() (dir string, ok bool) {
+	base, err := userCacheDir()
+	if err != nil || base == "" {
+		return "", false
+	}
+	return filepath.Join(base, "lazyagent"), true
+}

--- a/internal/sessions/cache_test.go
+++ b/internal/sessions/cache_test.go
@@ -146,6 +146,35 @@ func TestRun_SavesCacheAfterSuccessfulDiscovery(t *testing.T) {
 	}
 }
 
+// TestRun_SavesCacheAfterSuccessfulDiscoveryWithZeroResults is the
+// zero-results counterpart to the test above: a discovery that succeeds but
+// matches nothing (the fixture session's cwd is a different directory than
+// --dir queries for) must still save the caches -- per the brief, "Save
+// even when the run found zero sessions." This also exercises the
+// cwd-index specifically, since the one fixture file gets prefiltered
+// (its non-matching cwd populates cwdindex-codex.json) rather than parsed.
+func TestRun_SavesCacheAfterSuccessfulDiscoveryWithZeroResults(t *testing.T) {
+	home := writeFixtureCodexHome(t, "/tmp/some-completely-different-project")
+	t.Setenv("HOME", home)
+
+	cacheBase := t.TempDir()
+	withStubbedCacheDir(t, cacheBase)
+
+	dir := t.TempDir() // does not match the fixture session's cwd
+	code := Run([]string{"--agent", "codex", "--dir", dir})
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0 (successful discovery, zero results -> \"no sessions found\")", code)
+	}
+
+	cacheDir := filepath.Join(cacheBase, "lazyagent")
+	if _, err := os.Stat(filepath.Join(cacheDir, "discovery-codex.json")); err != nil {
+		t.Fatalf("expected discovery-codex.json to exist after a zero-result run: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "cwdindex-codex.json")); err != nil {
+		t.Fatalf("expected cwdindex-codex.json to exist after a zero-result run: %v", err)
+	}
+}
+
 func TestRun_DoesNotSaveCacheAfterDiscoveryError(t *testing.T) {
 	// An empty HOME makes codex.SessionsDir() return "", which
 	// discoverSessionsFromDir turns into a genuine discovery error.

--- a/internal/sessions/cache_test.go
+++ b/internal/sessions/cache_test.go
@@ -1,0 +1,196 @@
+package sessions
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- resolveCacheDir ---
+
+func TestResolveCacheDir_Success(t *testing.T) {
+	base := t.TempDir()
+	orig := userCacheDir
+	userCacheDir = func() (string, error) { return base, nil }
+	defer func() { userCacheDir = orig }()
+
+	dir, ok := resolveCacheDir()
+	if !ok {
+		t.Fatal("resolveCacheDir ok = false, want true")
+	}
+	want := filepath.Join(base, "lazyagent")
+	if dir != want {
+		t.Fatalf("dir = %q, want %q", dir, want)
+	}
+}
+
+func TestResolveCacheDir_UserCacheDirFailure(t *testing.T) {
+	orig := userCacheDir
+	userCacheDir = func() (string, error) { return "", errors.New("no cache dir on this platform") }
+	defer func() { userCacheDir = orig }()
+
+	dir, ok := resolveCacheDir()
+	if ok {
+		t.Fatalf("resolveCacheDir ok = true, want false; dir = %q", dir)
+	}
+	if dir != "" {
+		t.Fatalf("dir = %q, want empty", dir)
+	}
+}
+
+func TestResolveCacheDir_EmptyStringIsFailure(t *testing.T) {
+	orig := userCacheDir
+	userCacheDir = func() (string, error) { return "", nil }
+	defer func() { userCacheDir = orig }()
+
+	if _, ok := resolveCacheDir(); ok {
+		t.Fatal("resolveCacheDir ok = true, want false for an empty (but non-error) UserCacheDir result")
+	}
+}
+
+// --- writeFixtureCodexSession / fixture helpers ---
+
+// writeFixtureCodexHome creates a fake $HOME with a single codex rollout
+// session file whose cwd is cwd, and returns that HOME path. It also
+// creates an empty ~/.claude and ~/.codex/session_index.jsonl so the other
+// providers BuildProvider might touch (when agent is "all") don't error.
+func writeFixtureCodexHome(t *testing.T, cwd string) string {
+	t.Helper()
+	home := t.TempDir()
+	dayDir := filepath.Join(home, ".codex", "sessions", "2026", "03", "01")
+	if err := os.MkdirAll(dayDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessionID := "019d3431-8669-7603-be71-7079fa555f4a"
+	content := `{"timestamp":"2026-03-01T11:00:00.000Z","type":"session_meta","payload":{"id":"` + sessionID + `","cwd":"` + cwd + `","cli_version":"0.1.0","source":"cli"}}
+{"timestamp":"2026-03-01T11:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}
+`
+	path := filepath.Join(dayDir, "rollout-2026-03-01T11-00-00-"+sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".claude", "projects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// withStubbedCacheDir points userCacheDir at base for the duration of the
+// test and restores it afterward.
+func withStubbedCacheDir(t *testing.T, base string) {
+	t.Helper()
+	orig := userCacheDir
+	userCacheDir = func() (string, error) { return base, nil }
+	t.Cleanup(func() { userCacheDir = orig })
+}
+
+// captureStdout runs f with os.Stdout redirected to an in-memory pipe and
+// returns whatever f wrote to it. Run() writes --json output directly to
+// os.Stdout with no injectable writer, so this is the only way to capture
+// it from an in-process test.
+func captureStdout(t *testing.T, f func()) []byte {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	f()
+	os.Stdout = orig
+	w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// --- Run: cache wiring ---
+
+func TestRun_SavesCacheAfterSuccessfulDiscovery(t *testing.T) {
+	dir := t.TempDir() // the --dir target; also used as the fixture session's cwd
+	home := writeFixtureCodexHome(t, dir)
+	t.Setenv("HOME", home)
+
+	cacheBase := t.TempDir()
+	withStubbedCacheDir(t, cacheBase)
+
+	// No TTY in the test process, so the interactive picker path errors
+	// out with exit 2 -- irrelevant here, since Save happens right after
+	// discovery, before the picker is ever reached.
+	_ = Run([]string{"--agent", "codex", "--dir", dir})
+
+	cacheDir := filepath.Join(cacheBase, "lazyagent")
+	discoveryPath := filepath.Join(cacheDir, "discovery-codex.json")
+	data, err := os.ReadFile(discoveryPath)
+	if err != nil {
+		t.Fatalf("expected %s to exist after Run: %v", discoveryPath, err)
+	}
+	if !bytes.Contains(data, []byte("019d3431-8669-7603-be71-7079fa555f4a")) {
+		t.Fatalf("discovery-codex.json does not contain the fixture session ID -- content: %s", data)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "cwdindex-codex.json")); err != nil {
+		t.Fatalf("expected cwdindex-codex.json to exist after Run: %v", err)
+	}
+
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("cache dir perms = %o, want 0700", perm)
+	}
+}
+
+func TestRun_DoesNotSaveCacheAfterDiscoveryError(t *testing.T) {
+	// An empty HOME makes codex.SessionsDir() return "", which
+	// discoverSessionsFromDir turns into a genuine discovery error.
+	t.Setenv("HOME", "")
+
+	cacheBase := t.TempDir()
+	withStubbedCacheDir(t, cacheBase)
+
+	dir := t.TempDir()
+	code := Run([]string{"--agent", "codex", "--dir", dir})
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1 (discovery error)", code)
+	}
+
+	if _, err := os.Stat(filepath.Join(cacheBase, "lazyagent")); !os.IsNotExist(err) {
+		t.Fatalf("expected no cache dir to be created after a discovery error, stat err = %v", err)
+	}
+}
+
+// TestRun_JSONOutputIdenticalColdAndWarm is the sessions.Run-level
+// equivalence property test the brief calls for: running the exact same
+// query twice -- once cold (no persisted cache yet), once warm (reusing the
+// first run's persisted discovery cache and cwd index) -- must produce
+// byte-identical --json output.
+func TestRun_JSONOutputIdenticalColdAndWarm(t *testing.T) {
+	dir := t.TempDir()
+	home := writeFixtureCodexHome(t, dir)
+	t.Setenv("HOME", home)
+
+	cacheBase := t.TempDir()
+	withStubbedCacheDir(t, cacheBase)
+
+	args := []string{"--agent", "codex", "--json", "--dir", dir}
+
+	var coldCode, warmCode int
+	cold := captureStdout(t, func() { coldCode = Run(args) })
+	warm := captureStdout(t, func() { warmCode = Run(args) })
+
+	if coldCode != 0 || warmCode != 0 {
+		t.Fatalf("exit codes = (cold=%d, warm=%d), want (0, 0)", coldCode, warmCode)
+	}
+	if len(cold) == 0 {
+		t.Fatal("cold run produced no output")
+	}
+	if !bytes.Equal(cold, warm) {
+		t.Fatalf("cold and warm --json output differ:\ncold: %s\nwarm: %s", cold, warm)
+	}
+}

--- a/internal/sessions/cache_test.go
+++ b/internal/sessions/cache_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-// --- resolveCacheDir ---
+// --- ResolveCacheDir ---
 
 func TestResolveCacheDir_Success(t *testing.T) {
 	base := t.TempDir()
@@ -17,9 +17,9 @@ func TestResolveCacheDir_Success(t *testing.T) {
 	userCacheDir = func() (string, error) { return base, nil }
 	defer func() { userCacheDir = orig }()
 
-	dir, ok := resolveCacheDir()
+	dir, ok := ResolveCacheDir()
 	if !ok {
-		t.Fatal("resolveCacheDir ok = false, want true")
+		t.Fatal("ResolveCacheDir ok = false, want true")
 	}
 	want := filepath.Join(base, "lazyagent")
 	if dir != want {
@@ -32,9 +32,9 @@ func TestResolveCacheDir_UserCacheDirFailure(t *testing.T) {
 	userCacheDir = func() (string, error) { return "", errors.New("no cache dir on this platform") }
 	defer func() { userCacheDir = orig }()
 
-	dir, ok := resolveCacheDir()
+	dir, ok := ResolveCacheDir()
 	if ok {
-		t.Fatalf("resolveCacheDir ok = true, want false; dir = %q", dir)
+		t.Fatalf("ResolveCacheDir ok = true, want false; dir = %q", dir)
 	}
 	if dir != "" {
 		t.Fatalf("dir = %q, want empty", dir)
@@ -46,8 +46,8 @@ func TestResolveCacheDir_EmptyStringIsFailure(t *testing.T) {
 	userCacheDir = func() (string, error) { return "", nil }
 	defer func() { userCacheDir = orig }()
 
-	if _, ok := resolveCacheDir(); ok {
-		t.Fatal("resolveCacheDir ok = true, want false for an empty (but non-error) UserCacheDir result")
+	if _, ok := ResolveCacheDir(); ok {
+		t.Fatal("ResolveCacheDir ok = true, want false for an empty (but non-error) UserCacheDir result")
 	}
 }
 

--- a/internal/sessions/filter.go
+++ b/internal/sessions/filter.go
@@ -10,6 +10,22 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
 
+// resolveSymlink returns the symlink-resolved, cleaned form of cleaned, and
+// whether that differs from cleaned (i.e. there was actually something to
+// resolve). Both targetVariants and matchesDir need this same clean+resolve
+// step, just applied to different paths.
+func resolveSymlink(cleaned string) (resolved string, ok bool) {
+	r, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return "", false
+	}
+	r = filepath.Clean(r)
+	if r == cleaned {
+		return "", false
+	}
+	return r, true
+}
+
 // targetVariants normalizes dir for matching: the cleaned absolute path
 // plus, when it differs, the symlink-resolved form — so /tmp also matches
 // sessions recorded under /private/tmp on macOS.
@@ -20,32 +36,40 @@ func targetVariants(dir string) ([]string, error) {
 	}
 	abs = filepath.Clean(abs)
 	variants := []string{abs}
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		if resolved = filepath.Clean(resolved); resolved != abs {
-			variants = append(variants, resolved)
-		}
+	if resolved, ok := resolveSymlink(abs); ok {
+		variants = append(variants, resolved)
 	}
 	return variants, nil
 }
 
-// matchesDir reports whether cwd equals a target variant or lies beneath one
+// matchesVariants reports whether cwd equals a variant or lies beneath one
 // (prefix on a path boundary: /foo/bar must not match /foo/barbaz).
+func matchesVariants(cwd string, variants []string) bool {
+	for _, v := range variants {
+		if cwd == v || strings.HasPrefix(cwd, v+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesDir reports whether a session's recorded cwd falls under one of the
+// target variants. The spec matches on the cleaned, *unresolved* recorded
+// CWD first: a session recorded under a symlinked subdirectory of the target
+// (e.g. <target>/sub-link -> somewhere else entirely) must still match,
+// because the recorded path itself is what lies under the target. Only when
+// that fails do we fall back to resolving symlinks in cwd, which is what
+// lets e.g. /tmp-recorded sessions match a /private/tmp target on macOS.
 func matchesDir(cwd string, variants []string) bool {
 	if cwd == "" {
 		return false
 	}
 	cwd = filepath.Clean(cwd)
-	// Resolve symlinks in CWD for accurate matching, especially on macOS where
-	// /tmp may be a symlink to /private/tmp
-	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
-		if resolved = filepath.Clean(resolved); resolved != cwd {
-			cwd = resolved
-		}
+	if matchesVariants(cwd, variants) {
+		return true
 	}
-	for _, v := range variants {
-		if cwd == v || strings.HasPrefix(cwd, v+string(filepath.Separator)) {
-			return true
-		}
+	if resolved, ok := resolveSymlink(cwd); ok {
+		return matchesVariants(resolved, variants)
 	}
 	return false
 }
@@ -66,8 +90,11 @@ func FilterByDir(sessions []*model.Session, dir string) ([]*model.Session, error
 			out = append(out, s)
 		}
 	}
-	slices.SortFunc(out, func(a, b *model.Session) int {
-		return b.LastActivity.Compare(a.LastActivity)
+	slices.SortStableFunc(out, func(a, b *model.Session) int {
+		if c := b.LastActivity.Compare(a.LastActivity); c != 0 {
+			return c
+		}
+		return strings.Compare(a.SessionID, b.SessionID)
 	})
 	return out, nil
 }

--- a/internal/sessions/filter.go
+++ b/internal/sessions/filter.go
@@ -1,0 +1,73 @@
+// Package sessions implements the `lazyagent sessions` subcommand: list the
+// sessions recorded for a directory (all agents) and reopen one.
+package sessions
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// targetVariants normalizes dir for matching: the cleaned absolute path
+// plus, when it differs, the symlink-resolved form — so /tmp also matches
+// sessions recorded under /private/tmp on macOS.
+func targetVariants(dir string) ([]string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	abs = filepath.Clean(abs)
+	variants := []string{abs}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		if resolved = filepath.Clean(resolved); resolved != abs {
+			variants = append(variants, resolved)
+		}
+	}
+	return variants, nil
+}
+
+// matchesDir reports whether cwd equals a target variant or lies beneath one
+// (prefix on a path boundary: /foo/bar must not match /foo/barbaz).
+func matchesDir(cwd string, variants []string) bool {
+	if cwd == "" {
+		return false
+	}
+	cwd = filepath.Clean(cwd)
+	// Resolve symlinks in CWD for accurate matching, especially on macOS where
+	// /tmp may be a symlink to /private/tmp
+	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
+		if resolved = filepath.Clean(resolved); resolved != cwd {
+			cwd = resolved
+		}
+	}
+	for _, v := range variants {
+		if cwd == v || strings.HasPrefix(cwd, v+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterByDir returns the sessions whose CWD is dir or a subdirectory of it,
+// excluding sidechains, sorted by LastActivity descending.
+func FilterByDir(sessions []*model.Session, dir string) ([]*model.Session, error) {
+	variants, err := targetVariants(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []*model.Session
+	for _, s := range sessions {
+		if s.IsSidechain {
+			continue
+		}
+		if matchesDir(s.CWD, variants) {
+			out = append(out, s)
+		}
+	}
+	slices.SortFunc(out, func(a, b *model.Session) int {
+		return b.LastActivity.Compare(a.LastActivity)
+	})
+	return out, nil
+}

--- a/internal/sessions/filter.go
+++ b/internal/sessions/filter.go
@@ -74,15 +74,27 @@ func matchesDir(cwd string, variants []string) bool {
 	return false
 }
 
-// FilterByDir returns the sessions whose CWD is dir or a subdirectory of it,
-// excluding sidechains, sorted by LastActivity descending.
-func FilterByDir(sessions []*model.Session, dir string) ([]*model.Session, error) {
-	variants, err := targetVariants(dir)
-	if err != nil {
-		return nil, err
+// bySessionRecency orders sessions by LastActivity descending, breaking ties
+// by SessionID ascending. This is the single source of ordering truth
+// shared by FilterByDir's sort and the picker's incremental stream merge
+// (see mergeSessions in picker.go) — one comparator, so a session's rank
+// relative to its neighbors never depends on which code path placed it.
+func bySessionRecency(a, b *model.Session) int {
+	if c := b.LastActivity.Compare(a.LastActivity); c != 0 {
+		return c
 	}
+	return strings.Compare(a.SessionID, b.SessionID)
+}
+
+// filterBatch returns the sessions in batch whose CWD falls under one of
+// variants (see targetVariants), excluding sidechains. It is FilterByDir's
+// per-session filtering rule factored out so the picker's streaming path can
+// apply the exact same rule to each arriving batch without recomputing
+// variants (a symlink-resolving, syscall-touching step) on every call — see
+// runPicker in picker.go.
+func filterBatch(batch []*model.Session, variants []string) []*model.Session {
 	var out []*model.Session
-	for _, s := range sessions {
+	for _, s := range batch {
 		if s.IsSidechain {
 			continue
 		}
@@ -90,11 +102,17 @@ func FilterByDir(sessions []*model.Session, dir string) ([]*model.Session, error
 			out = append(out, s)
 		}
 	}
-	slices.SortStableFunc(out, func(a, b *model.Session) int {
-		if c := b.LastActivity.Compare(a.LastActivity); c != 0 {
-			return c
-		}
-		return strings.Compare(a.SessionID, b.SessionID)
-	})
+	return out
+}
+
+// FilterByDir returns the sessions whose CWD is dir or a subdirectory of it,
+// excluding sidechains, sorted by LastActivity descending.
+func FilterByDir(sessions []*model.Session, dir string) ([]*model.Session, error) {
+	variants, err := targetVariants(dir)
+	if err != nil {
+		return nil, err
+	}
+	out := filterBatch(sessions, variants)
+	slices.SortStableFunc(out, bySessionRecency)
 	return out, nil
 }

--- a/internal/sessions/filter.go
+++ b/internal/sessions/filter.go
@@ -3,75 +3,29 @@
 package sessions
 
 import (
-	"path/filepath"
 	"slices"
 	"strings"
 
+	"github.com/illegalstudio/lazyagent/internal/core"
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
 
-// resolveSymlink returns the symlink-resolved, cleaned form of cleaned, and
-// whether that differs from cleaned (i.e. there was actually something to
-// resolve). Both targetVariants and matchesDir need this same clean+resolve
-// step, just applied to different paths.
-func resolveSymlink(cleaned string) (resolved string, ok bool) {
-	r, err := filepath.EvalSymlinks(cleaned)
-	if err != nil {
-		return "", false
-	}
-	r = filepath.Clean(r)
-	if r == cleaned {
-		return "", false
-	}
-	return r, true
-}
-
 // targetVariants normalizes dir for matching: the cleaned absolute path
 // plus, when it differs, the symlink-resolved form — so /tmp also matches
-// sessions recorded under /private/tmp on macOS.
+// sessions recorded under /private/tmp on macOS. Thin wrapper delegating to
+// core.DirMatchVariants, the single shared implementation of this path
+// arithmetic (see task 15: the API's GET /api/sessions?dir= filter uses the
+// same function directly).
 func targetVariants(dir string) ([]string, error) {
-	abs, err := filepath.Abs(dir)
-	if err != nil {
-		return nil, err
-	}
-	abs = filepath.Clean(abs)
-	variants := []string{abs}
-	if resolved, ok := resolveSymlink(abs); ok {
-		variants = append(variants, resolved)
-	}
-	return variants, nil
-}
-
-// matchesVariants reports whether cwd equals a variant or lies beneath one
-// (prefix on a path boundary: /foo/bar must not match /foo/barbaz).
-func matchesVariants(cwd string, variants []string) bool {
-	for _, v := range variants {
-		if cwd == v || strings.HasPrefix(cwd, v+string(filepath.Separator)) {
-			return true
-		}
-	}
-	return false
+	return core.DirMatchVariants(dir)
 }
 
 // matchesDir reports whether a session's recorded cwd falls under one of the
-// target variants. The spec matches on the cleaned, *unresolved* recorded
-// CWD first: a session recorded under a symlinked subdirectory of the target
-// (e.g. <target>/sub-link -> somewhere else entirely) must still match,
-// because the recorded path itself is what lies under the target. Only when
-// that fails do we fall back to resolving symlinks in cwd, which is what
-// lets e.g. /tmp-recorded sessions match a /private/tmp target on macOS.
+// target variants. Thin wrapper delegating to core.CWDMatchesDir — see that
+// function's doc comment for the matching semantics (unresolved-then-
+// resolved cwd matching against target variants).
 func matchesDir(cwd string, variants []string) bool {
-	if cwd == "" {
-		return false
-	}
-	cwd = filepath.Clean(cwd)
-	if matchesVariants(cwd, variants) {
-		return true
-	}
-	if resolved, ok := resolveSymlink(cwd); ok {
-		return matchesVariants(resolved, variants)
-	}
-	return false
+	return core.CWDMatchesDir(cwd, variants)
 }
 
 // bySessionRecency orders sessions by LastActivity descending, breaking ties

--- a/internal/sessions/filter_test.go
+++ b/internal/sessions/filter_test.go
@@ -73,3 +73,44 @@ func TestFilterByDirSortsByLastActivityDesc(t *testing.T) {
 		t.Errorf("oldest must be last, got %v", got[2].LastActivity)
 	}
 }
+
+// sessID builds a session with an explicit SessionID distinct from its CWD,
+// for tiebreak assertions where two sessions share a LastActivity.
+func sessID(id, cwd string, last time.Time) *model.Session {
+	return &model.Session{SessionID: id, CWD: cwd, LastActivity: last}
+}
+
+func TestFilterByDirTiebreaksEqualLastActivityBySessionID(t *testing.T) {
+	base := t.TempDir()
+	now := time.Now()
+	in := []*model.Session{
+		sessID("zzz", base, now),
+		sessID("aaa", base, now),
+	}
+	got, err := FilterByDir(in, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 sessions, got %d", len(got))
+	}
+	if got[0].SessionID != "aaa" || got[1].SessionID != "zzz" {
+		t.Errorf("equal-timestamp tiebreak must be ascending SessionID, got %s, %s", got[0].SessionID, got[1].SessionID)
+	}
+}
+
+func TestFilterByDirSessionUnderSymlinkedSubdir(t *testing.T) {
+	target := t.TempDir()
+	external := t.TempDir() // outside target
+	subLink := filepath.Join(target, "sub-link")
+	if err := os.Symlink(external, subLink); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	got, err := FilterByDir([]*model.Session{sess(subLink, time.Now(), false)}, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("session recorded under a symlinked subdir of the target must match, got %d matches", len(got))
+	}
+}

--- a/internal/sessions/filter_test.go
+++ b/internal/sessions/filter_test.go
@@ -1,0 +1,75 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func sess(cwd string, last time.Time, sidechain bool) *model.Session {
+	return &model.Session{SessionID: cwd, CWD: cwd, LastActivity: last, IsSidechain: sidechain}
+}
+
+func TestFilterByDirMatching(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	in := []*model.Session{
+		sess(base, now, false),                // exact match
+		sess(sub, now.Add(-time.Hour), false), // subdirectory
+		sess(base+"extra", now, false),        // false prefix — excluded
+		sess("/somewhere/else", now, false),   // unrelated — excluded
+		sess(base, now, true),                 // sidechain — excluded
+	}
+	got, err := FilterByDir(in, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 sessions, got %d", len(got))
+	}
+	if got[0].CWD != base || got[1].CWD != sub {
+		t.Errorf("wrong contents/order: %s, %s", got[0].CWD, got[1].CWD)
+	}
+}
+
+func TestFilterByDirSymlinkedTarget(t *testing.T) {
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	got, err := FilterByDir([]*model.Session{sess(real, time.Now(), false)}, link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("symlinked target should match resolved CWD, got %d matches", len(got))
+	}
+}
+
+func TestFilterByDirSortsByLastActivityDesc(t *testing.T) {
+	base := t.TempDir()
+	now := time.Now()
+	in := []*model.Session{
+		sess(base, now.Add(-2*time.Hour), false),
+		sess(base, now, false),
+		sess(base, now.Add(-time.Hour), false),
+	}
+	got, err := FilterByDir(in, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got[0].LastActivity.Equal(now) {
+		t.Errorf("most recent must be first, got %v", got[0].LastActivity)
+	}
+	if !got[2].LastActivity.Equal(now.Add(-2 * time.Hour)) {
+		t.Errorf("oldest must be last, got %v", got[2].LastActivity)
+	}
+}

--- a/internal/sessions/json.go
+++ b/internal/sessions/json.go
@@ -10,19 +10,21 @@ import (
 )
 
 // sessionJSON is the wire shape of one row in `lazyagent sessions --json`.
-// Field names are part of the CLI contract — do not rename.
+// Field names are part of the CLI contract — do not rename. All seven fields
+// are always present in every row; a session with no name or no resume
+// command still emits "" rather than omitting the key.
 type sessionJSON struct {
 	Agent         string    `json:"agent"`
 	SessionID     string    `json:"session_id"`
-	Name          string    `json:"name,omitempty"`
+	Name          string    `json:"name"`
 	CWD           string    `json:"cwd"`
 	LastActivity  time.Time `json:"last_activity"`
 	Messages      int       `json:"messages"`
-	ResumeCommand string    `json:"resume_command,omitempty"`
+	ResumeCommand string    `json:"resume_command"`
 }
 
 // writeJSON emits the filtered sessions as an indented JSON array.
-// nameFor resolves the display name for a session ("" omits the field).
+// nameFor resolves the display name for a session ("" when none).
 func writeJSON(w io.Writer, sessions []*model.Session, nameFor func(*model.Session) string) error {
 	out := make([]sessionJSON, 0, len(sessions)) // non-nil so empty encodes as []
 	for _, s := range sessions {

--- a/internal/sessions/json.go
+++ b/internal/sessions/json.go
@@ -1,0 +1,42 @@
+package sessions
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// sessionJSON is the wire shape of one row in `lazyagent sessions --json`.
+// Field names are part of the CLI contract — do not rename.
+type sessionJSON struct {
+	Agent         string    `json:"agent"`
+	SessionID     string    `json:"session_id"`
+	Name          string    `json:"name,omitempty"`
+	CWD           string    `json:"cwd"`
+	LastActivity  time.Time `json:"last_activity"`
+	Messages      int       `json:"messages"`
+	ResumeCommand string    `json:"resume_command,omitempty"`
+}
+
+// writeJSON emits the filtered sessions as an indented JSON array.
+// nameFor resolves the display name for a session ("" omits the field).
+func writeJSON(w io.Writer, sessions []*model.Session, nameFor func(*model.Session) string) error {
+	out := make([]sessionJSON, 0, len(sessions)) // non-nil so empty encodes as []
+	for _, s := range sessions {
+		out = append(out, sessionJSON{
+			Agent:         s.Agent,
+			SessionID:     s.SessionID,
+			Name:          nameFor(s),
+			CWD:           s.CWD,
+			LastActivity:  s.LastActivity,
+			Messages:      s.TotalMessages,
+			ResumeCommand: core.ResumeCommand(s.Agent, s.SessionID),
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}

--- a/internal/sessions/json_test.go
+++ b/internal/sessions/json_test.go
@@ -1,0 +1,56 @@
+package sessions
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestWriteJSONFields(t *testing.T) {
+	last := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	list := []*model.Session{{
+		Agent: "claude", SessionID: "abc", CWD: "/proj",
+		LastActivity: last, TotalMessages: 5,
+	}}
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, list, func(*model.Session) string { return "my-alias" }); err != nil {
+		t.Fatal(err)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(out))
+	}
+	e := out[0]
+	if e["agent"] != "claude" || e["session_id"] != "abc" || e["cwd"] != "/proj" {
+		t.Errorf("identity fields wrong: %v", e)
+	}
+	if e["name"] != "my-alias" {
+		t.Errorf("name = %v, want my-alias", e["name"])
+	}
+	if e["messages"] != float64(5) {
+		t.Errorf("messages = %v, want 5", e["messages"])
+	}
+	if e["resume_command"] != "claude --resume abc" {
+		t.Errorf("resume_command = %v", e["resume_command"])
+	}
+	if _, ok := e["last_activity"]; !ok {
+		t.Error("missing last_activity")
+	}
+}
+
+func TestWriteJSONEmptyList(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, nil, func(*model.Session) string { return "" }); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Errorf("empty list must encode as [], got %q", got)
+	}
+}

--- a/internal/sessions/json_test.go
+++ b/internal/sessions/json_test.go
@@ -45,6 +45,54 @@ func TestWriteJSONFields(t *testing.T) {
 	}
 }
 
+func TestWriteJSONAllFieldsPresentEvenWhenEmpty(t *testing.T) {
+	last := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	list := []*model.Session{
+		{Agent: "grok", SessionID: "g1", CWD: "/proj/grok", LastActivity: last, TotalMessages: 1},
+		{Agent: "claude", SessionID: "c1", CWD: "/proj/claude", LastActivity: last, TotalMessages: 2},
+	}
+	wantKeys := []string{"agent", "session_id", "name", "cwd", "last_activity", "messages", "resume_command"}
+	var buf bytes.Buffer
+	// nameFor returns "" for every session (unnamed), exercising the omitted-name case too.
+	if err := writeJSON(&buf, list, func(*model.Session) string { return "" }); err != nil {
+		t.Fatal(err)
+	}
+	var out []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(out))
+	}
+	// Rows must appear in input order.
+	if out[0]["session_id"] != "g1" || out[1]["session_id"] != "c1" {
+		t.Errorf("rows out of input order: %v", out)
+	}
+	for i, row := range out {
+		for _, k := range wantKeys {
+			v, ok := row[k]
+			if !ok {
+				t.Errorf("row %d missing key %q: %v", i, k, row)
+			}
+			_ = v
+		}
+	}
+	// grok has no resume command and neither session has a name: both must
+	// be present as empty strings, not omitted.
+	if out[0]["name"] != "" {
+		t.Errorf("grok row name = %v, want empty string", out[0]["name"])
+	}
+	if out[0]["resume_command"] != "" {
+		t.Errorf("grok row resume_command = %v, want empty string", out[0]["resume_command"])
+	}
+	if out[1]["name"] != "" {
+		t.Errorf("claude row name = %v, want empty string", out[1]["name"])
+	}
+	if out[1]["resume_command"] != "claude --resume c1" {
+		t.Errorf("claude row resume_command = %v, want claude --resume c1", out[1]["resume_command"])
+	}
+}
+
 func TestWriteJSONEmptyList(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeJSON(&buf, nil, func(*model.Session) string { return "" }); err != nil {

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -3,6 +3,7 @@ package sessions
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -157,6 +158,69 @@ func visibleRange(cursor, total, height int) (start, end int) {
 		}
 	}
 	return start, end
+}
+
+// mergeSessions merges an incoming discovery batch (batchSessions/
+// batchTitles, parallel slices) into the already-accumulated sessions/
+// titles (also parallel), returning a new pair of parallel slices sorted by
+// bySessionRecency — the same ordering rule FilterByDir uses, so the merged
+// list is deterministic at any point in the stream regardless of the order
+// batches arrive in. Titles travel alongside their session through the sort
+// so the two slices never desync.
+func mergeSessions(sessions []*model.Session, titles []string, batchSessions []*model.Session, batchTitles []string) ([]*model.Session, []string) {
+	type row struct {
+		session *model.Session
+		title   string
+	}
+	rows := make([]row, 0, len(sessions)+len(batchSessions))
+	for i, s := range sessions {
+		rows = append(rows, row{s, titles[i]})
+	}
+	for i, s := range batchSessions {
+		rows = append(rows, row{s, batchTitles[i]})
+	}
+	slices.SortStableFunc(rows, func(a, b row) int {
+		return bySessionRecency(a.session, b.session)
+	})
+	mergedSessions := make([]*model.Session, len(rows))
+	mergedTitles := make([]string, len(rows))
+	for i, r := range rows {
+		mergedSessions[i] = r.session
+		mergedTitles[i] = r.title
+	}
+	return mergedSessions, mergedTitles
+}
+
+// relocateCursor computes where the cursor should land in merged given
+// where it was before the merge (prevCursor into prevSessions).
+//
+// If the user hasn't navigated away from the top row yet (prevCursor <= 0),
+// the cursor stays pinned to the top: there's no meaningful selection to
+// preserve, so we don't try to "follow" whichever session happened to be
+// first. Otherwise the previously selected session's SessionID is looked up
+// in merged and the cursor follows it to its new index; if that session is
+// no longer present, the cursor clamps to the nearest valid index.
+func relocateCursor(prevSessions []*model.Session, prevCursor int, merged []*model.Session) int {
+	if len(merged) == 0 {
+		return 0
+	}
+	if prevCursor <= 0 || prevCursor >= len(prevSessions) {
+		return 0
+	}
+	selectedID := prevSessions[prevCursor].SessionID
+	for i, s := range merged {
+		if s.SessionID == selectedID {
+			return i
+		}
+	}
+	// The previously selected session disappeared: clamp to the nearest
+	// valid index (sessions are only ever added by this feature's merges,
+	// so this branch is defensive rather than something that happens in
+	// practice today).
+	if prevCursor >= len(merged) {
+		return len(merged) - 1
+	}
+	return prevCursor
 }
 
 func (m pickerModel) View() string {

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -67,7 +67,22 @@ type pickerModel struct {
 	titles   []string // pre-computed row titles, same indexing as sessions
 	cursor   int
 	action   pickerAction
-	status   string
+	// chosen is the concrete session the user acted on (enter/c), captured
+	// at the moment of the decision rather than re-derived later from
+	// sessions[cursor]. A batch can still be in flight on p.msgs when the
+	// user decides -- both a sessionBatchMsg and the QuitMsg from tea.Quit
+	// travel through the same channel -- so if that batch is processed
+	// after the key and re-sorts the list, sessions[cursor] could end up
+	// pointing at a different session than the one the user actually
+	// looked at. Capturing it here means runPicker never has to re-derive
+	// it from a cursor that may have moved.
+	chosen *model.Session
+	status string
+	// decided is set the moment updateKey sets a terminal action
+	// (actionOpen/actionCopy/actionQuit). Once true, applyBatch and
+	// applyStreamDone become no-ops: the decision has already been made
+	// and must not be disturbed by a message that was already in flight.
+	decided  bool
 	dirLabel string
 	now      time.Time
 	height   int // terminal height from the last tea.WindowSizeMsg; 0 = unknown
@@ -115,7 +130,16 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // applyBatch merges one discovery member's batch into the accumulated
 // list, keeps the cursor on whatever session it was tracking (see
 // relocateCursor), and advances the loading progress counter.
+//
+// It's a no-op once the user has already made a terminal decision
+// (m.decided): a batch can still be in flight on p.msgs at the moment
+// enter/c/q is pressed (see the chosen field's doc comment), and once the
+// program is quitting, nothing should keep mutating the list, the cursor,
+// or the loading counters underneath that decision.
 func (m pickerModel) applyBatch(msg sessionBatchMsg) pickerModel {
+	if m.decided {
+		return m
+	}
 	prevSessions, prevCursor := m.sessions, m.cursor
 	m.sessions, m.titles = mergeSessions(m.sessions, m.titles, msg.sessions, msg.titles)
 	m.cursor = relocateCursor(prevSessions, prevCursor, m.sessions)
@@ -129,10 +153,23 @@ func (m pickerModel) applyBatch(msg sessionBatchMsg) pickerModel {
 // nothing was ever found, the picker quits itself with actionEmpty so Run
 // can print the "No sessions found" message; otherwise it just switches the
 // footer out of its loading state.
+//
+// Like applyBatch, this is a no-op once m.decided: without this guard, a
+// streamDoneMsg arriving right after an explicit quit on an
+// still-empty-so-far list would flip m.action from the user's actionQuit
+// to actionEmpty, corrupting a decision that had already been made. In
+// practice DiscoverMatchingStream never sends a batch after streamDoneMsg
+// (done only closes once every member's emit has already been delivered),
+// so this guard's only real job is protecting against a decision racing
+// the done message itself, not a batch racing after it.
 func (m pickerModel) applyStreamDone() (tea.Model, tea.Cmd) {
+	if m.decided {
+		return m, nil
+	}
 	m.loading = false
 	if len(m.sessions) == 0 {
 		m.action = actionEmpty
+		m.decided = true
 		return m, tea.Quit
 	}
 	return m, nil
@@ -160,10 +197,14 @@ func (m pickerModel) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch {
 		case core.ResumeArgv(s.Agent, s.SessionID) != nil:
 			m.action = actionOpen
+			m.chosen = s
+			m.decided = true
 			return m, tea.Quit
 		case core.ResumeCommand(s.Agent, s.SessionID) != "":
 			// Not executable from here, but the command exists: copy it.
 			m.action = actionCopy
+			m.chosen = s
+			m.decided = true
 			return m, tea.Quit
 		default:
 			m.status = fmt.Sprintf("no resume available for %s sessions", s.Agent)
@@ -175,11 +216,14 @@ func (m pickerModel) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		s := m.sessions[m.cursor]
 		if core.ResumeCommand(s.Agent, s.SessionID) != "" {
 			m.action = actionCopy
+			m.chosen = s
+			m.decided = true
 			return m, tea.Quit
 		}
 		m.status = fmt.Sprintf("no resume command for %s sessions", s.Agent)
 	case "q", "esc", "ctrl+c":
 		m.action = actionQuit
+		m.decided = true
 		return m, tea.Quit
 	}
 	return m, nil
@@ -423,7 +467,12 @@ func runPicker(provider core.SessionProvider, match func(string) bool, dir, dirL
 	if res.action == actionQuit || res.action == actionEmpty {
 		return nil, res.action, streamComplete, nil
 	}
-	return res.sessions[res.cursor], res.action, streamComplete, nil
+	// res.chosen, not res.sessions[res.cursor]: the session was captured at
+	// the moment of the decision (see pickerModel.chosen's doc comment), so
+	// it's correct even if a batch that was already in flight got merged in
+	// afterward (applyBatch is a no-op post-decision, but chosen is what
+	// actually protects the returned session's identity).
+	return res.chosen, res.action, streamComplete, nil
 }
 
 // relTime renders t relative to now, degrading to an absolute date after

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -21,7 +21,23 @@ const (
 	actionQuit pickerAction = iota
 	actionOpen
 	actionCopy
+	// actionEmpty fires when the discovery stream finishes with zero
+	// sessions total — distinct from actionQuit (an explicit user quit)
+	// so Run can print the "No sessions found" message only in this case.
+	actionEmpty
 )
+
+// sessionBatchMsg carries one discovery member's already dir-filtered
+// results (sessions/titles, parallel slices) as they arrive from the
+// streaming discovery goroutine. See runPicker.
+type sessionBatchMsg struct {
+	sessions []*model.Session
+	titles   []string
+}
+
+// streamDoneMsg signals that every discovery member has finished (the
+// DiscoverMatchingStream done channel closed). See runPicker.
+type streamDoneMsg struct{}
 
 // agentColors maps agent keys to identity colors. The keys shared with the
 // prune/compact selectors reuse their palette; the rest stay in the family.
@@ -55,6 +71,17 @@ type pickerModel struct {
 	dirLabel string
 	now      time.Time
 	height   int // terminal height from the last tea.WindowSizeMsg; 0 = unknown
+
+	// Streaming discovery state (see sessionBatchMsg/streamDoneMsg). loading
+	// is true until the discovery stream's done message arrives; total is
+	// the number of discovery members expected (memberCount), doneCount the
+	// number that have delivered a batch so far, bounded by total. A member
+	// that fails contributes no batch at all (best-effort), so doneCount can
+	// stay below total even after loading flips false -- the footer just
+	// switches away from the progress text at that point regardless.
+	loading   bool
+	doneCount int
+	total     int
 }
 
 // defaultVisibleRows is the row budget View falls back to when the terminal
@@ -77,6 +104,36 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		return m.updateKey(msg)
+	case sessionBatchMsg:
+		return m.applyBatch(msg), nil
+	case streamDoneMsg:
+		return m.applyStreamDone()
+	}
+	return m, nil
+}
+
+// applyBatch merges one discovery member's batch into the accumulated
+// list, keeps the cursor on whatever session it was tracking (see
+// relocateCursor), and advances the loading progress counter.
+func (m pickerModel) applyBatch(msg sessionBatchMsg) pickerModel {
+	prevSessions, prevCursor := m.sessions, m.cursor
+	m.sessions, m.titles = mergeSessions(m.sessions, m.titles, msg.sessions, msg.titles)
+	m.cursor = relocateCursor(prevSessions, prevCursor, m.sessions)
+	if m.doneCount < m.total {
+		m.doneCount++
+	}
+	return m
+}
+
+// applyStreamDone reacts to every discovery member having finished: if
+// nothing was ever found, the picker quits itself with actionEmpty so Run
+// can print the "No sessions found" message; otherwise it just switches the
+// footer out of its loading state.
+func (m pickerModel) applyStreamDone() (tea.Model, tea.Cmd) {
+	m.loading = false
+	if len(m.sessions) == 0 {
+		m.action = actionEmpty
+		return m, tea.Quit
 	}
 	return m, nil
 }
@@ -94,6 +151,11 @@ func (m pickerModel) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.status = ""
 	case "enter":
+		// During loading the list can still be empty (no batch has arrived
+		// yet): nothing to act on, so no-op rather than index out of range.
+		if len(m.sessions) == 0 {
+			return m, nil
+		}
 		s := m.sessions[m.cursor]
 		switch {
 		case core.ResumeArgv(s.Agent, s.SessionID) != nil:
@@ -107,6 +169,9 @@ func (m pickerModel) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.status = fmt.Sprintf("no resume available for %s sessions", s.Agent)
 		}
 	case "c":
+		if len(m.sessions) == 0 {
+			return m, nil
+		}
 		s := m.sessions[m.cursor]
 		if core.ResumeCommand(s.Agent, s.SessionID) != "" {
 			m.action = actionCopy
@@ -270,11 +335,21 @@ func (m pickerModel) View() string {
 
 	title := chatops.StyleTableHeader.Render(fmt.Sprintf("Sessions in %s (%d)", m.dirLabel, total))
 	box := stylePickerBox.Render(title + "\n\n" + strings.Join(rows, "\n"))
-	footer := chatops.StyleFooter.Render("  ↑/↓ move · enter open · c copy resume cmd · q quit")
+	footer := chatops.StyleFooter.Render(m.footerText())
 	if m.status != "" {
 		footer += "\n" + styleStatus.Render("  "+m.status)
 	}
 	return box + "\n" + footer + "\n"
+}
+
+// footerText is the footer line's content: a loading indicator with
+// progress while the discovery stream is still running, the normal
+// keybinding hint once it's done.
+func (m pickerModel) footerText() string {
+	if m.loading {
+		return fmt.Sprintf("  loading agents… (%d/%d)", m.doneCount, m.total)
+	}
+	return "  ↑/↓ move · enter open · c copy resume cmd · q quit"
 }
 
 func agentColor(agent string) lipgloss.Color {

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -359,8 +359,6 @@ func agentColor(agent string) lipgloss.Color {
 	return chatops.ColTextSubtle
 }
 
-// runPicker shows the interactive list and returns the chosen session and
-// action. A nil session means the user quit without choosing.
 // memberCount returns how many independent discovery members provider has,
 // matching DiscoverMatchingStream's granularity: a MultiProvider fans out
 // to one member per entry in Providers (zero for an empty MultiProvider,

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -361,21 +361,71 @@ func agentColor(agent string) lipgloss.Color {
 
 // runPicker shows the interactive list and returns the chosen session and
 // action. A nil session means the user quit without choosing.
-func runPicker(list []*model.Session, titles []string, dirLabel string) (*model.Session, pickerAction, error) {
-	if len(list) == 0 {
-		return nil, actionQuit, nil
+// memberCount returns how many independent discovery members provider has,
+// matching DiscoverMatchingStream's granularity: a MultiProvider fans out
+// to one member per entry in Providers (zero for an empty MultiProvider,
+// e.g. when every agent is disabled); any other provider is a single
+// member. Used to size the picker's "loading agents… (done/total)" footer.
+func memberCount(p core.SessionProvider) int {
+	if mp, ok := p.(core.MultiProvider); ok {
+		return len(mp.Providers)
 	}
-	m := pickerModel{sessions: list, titles: titles, dirLabel: dirLabel, now: time.Now()}
+	return 1
+}
+
+// runPicker opens the interactive picker immediately and streams discovery
+// results into it via core.DiscoverMatchingStream as they arrive, instead
+// of blocking until every agent has finished. Each incoming batch is
+// filtered to dir's variants (filterBatch — the same per-session rule
+// FilterByDir applies) and given per-session titles (titleFor) before being
+// delivered to the running program as a sessionBatchMsg; a final
+// streamDoneMsg follows once every member is done.
+//
+// The discovery goroutine is never joined here: once the picker exits,
+// runPicker returns immediately regardless of whether background discovery
+// is still running (Program.Send is documented safe to call, and a no-op,
+// once the program has exited — see bubbletea's Program.Send/Quit docs).
+// This is deliberate: Run must not block the user's chosen action (open/
+// copy) on unfinished discovery.
+//
+// streamComplete reports whether the discovery stream's done message had
+// already arrived by the time the picker exited. Run uses it to decide
+// whether saving provider caches is safe — see Run's comment on cache-save
+// timing on the picker path.
+func runPicker(provider core.SessionProvider, match func(string) bool, dir, dirLabel string, names *core.SessionNames) (chosen *model.Session, action pickerAction, streamComplete bool, err error) {
+	// dir was already validated by Run (os.Stat + this same targetVariants
+	// call both succeeded there) before runPicker is ever reached, so this
+	// error is not expected in practice; degrade to "nothing matches"
+	// rather than propagate a surprising failure out of the picker.
+	variants, _ := targetVariants(dir)
+
+	m := pickerModel{dirLabel: dirLabel, now: time.Now(), loading: true, total: memberCount(provider)}
 	p := tea.NewProgram(m, tea.WithInput(os.Stdin), tea.WithOutput(os.Stderr))
-	final, err := p.Run()
-	if err != nil {
-		return nil, actionQuit, fmt.Errorf("session picker: %w", err)
+
+	go func() {
+		emit := func(batch []*model.Session) {
+			filtered := filterBatch(batch, variants)
+			titles := make([]string, len(filtered))
+			for i, s := range filtered {
+				titles[i] = titleFor(s, names.Get(s.SessionID))
+			}
+			p.Send(sessionBatchMsg{sessions: filtered, titles: titles})
+		}
+		done := core.DiscoverMatchingStream(provider, match, emit)
+		<-done
+		p.Send(streamDoneMsg{})
+	}()
+
+	final, runErr := p.Run()
+	if runErr != nil {
+		return nil, actionQuit, false, fmt.Errorf("session picker: %w", runErr)
 	}
 	res := final.(pickerModel)
-	if res.action == actionQuit {
-		return nil, actionQuit, nil
+	streamComplete = !res.loading
+	if res.action == actionQuit || res.action == actionEmpty {
+		return nil, res.action, streamComplete, nil
 	}
-	return res.sessions[res.cursor], res.action, nil
+	return res.sessions[res.cursor], res.action, streamComplete, nil
 }
 
 // relTime renders t relative to now, degrading to an absolute date after

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -134,6 +134,9 @@ func agentColor(agent string) lipgloss.Color {
 // runPicker shows the interactive list and returns the chosen session and
 // action. A nil session means the user quit without choosing.
 func runPicker(list []*model.Session, titles []string, dirLabel string) (*model.Session, pickerAction, error) {
+	if len(list) == 0 {
+		return nil, actionQuit, nil
+	}
 	m := pickerModel{sessions: list, titles: titles, dirLabel: dirLabel, now: time.Now()}
 	p := tea.NewProgram(m, tea.WithInput(os.Stdin), tea.WithOutput(os.Stderr))
 	final, err := p.Run()

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -53,15 +53,34 @@ type pickerModel struct {
 	status   string
 	dirLabel string
 	now      time.Time
+	height   int // terminal height from the last tea.WindowSizeMsg; 0 = unknown
 }
+
+// defaultVisibleRows is the row budget View falls back to when the terminal
+// height is unknown (height == 0, e.g. in unit tests that never deliver a
+// tea.WindowSizeMsg).
+const defaultVisibleRows = 20
+
+// chromeLines is the number of non-row lines View always emits: the box's
+// top border, the title, the blank line separating the title from the rows,
+// the box's bottom border, and the footer. The status line, when present,
+// and the "N more" clip indicators are counted on top of this.
+const chromeLines = 5
 
 func (m pickerModel) Init() tea.Cmd { return nil }
 
 func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	key, ok := msg.(tea.KeyMsg)
-	if !ok {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.height = msg.Height
 		return m, nil
+	case tea.KeyMsg:
+		return m.updateKey(msg)
 	}
+	return m, nil
+}
+
+func (m pickerModel) updateKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch key.String() {
 	case "up", "k":
 		if m.cursor > 0 {
@@ -100,9 +119,75 @@ func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// rowBudget returns how many session rows View can render: the terminal
+// height minus chromeLines minus one more if a status line is showing, with
+// a floor of 1. Falls back to defaultVisibleRows when the height is unknown.
+func (m pickerModel) rowBudget() int {
+	if m.height <= 0 {
+		return defaultVisibleRows
+	}
+	budget := m.height - chromeLines
+	if m.status != "" {
+		budget--
+	}
+	if budget < 1 {
+		budget = 1
+	}
+	return budget
+}
+
+// visibleRange returns the half-open row window [start, end) of at most
+// height rows that contains cursor, scrolling the window — never the
+// cursor — as needed to stay within [0, total). When the whole list fits,
+// it returns the full range.
+func visibleRange(cursor, total, height int) (start, end int) {
+	if height <= 0 || total <= height {
+		return 0, total
+	}
+	start = cursor - height/2
+	if start < 0 {
+		start = 0
+	}
+	end = start + height
+	if end > total {
+		end = total
+		start = end - height
+		if start < 0 {
+			start = 0
+		}
+	}
+	return start, end
+}
+
 func (m pickerModel) View() string {
+	total := len(m.sessions)
+	budget := m.rowBudget()
+	start, end := visibleRange(m.cursor, total, budget)
+	clippedAbove := start > 0
+	clippedBelow := end < total
+	// The clip indicators themselves consume rows out of the same budget,
+	// so once we know we need one, shrink the budget and re-window.
+	if clippedAbove {
+		budget--
+	}
+	if clippedBelow {
+		budget--
+	}
+	if clippedAbove || clippedBelow {
+		if budget < 1 {
+			budget = 1
+		}
+		start, end = visibleRange(m.cursor, total, budget)
+		clippedAbove = start > 0
+		clippedBelow = end < total
+	}
+
 	var rows []string
-	for i, s := range m.sessions {
+	if clippedAbove {
+		rows = append(rows, chatops.StyleMuted.Render(fmt.Sprintf("  … %d more above", start)))
+	}
+	for i := start; i < end; i++ {
+		s := m.sessions[i]
 		marker := "  "
 		if i == m.cursor {
 			marker = styleCursor.Render("▸ ")
@@ -115,7 +200,11 @@ func (m pickerModel) View() string {
 		}
 		rows = append(rows, row)
 	}
-	title := chatops.StyleTableHeader.Render(fmt.Sprintf("Sessions in %s (%d)", m.dirLabel, len(m.sessions)))
+	if clippedBelow {
+		rows = append(rows, chatops.StyleMuted.Render(fmt.Sprintf("  … %d more below", total-end)))
+	}
+
+	title := chatops.StyleTableHeader.Render(fmt.Sprintf("Sessions in %s (%d)", m.dirLabel, total))
 	box := stylePickerBox.Render(title + "\n\n" + strings.Join(rows, "\n"))
 	footer := chatops.StyleFooter.Render("  ↑/↓ move · enter open · c copy resume cmd · q quit")
 	if m.status != "" {

--- a/internal/sessions/picker.go
+++ b/internal/sessions/picker.go
@@ -1,0 +1,197 @@
+package sessions
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/illegalstudio/lazyagent/internal/chatops"
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// pickerAction is what the user chose when the picker exited.
+type pickerAction int
+
+const (
+	actionQuit pickerAction = iota
+	actionOpen
+	actionCopy
+)
+
+// agentColors maps agent keys to identity colors. The keys shared with the
+// prune/compact selectors reuse their palette; the rest stay in the family.
+var agentColors = map[string]lipgloss.Color{
+	"claude":   "#E7A15E",
+	"pi":       "#F38BA8",
+	"codex":    "#A6E3A1",
+	"grok":     "#89B4FA",
+	"kimi":     "#CBA6F7",
+	"opencode": "#94E2D5",
+	"kilo":     "#F9E2AF",
+	"cursor":   "#B4BEFE",
+	"amp":      "#EBA0AC",
+}
+
+var (
+	stylePickerBox = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(chatops.ColBorderDim).
+		Padding(0, 1)
+	styleCursor = lipgloss.NewStyle().Foreground(chatops.ColPrimary).Bold(true)
+	styleStatus = lipgloss.NewStyle().Foreground(chatops.ColWarn)
+)
+
+type pickerModel struct {
+	sessions []*model.Session
+	titles   []string // pre-computed row titles, same indexing as sessions
+	cursor   int
+	action   pickerAction
+	status   string
+	dirLabel string
+	now      time.Time
+}
+
+func (m pickerModel) Init() tea.Cmd { return nil }
+
+func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		m.status = ""
+	case "down", "j":
+		if m.cursor < len(m.sessions)-1 {
+			m.cursor++
+		}
+		m.status = ""
+	case "enter":
+		s := m.sessions[m.cursor]
+		switch {
+		case core.ResumeArgv(s.Agent, s.SessionID) != nil:
+			m.action = actionOpen
+			return m, tea.Quit
+		case core.ResumeCommand(s.Agent, s.SessionID) != "":
+			// Not executable from here, but the command exists: copy it.
+			m.action = actionCopy
+			return m, tea.Quit
+		default:
+			m.status = fmt.Sprintf("no resume available for %s sessions", s.Agent)
+		}
+	case "c":
+		s := m.sessions[m.cursor]
+		if core.ResumeCommand(s.Agent, s.SessionID) != "" {
+			m.action = actionCopy
+			return m, tea.Quit
+		}
+		m.status = fmt.Sprintf("no resume command for %s sessions", s.Agent)
+	case "q", "esc", "ctrl+c":
+		m.action = actionQuit
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m pickerModel) View() string {
+	var rows []string
+	for i, s := range m.sessions {
+		marker := "  "
+		if i == m.cursor {
+			marker = styleCursor.Render("▸ ")
+		}
+		agent := lipgloss.NewStyle().Foreground(agentColor(s.Agent)).Render(fmt.Sprintf("%-8s", s.Agent))
+		row := fmt.Sprintf("%s%s %-10s %4d  %s",
+			marker, agent, relTime(s.LastActivity, m.now), s.TotalMessages, m.titles[i])
+		if core.ResumeCommand(s.Agent, s.SessionID) == "" {
+			row += chatops.StyleMuted.Render("  (no resume)")
+		}
+		rows = append(rows, row)
+	}
+	title := chatops.StyleTableHeader.Render(fmt.Sprintf("Sessions in %s (%d)", m.dirLabel, len(m.sessions)))
+	box := stylePickerBox.Render(title + "\n\n" + strings.Join(rows, "\n"))
+	footer := chatops.StyleFooter.Render("  ↑/↓ move · enter open · c copy resume cmd · q quit")
+	if m.status != "" {
+		footer += "\n" + styleStatus.Render("  "+m.status)
+	}
+	return box + "\n" + footer + "\n"
+}
+
+func agentColor(agent string) lipgloss.Color {
+	if c, ok := agentColors[agent]; ok {
+		return c
+	}
+	return chatops.ColTextSubtle
+}
+
+// runPicker shows the interactive list and returns the chosen session and
+// action. A nil session means the user quit without choosing.
+func runPicker(list []*model.Session, titles []string, dirLabel string) (*model.Session, pickerAction, error) {
+	m := pickerModel{sessions: list, titles: titles, dirLabel: dirLabel, now: time.Now()}
+	p := tea.NewProgram(m, tea.WithInput(os.Stdin), tea.WithOutput(os.Stderr))
+	final, err := p.Run()
+	if err != nil {
+		return nil, actionQuit, fmt.Errorf("session picker: %w", err)
+	}
+	res := final.(pickerModel)
+	if res.action == actionQuit {
+		return nil, actionQuit, nil
+	}
+	return res.sessions[res.cursor], res.action, nil
+}
+
+// relTime renders t relative to now, degrading to an absolute date after
+// 30 days. Zero times render as "unknown".
+func relTime(t, now time.Time) string {
+	if t.IsZero() {
+		return "unknown"
+	}
+	d := now.Sub(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 48*time.Hour:
+		return "yesterday"
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+	return t.Format("2006-01-02")
+}
+
+// titleFor picks the row title: user alias, then agent-provided name, then
+// the earliest user message still in the RecentMessages window.
+func titleFor(s *model.Session, alias string) string {
+	if alias != "" {
+		return alias
+	}
+	if s.Name != "" {
+		return s.Name
+	}
+	for _, msg := range s.RecentMessages {
+		if msg.Role == "user" && strings.TrimSpace(msg.Text) != "" {
+			return truncate(msg.Text, 60)
+		}
+	}
+	return "(no messages)"
+}
+
+// truncate collapses whitespace and cuts s to max runes with an ellipsis.
+func truncate(s string, max int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max-1]) + "…"
+}

--- a/internal/sessions/picker_test.go
+++ b/internal/sessions/picker_test.go
@@ -1,0 +1,123 @@
+package sessions
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func keyRune(r rune) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}} }
+
+func TestPickerNavigationAndOpen(t *testing.T) {
+	m := pickerModel{
+		sessions: []*model.Session{
+			{Agent: "claude", SessionID: "a"},
+			{Agent: "grok", SessionID: "b"},
+		},
+		titles: []string{"one", "two"},
+	}
+
+	next, _ := m.Update(keyRune('j'))
+	m = next.(pickerModel)
+	if m.cursor != 1 {
+		t.Fatalf("cursor = %d, want 1", m.cursor)
+	}
+	// j at the bottom stays put.
+	next, _ = m.Update(keyRune('j'))
+	m = next.(pickerModel)
+	if m.cursor != 1 {
+		t.Fatalf("cursor moved past end: %d", m.cursor)
+	}
+
+	// enter on grok (no resume at all): stays open, shows a status message.
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("picker must stay open on a grok row")
+	}
+	if m.status == "" {
+		t.Fatal("expected a status message for grok")
+	}
+
+	// back up to claude and open.
+	next, _ = m.Update(keyRune('k'))
+	m = next.(pickerModel)
+	next, cmd = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if m.action != actionOpen {
+		t.Fatalf("action = %v, want actionOpen", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after open")
+	}
+}
+
+func TestPickerEnterFallsBackToCopy(t *testing.T) {
+	// opencode: display command exists, executable argv does not → copy.
+	m := pickerModel{sessions: []*model.Session{{Agent: "opencode", SessionID: "x"}}, titles: []string{"t"}}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if m.action != actionCopy {
+		t.Fatalf("action = %v, want actionCopy", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after copy")
+	}
+}
+
+func TestPickerQuitKeys(t *testing.T) {
+	for _, k := range []tea.KeyMsg{{Type: tea.KeyEsc}, {Type: tea.KeyCtrlC}, keyRune('q')} {
+		m := pickerModel{sessions: []*model.Session{{Agent: "claude", SessionID: "a"}}, titles: []string{"t"}}
+		next, cmd := m.Update(k)
+		m = next.(pickerModel)
+		if m.action != actionQuit || cmd == nil {
+			t.Fatalf("key %v: action=%v cmd=%v, want quit", k, m.action, cmd)
+		}
+	}
+}
+
+func TestRelTime(t *testing.T) {
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		in   time.Time
+		want string
+	}{
+		{now.Add(-30 * time.Second), "just now"},
+		{now.Add(-5 * time.Minute), "5m ago"},
+		{now.Add(-2 * time.Hour), "2h ago"},
+		{now.Add(-30 * time.Hour), "yesterday"},
+		{now.Add(-3 * 24 * time.Hour), "3d ago"},
+		{now.Add(-40 * 24 * time.Hour), "2026-06-10"},
+		{time.Time{}, "unknown"},
+	}
+	for _, c := range cases {
+		if got := relTime(c.in, now); got != c.want {
+			t.Errorf("relTime(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTitleFor(t *testing.T) {
+	s := &model.Session{
+		Name: "agent-name",
+		RecentMessages: []model.ConversationMessage{
+			{Role: "assistant", Text: "hi"},
+			{Role: "user", Text: "fix the build\nplease"},
+		},
+	}
+	if got := titleFor(s, "custom"); got != "custom" {
+		t.Errorf("alias must win, got %q", got)
+	}
+	if got := titleFor(s, ""); got != "agent-name" {
+		t.Errorf("agent name second, got %q", got)
+	}
+	s.Name = ""
+	if got := titleFor(s, ""); got != "fix the build please" {
+		t.Errorf("user message preview third, got %q", got)
+	}
+	if got := titleFor(&model.Session{}, ""); got != "(no messages)" {
+		t.Errorf("fallback, got %q", got)
+	}
+}

--- a/internal/sessions/picker_test.go
+++ b/internal/sessions/picker_test.go
@@ -2,6 +2,7 @@ package sessions
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -347,5 +348,154 @@ func TestRelocateCursorOnEmptyMergedIsZero(t *testing.T) {
 	prev := []*model.Session{{SessionID: "x"}}
 	if got := relocateCursor(prev, 0, nil); got != 0 {
 		t.Errorf("relocateCursor = %d, want 0", got)
+	}
+}
+
+// --- Update-driven stream transitions ---
+
+func TestPickerBatchMsgAppendsAndResorts(t *testing.T) {
+	now := time.Now()
+	m := pickerModel{loading: true, total: 2}
+
+	next, cmd := m.Update(sessionBatchMsg{
+		sessions: []*model.Session{{SessionID: "a", LastActivity: now.Add(-time.Hour)}},
+		titles:   []string{"A"},
+	})
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("a batch message must not quit the program")
+	}
+	if len(m.sessions) != 1 || m.sessions[0].SessionID != "a" {
+		t.Fatalf("sessions = %#v, want [a]", m.sessions)
+	}
+	if m.doneCount != 1 {
+		t.Fatalf("doneCount = %d, want 1", m.doneCount)
+	}
+	if !m.loading {
+		t.Fatal("model must still be loading before a streamDoneMsg arrives")
+	}
+
+	// A second, more recent batch: the merged list must end up sorted even
+	// though it arrived after the older one.
+	next, _ = m.Update(sessionBatchMsg{
+		sessions: []*model.Session{{SessionID: "b", LastActivity: now}},
+		titles:   []string{"B"},
+	})
+	m = next.(pickerModel)
+	if len(m.sessions) != 2 || m.sessions[0].SessionID != "b" || m.sessions[1].SessionID != "a" {
+		t.Fatalf("sessions = %#v, want [b, a]", m.sessions)
+	}
+	if m.doneCount != 2 {
+		t.Fatalf("doneCount = %d, want 2", m.doneCount)
+	}
+}
+
+func TestPickerBatchMsgDoneCountNeverExceedsTotal(t *testing.T) {
+	m := pickerModel{loading: true, total: 1}
+	next, _ := m.Update(sessionBatchMsg{sessions: []*model.Session{{SessionID: "a"}}, titles: []string{"A"}})
+	m = next.(pickerModel)
+	next, _ = m.Update(sessionBatchMsg{sessions: []*model.Session{{SessionID: "b"}}, titles: []string{"B"}})
+	m = next.(pickerModel)
+	if m.doneCount != 1 {
+		t.Fatalf("doneCount = %d, want 1 (bounded by total)", m.doneCount)
+	}
+}
+
+func TestPickerStreamDoneWithZeroSessionsQuitsWithEmptyAction(t *testing.T) {
+	m := pickerModel{loading: true, total: 1}
+	next, cmd := m.Update(streamDoneMsg{})
+	m = next.(pickerModel)
+	if m.action != actionEmpty {
+		t.Fatalf("action = %v, want actionEmpty", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit when the stream finishes with zero sessions")
+	}
+	if m.loading {
+		t.Fatal("loading must be false once the stream is done")
+	}
+}
+
+func TestPickerStreamDoneSwitchesFooterWhenNonEmpty(t *testing.T) {
+	m := pickerModel{
+		loading:  true,
+		total:    1,
+		sessions: []*model.Session{{Agent: "claude", SessionID: "a"}},
+		titles:   []string{"one"},
+	}
+	next, cmd := m.Update(streamDoneMsg{})
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("a non-empty completion must not quit the program")
+	}
+	if m.loading {
+		t.Fatal("loading must be false once the stream is done")
+	}
+	if m.action == actionEmpty {
+		t.Fatal("action must not be actionEmpty when sessions were found")
+	}
+	if strings.Contains(m.View(), "loading agents") {
+		t.Error("footer must switch away from the loading text once done")
+	}
+}
+
+func TestPickerLoadingFooterShowsProgress(t *testing.T) {
+	m := pickerModel{loading: true, total: 3, doneCount: 1}
+	view := m.View()
+	if !strings.Contains(view, "loading agents… (1/3)") {
+		t.Errorf("View() = %q, want it to contain the loading progress footer", view)
+	}
+}
+
+func TestPickerEnterDuringLoadingActsOnCurrentRow(t *testing.T) {
+	m := pickerModel{
+		loading:  true,
+		total:    2,
+		sessions: []*model.Session{{Agent: "claude", SessionID: "a"}},
+		titles:   []string{"one"},
+	}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if m.action != actionOpen {
+		t.Fatalf("action = %v, want actionOpen", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after opening a row while still loading")
+	}
+}
+
+func TestPickerQuitDuringLoadingWorks(t *testing.T) {
+	m := pickerModel{loading: true, total: 2}
+	next, cmd := m.Update(keyRune('q'))
+	m = next.(pickerModel)
+	if m.action != actionQuit {
+		t.Fatalf("action = %v, want actionQuit (explicit quit, not actionEmpty)", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit")
+	}
+}
+
+func TestPickerEnterOnEmptyListDuringLoadingIsNoop(t *testing.T) {
+	m := pickerModel{loading: true, total: 2}
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("enter on an empty (still loading) list must not quit")
+	}
+	if m.action != actionQuit {
+		t.Fatalf("action = %v, want the zero value actionQuit (no-op)", m.action)
+	}
+}
+
+func TestPickerCKeyOnEmptyListDuringLoadingIsNoop(t *testing.T) {
+	m := pickerModel{loading: true, total: 2}
+	next, cmd := m.Update(keyRune('c'))
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("c on an empty (still loading) list must not quit")
+	}
+	if m.action != actionQuit {
+		t.Fatalf("action = %v, want the zero value actionQuit (no-op)", m.action)
 	}
 }

--- a/internal/sessions/picker_test.go
+++ b/internal/sessions/picker_test.go
@@ -499,3 +499,135 @@ func TestPickerCKeyOnEmptyListDuringLoadingIsNoop(t *testing.T) {
 		t.Fatalf("action = %v, want the zero value actionQuit (no-op)", m.action)
 	}
 }
+
+// --- decisive-key vs concurrent-batch race ---
+//
+// A batch can be in flight on p.msgs at the exact moment the user presses
+// enter/c: both a sessionBatchMsg and the QuitMsg produced by tea.Quit
+// travel through the same channel, and Update processes messages strictly
+// in receive order, so a batch that was sent before the key but read after
+// it (or vice versa) is a legitimate interleaving, not a bug in bubbletea.
+// If a late batch re-sorts the list and relocateCursor pins cursor 0 to a
+// brand new top row, re-deriving the chosen session from sessions[cursor]
+// after the fact returns a DIFFERENT session than the one the user actually
+// acted on. These tests drive Update with the exact ordering: a batch
+// lands, the user decides on the row it's now looking at, then a second,
+// newer batch that would displace that row from the top arrives. The
+// decision must survive untouched.
+
+func TestPickerEnterFreezesSelectionAgainstLaterBatch(t *testing.T) {
+	now := time.Now()
+	m := pickerModel{loading: true, total: 2}
+
+	// Batch A lands: session "a" is the only (so top) row.
+	next, _ := m.Update(sessionBatchMsg{
+		sessions: []*model.Session{{Agent: "claude", SessionID: "a", LastActivity: now.Add(-time.Hour)}},
+		titles:   []string{"A"},
+	})
+	m = next.(pickerModel)
+
+	// The user decides on the row they're looking at (session "a", cursor 0).
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(pickerModel)
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after opening")
+	}
+	if m.action != actionOpen {
+		t.Fatalf("action = %v, want actionOpen", m.action)
+	}
+	if m.chosen == nil || m.chosen.SessionID != "a" {
+		t.Fatalf("chosen = %v, want session a", m.chosen)
+	}
+
+	// Batch B "arrives late": a NEWER session that would sort ahead of "a",
+	// displacing it from row 0.
+	next, cmd = m.Update(sessionBatchMsg{
+		sessions: []*model.Session{{Agent: "codex", SessionID: "b", LastActivity: now}},
+		titles:   []string{"B"},
+	})
+	m = next.(pickerModel)
+
+	if cmd != nil {
+		t.Fatal("a batch arriving after a terminal decision must not produce a command")
+	}
+	if m.chosen == nil || m.chosen.SessionID != "a" {
+		t.Fatalf("chosen after the late batch = %v, want still session a", m.chosen)
+	}
+	if len(m.sessions) != 1 || m.sessions[0].SessionID != "a" {
+		t.Fatalf("sessions must not be re-merged after a terminal decision, got %#v", m.sessions)
+	}
+}
+
+func TestPickerCKeyFreezesSelectionAgainstLaterBatch(t *testing.T) {
+	now := time.Now()
+	m := pickerModel{loading: true, total: 2}
+
+	// Batch A: an opencode session (copyable, not directly executable) is
+	// the only, so top, row.
+	next, _ := m.Update(sessionBatchMsg{
+		sessions: []*model.Session{{Agent: "opencode", SessionID: "a", LastActivity: now.Add(-time.Hour)}},
+		titles:   []string{"A"},
+	})
+	m = next.(pickerModel)
+
+	next, cmd := m.Update(keyRune('c'))
+	m = next.(pickerModel)
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after copy")
+	}
+	if m.action != actionCopy {
+		t.Fatalf("action = %v, want actionCopy", m.action)
+	}
+	if m.chosen == nil || m.chosen.SessionID != "a" {
+		t.Fatalf("chosen = %v, want session a", m.chosen)
+	}
+
+	next, cmd = m.Update(sessionBatchMsg{
+		sessions: []*model.Session{{Agent: "codex", SessionID: "b", LastActivity: now}},
+		titles:   []string{"B"},
+	})
+	m = next.(pickerModel)
+
+	if cmd != nil {
+		t.Fatal("a batch arriving after a terminal decision must not produce a command")
+	}
+	if m.chosen == nil || m.chosen.SessionID != "a" {
+		t.Fatalf("chosen after the late batch = %v, want still session a", m.chosen)
+	}
+}
+
+func TestPickerQuitFreezesAgainstLaterBatch(t *testing.T) {
+	m := pickerModel{loading: true, total: 2}
+	next, cmd := m.Update(keyRune('q'))
+	m = next.(pickerModel)
+	if cmd == nil || m.action != actionQuit {
+		t.Fatalf("expected actionQuit + tea.Quit, got action=%v cmd=%v", m.action, cmd)
+	}
+
+	next, cmd = m.Update(sessionBatchMsg{sessions: []*model.Session{{SessionID: "z"}}, titles: []string{"Z"}})
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("a batch arriving after quit must not produce a command")
+	}
+	if len(m.sessions) != 0 {
+		t.Fatalf("sessions must stay empty once quit was decided, got %#v", m.sessions)
+	}
+}
+
+func TestPickerStreamDoneFreezesAfterDecision(t *testing.T) {
+	m := pickerModel{loading: true, total: 1}
+	next, cmd := m.Update(keyRune('q'))
+	m = next.(pickerModel)
+	if cmd == nil {
+		t.Fatal("expected tea.Quit")
+	}
+
+	next, cmd = m.Update(streamDoneMsg{})
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("streamDoneMsg arriving after a decision must not produce a command")
+	}
+	if m.action != actionQuit {
+		t.Fatalf("action must stay actionQuit, got %v (must not flip to actionEmpty)", m.action)
+	}
+}

--- a/internal/sessions/picker_test.go
+++ b/internal/sessions/picker_test.go
@@ -1,6 +1,7 @@
 package sessions
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -119,6 +120,146 @@ func TestTitleFor(t *testing.T) {
 	}
 	if got := titleFor(&model.Session{}, ""); got != "(no messages)" {
 		t.Errorf("fallback, got %q", got)
+	}
+}
+
+func TestPickerCKeyOnGrokShowsStatusAndStaysOpen(t *testing.T) {
+	m := pickerModel{sessions: []*model.Session{{Agent: "grok", SessionID: "g"}}, titles: []string{"t"}}
+	next, cmd := m.Update(keyRune('c'))
+	m = next.(pickerModel)
+	if cmd != nil {
+		t.Fatal("picker must stay open when the row has no resume command")
+	}
+	if m.status == "" {
+		t.Fatal("expected a status message for grok")
+	}
+	if m.action == actionCopy {
+		t.Fatal("action must not be actionCopy when there is nothing to copy")
+	}
+}
+
+func TestPickerCKeyOnCopyableSessionCopiesAndQuits(t *testing.T) {
+	// opencode has a display resume command (copyable) but no executable argv.
+	m := pickerModel{sessions: []*model.Session{{Agent: "opencode", SessionID: "o"}}, titles: []string{"t"}}
+	next, cmd := m.Update(keyRune('c'))
+	m = next.(pickerModel)
+	if m.action != actionCopy {
+		t.Fatalf("action = %v, want actionCopy", m.action)
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit after copy")
+	}
+}
+
+func TestPickerArrowAliasNavigation(t *testing.T) {
+	m := pickerModel{
+		sessions: []*model.Session{
+			{Agent: "claude", SessionID: "a"},
+			{Agent: "claude", SessionID: "b"},
+		},
+		titles: []string{"one", "two"},
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(pickerModel)
+	if m.cursor != 1 {
+		t.Fatalf("down arrow: cursor = %d, want 1", m.cursor)
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = next.(pickerModel)
+	if m.cursor != 0 {
+		t.Fatalf("up arrow: cursor = %d, want 0", m.cursor)
+	}
+}
+
+func TestVisibleRangeWithinHeightReturnsFullRange(t *testing.T) {
+	start, end := visibleRange(2, 5, 20)
+	if start != 0 || end != 5 {
+		t.Errorf("visibleRange(2,5,20) = (%d,%d), want (0,5)", start, end)
+	}
+}
+
+func TestVisibleRangeAtTop(t *testing.T) {
+	start, end := visibleRange(0, 100, 10)
+	if start != 0 || end != 10 {
+		t.Errorf("visibleRange(0,100,10) = (%d,%d), want (0,10)", start, end)
+	}
+}
+
+func TestVisibleRangeAtBottom(t *testing.T) {
+	start, end := visibleRange(99, 100, 10)
+	if start != 90 || end != 100 {
+		t.Errorf("visibleRange(99,100,10) = (%d,%d), want (90,100)", start, end)
+	}
+}
+
+func TestVisibleRangeInMiddleIsCentered(t *testing.T) {
+	start, end := visibleRange(50, 100, 10)
+	if start != 45 || end != 55 {
+		t.Errorf("visibleRange(50,100,10) = (%d,%d), want (45,55)", start, end)
+	}
+}
+
+func TestVisibleRangeCursorAlwaysWithinWindow(t *testing.T) {
+	total := 100
+	height := 7
+	for cursor := 0; cursor < total; cursor++ {
+		start, end := visibleRange(cursor, total, height)
+		if cursor < start || cursor >= end {
+			t.Fatalf("cursor %d out of window [%d,%d)", cursor, start, end)
+		}
+		if end-start > height {
+			t.Fatalf("window [%d,%d) exceeds height %d", start, end, height)
+		}
+	}
+}
+
+func TestPickerWindowFollowsCursorAfterWindowSizeMsg(t *testing.T) {
+	sessions := make([]*model.Session, 30)
+	titles := make([]string, 30)
+	for i := range sessions {
+		sessions[i] = &model.Session{Agent: "claude", SessionID: fmt.Sprintf("s%d", i)}
+		titles[i] = fmt.Sprintf("session %d", i)
+	}
+	m := pickerModel{sessions: sessions, titles: titles}
+
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 15})
+	m = next.(pickerModel)
+	if m.height != 15 {
+		t.Fatalf("height = %d, want 15", m.height)
+	}
+
+	// Cursor starts at 0: the window must start at 0.
+	budget := m.rowBudget()
+	start, end := visibleRange(m.cursor, len(m.sessions), budget)
+	if start != 0 {
+		t.Fatalf("initial window start = %d, want 0", start)
+	}
+	if m.cursor < start || m.cursor >= end {
+		t.Fatalf("cursor %d not within initial window [%d,%d)", m.cursor, start, end)
+	}
+
+	// Drive the cursor to the bottom; the window must follow and reach the end.
+	for i := 0; i < len(sessions)-1; i++ {
+		next, _ = m.Update(keyRune('j'))
+		m = next.(pickerModel)
+	}
+	if m.cursor != len(sessions)-1 {
+		t.Fatalf("cursor = %d, want %d", m.cursor, len(sessions)-1)
+	}
+	budget = m.rowBudget()
+	start, end = visibleRange(m.cursor, len(m.sessions), budget)
+	if m.cursor < start || m.cursor >= end {
+		t.Fatalf("cursor %d not within window [%d,%d) at bottom", m.cursor, start, end)
+	}
+	if end != len(sessions) {
+		t.Fatalf("window should reach the end when cursor is at the bottom, got end=%d", end)
+	}
+}
+
+func TestPickerRowBudgetFallsBackWhenHeightUnknown(t *testing.T) {
+	m := pickerModel{}
+	if got := m.rowBudget(); got != defaultVisibleRows {
+		t.Errorf("rowBudget() with unknown height = %d, want %d", got, defaultVisibleRows)
 	}
 }
 

--- a/internal/sessions/picker_test.go
+++ b/internal/sessions/picker_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/illegalstudio/lazyagent/internal/core"
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
 
@@ -629,5 +630,35 @@ func TestPickerStreamDoneFreezesAfterDecision(t *testing.T) {
 	}
 	if m.action != actionQuit {
 		t.Fatalf("action must stay actionQuit, got %v (must not flip to actionEmpty)", m.action)
+	}
+}
+
+// --- memberCount (pure) ---
+
+// noopProvider is a minimal core.SessionProvider that does nothing; used
+// only to stand in as a "single, non-multi" provider for memberCount.
+type noopProvider struct{}
+
+func (noopProvider) DiscoverSessions() ([]*model.Session, error) { return nil, nil }
+func (noopProvider) UseWatcher() bool                            { return false }
+func (noopProvider) RefreshInterval() time.Duration              { return 0 }
+func (noopProvider) WatchDirs() []string                         { return nil }
+
+func TestMemberCountSingleNonMultiProviderIsOne(t *testing.T) {
+	if got := memberCount(noopProvider{}); got != 1 {
+		t.Errorf("memberCount(noopProvider{}) = %d, want 1", got)
+	}
+}
+
+func TestMemberCountMultiProviderIsProviderCount(t *testing.T) {
+	mp := core.MultiProvider{Providers: []core.SessionProvider{noopProvider{}, noopProvider{}, noopProvider{}}}
+	if got := memberCount(mp); got != 3 {
+		t.Errorf("memberCount(3-provider MultiProvider) = %d, want 3", got)
+	}
+}
+
+func TestMemberCountEmptyMultiProviderIsZero(t *testing.T) {
+	if got := memberCount(core.MultiProvider{}); got != 0 {
+		t.Errorf("memberCount(empty MultiProvider) = %d, want 0", got)
 	}
 }

--- a/internal/sessions/picker_test.go
+++ b/internal/sessions/picker_test.go
@@ -121,3 +121,16 @@ func TestTitleFor(t *testing.T) {
 		t.Errorf("fallback, got %q", got)
 	}
 }
+
+func TestRunPickerEmptyList(t *testing.T) {
+	s, action, err := runPicker(nil, nil, "x")
+	if s != nil {
+		t.Errorf("session = %v, want nil", s)
+	}
+	if action != actionQuit {
+		t.Errorf("action = %v, want actionQuit", action)
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}

--- a/internal/sessions/picker_test.go
+++ b/internal/sessions/picker_test.go
@@ -263,15 +263,89 @@ func TestPickerRowBudgetFallsBackWhenHeightUnknown(t *testing.T) {
 	}
 }
 
-func TestRunPickerEmptyList(t *testing.T) {
-	s, action, err := runPicker(nil, nil, "x")
-	if s != nil {
-		t.Errorf("session = %v, want nil", s)
+// --- mergeSessions (pure) ---
+
+func TestMergeSessionsSortsOutOfOrderBatches(t *testing.T) {
+	now := time.Now()
+	sessions := []*model.Session{{SessionID: "a", LastActivity: now.Add(-time.Hour)}}
+	titles := []string{"A"}
+
+	// Incoming batch is MORE recent than what's already merged -- out-of-
+	// order arrival relative to final sort order.
+	batchSessions := []*model.Session{{SessionID: "b", LastActivity: now}}
+	batchTitles := []string{"B"}
+
+	gotSessions, gotTitles := mergeSessions(sessions, titles, batchSessions, batchTitles)
+	if len(gotSessions) != 2 {
+		t.Fatalf("len = %d, want 2", len(gotSessions))
 	}
-	if action != actionQuit {
-		t.Errorf("action = %v, want actionQuit", action)
+	if gotSessions[0].SessionID != "b" || gotSessions[1].SessionID != "a" {
+		t.Fatalf("sessions = [%s, %s], want [b, a] (most recent first)", gotSessions[0].SessionID, gotSessions[1].SessionID)
 	}
-	if err != nil {
-		t.Errorf("err = %v, want nil", err)
+	if gotTitles[0] != "B" || gotTitles[1] != "A" {
+		t.Fatalf("titles = %v, want [B, A] (must stay zipped with sessions after sort)", gotTitles)
+	}
+}
+
+func TestMergeSessionsKeepsTitlesZippedWithSessions(t *testing.T) {
+	now := time.Now()
+	sessions := []*model.Session{
+		{SessionID: "mid", LastActivity: now.Add(-time.Hour)},
+	}
+	titles := []string{"mid-title"}
+	batchSessions := []*model.Session{
+		{SessionID: "newest", LastActivity: now},
+		{SessionID: "oldest", LastActivity: now.Add(-2 * time.Hour)},
+	}
+	batchTitles := []string{"newest-title", "oldest-title"}
+
+	gotSessions, gotTitles := mergeSessions(sessions, titles, batchSessions, batchTitles)
+	wantOrder := []string{"newest", "mid", "oldest"}
+	for i, id := range wantOrder {
+		if gotSessions[i].SessionID != id {
+			t.Fatalf("sessions[%d] = %s, want %s", i, gotSessions[i].SessionID, id)
+		}
+		if gotTitles[i] != id+"-title" {
+			t.Fatalf("titles[%d] = %s, want %s", i, gotTitles[i], id+"-title")
+		}
+	}
+}
+
+// --- relocateCursor (pure) ---
+
+func TestRelocateCursorFollowsSelectedSession(t *testing.T) {
+	prev := []*model.Session{{SessionID: "x"}, {SessionID: "y"}}
+	// User had navigated down to "y" (cursor 1). A merge reorders the list
+	// so "y" is now first.
+	merged := []*model.Session{{SessionID: "y"}, {SessionID: "z"}, {SessionID: "x"}}
+	if got := relocateCursor(prev, 1, merged); got != 0 {
+		t.Errorf("relocateCursor = %d, want 0 (cursor must follow the selected session)", got)
+	}
+}
+
+func TestRelocateCursorStaysAtTopWhenNotNavigated(t *testing.T) {
+	prev := []*model.Session{{SessionID: "x"}, {SessionID: "y"}}
+	// cursor is still 0 (user hasn't navigated): the merge reorders the
+	// list, but the cursor must stay pinned to the top regardless of
+	// identity.
+	merged := []*model.Session{{SessionID: "y"}, {SessionID: "x"}, {SessionID: "z"}}
+	if got := relocateCursor(prev, 0, merged); got != 0 {
+		t.Errorf("relocateCursor = %d, want 0 (must stay at top when not navigated)", got)
+	}
+}
+
+func TestRelocateCursorClampsWhenSelectedSessionDisappears(t *testing.T) {
+	prev := []*model.Session{{SessionID: "x"}, {SessionID: "y"}}
+	// "y" (cursor 1) is no longer present in merged.
+	merged := []*model.Session{{SessionID: "x"}}
+	if got := relocateCursor(prev, 1, merged); got != 0 {
+		t.Errorf("relocateCursor = %d, want 0 (clamp to the last valid index)", got)
+	}
+}
+
+func TestRelocateCursorOnEmptyMergedIsZero(t *testing.T) {
+	prev := []*model.Session{{SessionID: "x"}}
+	if got := relocateCursor(prev, 0, nil); got != 0 {
+		t.Errorf("relocateCursor = %d, want 0", got)
 	}
 }

--- a/internal/sessions/run_test.go
+++ b/internal/sessions/run_test.go
@@ -1,0 +1,21 @@
+package sessions
+
+import "testing"
+
+func TestRunRejectsUnknownAgent(t *testing.T) {
+	if code := Run([]string{"--agent", "nope"}); code != 2 {
+		t.Errorf("unknown agent: exit = %d, want 2", code)
+	}
+}
+
+func TestRunRejectsMissingDir(t *testing.T) {
+	if code := Run([]string{"--dir", "/nonexistent-lazyagent-test-dir"}); code != 2 {
+		t.Errorf("missing dir: exit = %d, want 2", code)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	if code := Run([]string{"--help"}); code != 0 {
+		t.Errorf("--help: exit = %d, want 0", code)
+	}
+}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -76,9 +76,14 @@ Flags:
 
 	// Persistence is advisory and best-effort: when the user cache
 	// directory can't be resolved, discovery just runs cold, exactly as
-	// before this existed. Only the sessions subcommand wires this up (the
-	// TUI/GUI/API keep their in-memory-only behavior).
-	cacheDir, hasCacheDir := resolveCacheDir()
+	// before this existed. This subcommand wires Load/Save explicitly
+	// (below and around the picker) rather than through
+	// core.SessionManager.EnableCachePersistence -- the mechanism the
+	// long-lived surfaces (TUI/GUI/API) use -- because it needs save points
+	// tied to this command's own control flow (e.g. skipping the save when
+	// the interactive picker exits before its background discovery stream
+	// finishes; see runInteractive).
+	cacheDir, hasCacheDir := ResolveCacheDir()
 	if hasCacheDir {
 		core.LoadProviderCaches(provider, cacheDir)
 	}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -104,7 +104,7 @@ Flags:
 		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
 		return 0
 	}
-	if !isatty.IsTerminal(os.Stdin.Fd()) {
+	if !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stderr.Fd()) {
 		fmt.Fprintln(os.Stderr, "Error: the interactive picker needs a terminal (use --json for scripted output)")
 		return 2
 	}
@@ -161,7 +161,7 @@ func openSession(s *model.Session) int {
 // abbreviateHome shortens a path with the user's home directory to ~/...
 func abbreviateHome(path string) string {
 	home, err := os.UserHomeDir()
-	if err == nil && home != "" && strings.HasPrefix(path, home) {
+	if err == nil && home != "" && (path == home || strings.HasPrefix(path, home+"/")) {
 		return "~" + strings.TrimPrefix(path, home)
 	}
 	return path

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -1,0 +1,168 @@
+package sessions
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/illegalstudio/lazyagent/internal/chatops"
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+	"github.com/mattn/go-isatty"
+)
+
+var validAgents = map[string]bool{
+	"claude": true, "pi": true, "opencode": true, "kilo": true, "cursor": true,
+	"codex": true, "amp": true, "grok": true, "kimi": true, "all": true,
+}
+
+// Run implements `lazyagent sessions`. It lists the sessions recorded for
+// the current (or --dir) directory across agents and reopens the chosen one.
+func Run(args []string) int {
+	fs := flag.NewFlagSet("sessions", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	agent := fs.String("agent", "all", "Agent to list: claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, all")
+	jsonOut := fs.Bool("json", false, "Print the session list as JSON and exit")
+	dirFlag := fs.String("dir", "", "List sessions for this directory instead of the current one")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `lazyagent sessions — list sessions for a directory and reopen one
+
+Lists every recorded session whose working directory is the current
+directory (or --dir) or a subdirectory of it, across all agents.
+Selecting a session resumes it with the originating agent's CLI.
+
+Usage:
+  lazyagent sessions
+  lazyagent sessions --agent claude
+  lazyagent sessions --json
+  lazyagent sessions --dir ~/projects/foo
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	if !validAgents[*agent] {
+		fmt.Fprintf(os.Stderr, "Error: unknown --agent value %q (use claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, or all)\n", *agent)
+		return 2
+	}
+
+	dir := *dirFlag
+	if dir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: cannot determine working directory: %v\n", err)
+			return 2
+		}
+		dir = wd
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "Error: %q is not a directory\n", dir)
+		return 2
+	}
+
+	cfg := core.LoadConfig()
+	provider := core.BuildProvider(*agent, cfg)
+	all, err := provider.DiscoverSessions()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	filtered, err := FilterByDir(all, dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+
+	names := core.NewSessionNames()
+	nameFor := func(s *model.Session) string {
+		if alias := names.Get(s.SessionID); alias != "" {
+			return alias
+		}
+		return s.Name
+	}
+
+	if *jsonOut {
+		if err := writeJSON(os.Stdout, filtered, nameFor); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	if len(filtered) == 0 {
+		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
+		return 0
+	}
+	if !isatty.IsTerminal(os.Stdin.Fd()) {
+		fmt.Fprintln(os.Stderr, "Error: the interactive picker needs a terminal (use --json for scripted output)")
+		return 2
+	}
+
+	titles := make([]string, len(filtered))
+	for i, s := range filtered {
+		titles[i] = titleFor(s, names.Get(s.SessionID))
+	}
+	chosen, action, err := runPicker(filtered, titles, abbreviateHome(dir))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	switch action {
+	case actionOpen:
+		return openSession(chosen)
+	case actionCopy:
+		cmdStr := core.ResumeCommand(chosen.Agent, chosen.SessionID)
+		if err := core.CopyToClipboard(cmdStr); err != nil {
+			fmt.Fprintf(os.Stderr, "Copy failed: %v\nCommand: %s\n", err, cmdStr)
+			return 1
+		}
+		fmt.Fprintf(os.Stderr, "Copied to clipboard: %s\n", cmdStr)
+	}
+	return 0
+}
+
+// openSession execs the agent's resume command in the current terminal,
+// running from the session's own CWD when it still exists (claude --resume
+// locates sessions by project directory).
+func openSession(s *model.Session) int {
+	argv := core.ResumeArgv(s.Agent, s.SessionID)
+	if argv == nil {
+		fmt.Fprintf(os.Stderr, "No resume command available for %s sessions.\n", s.Agent)
+		return 1
+	}
+	cmd := exec.Command(argv[0], argv[1:]...)
+	if s.CWD != "" {
+		if info, err := os.Stat(s.CWD); err == nil && info.IsDir() {
+			cmd.Dir = s.CWD
+		}
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	fmt.Fprintf(os.Stderr, "%s %s\n", chatops.StyleMuted.Render("Opening:"), core.ResumeCommand(s.Agent, s.SessionID))
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// abbreviateHome shortens a path with the user's home directory to ~/...
+func abbreviateHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" && strings.HasPrefix(path, home) {
+		return "~" + strings.TrimPrefix(path, home)
+	}
+	return path
+}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -98,6 +98,15 @@ Flags:
 	// complete, byte-identical list, and without a TTY there is no
 	// progressive rendering to benefit from, so both of those keep using
 	// the plain blocking flow below unchanged.
+	//
+	// Accepted divergence from that blocking flow: core.DiscoverMatchingStream
+	// has no error channel (best-effort by design, the same swallow
+	// semantics MultiProvider's fan-out already has in the default "all"
+	// mode), so here a single misconfigured provider's hard error is
+	// indistinguishable from "found nothing" -- it surfaces as an empty
+	// listing (exit 0) rather than the sharp "Error: ..." + exit 1 that
+	// --json and the no-TTY fallback below still give. Signed off as
+	// acceptable specifically for the interactive path.
 	if !*jsonOut && isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stderr.Fd()) {
 		return runInteractive(provider, match, dir, names, hasCacheDir, cacheDir)
 	}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -74,6 +74,15 @@ Flags:
 	cfg := core.LoadConfig()
 	provider := core.BuildProvider(*agent, cfg)
 
+	// Persistence is advisory and best-effort: when the user cache
+	// directory can't be resolved, discovery just runs cold, exactly as
+	// before this existed. Only the sessions subcommand wires this up (the
+	// TUI/GUI/API keep their in-memory-only behavior).
+	cacheDir, hasCacheDir := resolveCacheDir()
+	if hasCacheDir {
+		core.LoadProviderCaches(provider, cacheDir)
+	}
+
 	variants, err := targetVariants(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -85,6 +94,12 @@ Flags:
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
+	}
+	// Save right after a successful discovery, reached by both the --json
+	// and interactive-picker paths below, and even when zero sessions were
+	// found. Never reached on a discovery error (the return above).
+	if hasCacheDir {
+		core.SaveProviderCaches(provider, cacheDir)
 	}
 	filtered, err := FilterByDir(all, dir)
 	if err != nil {

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -89,15 +89,29 @@ Flags:
 		return 1
 	}
 	match := func(cwd string) bool { return matchesDir(cwd, variants) }
+	names := core.NewSessionNames()
+
+	// Interactive picker path: open immediately and stream discovery
+	// results in as agents finish (see runPicker), instead of blocking on
+	// a full discovery first. This only applies when we're actually about
+	// to show a picker on a real terminal -- --json always wants the
+	// complete, byte-identical list, and without a TTY there is no
+	// progressive rendering to benefit from, so both of those keep using
+	// the plain blocking flow below unchanged.
+	if !*jsonOut && isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stderr.Fd()) {
+		return runInteractive(provider, match, dir, names, hasCacheDir, cacheDir)
+	}
 
 	all, err := core.DiscoverMatching(provider, match)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
 	}
-	// Save right after a successful discovery, reached by both the --json
-	// and interactive-picker paths below, and even when zero sessions were
-	// found. Never reached on a discovery error (the return above).
+	// Save right after a successful discovery, reached by --json and by
+	// the non-interactive (no-TTY) fallback below, and even when zero
+	// sessions were found. Never reached on a discovery error (the return
+	// above). The interactive picker path above has its own, later save
+	// point tied to stream completion -- see runInteractive.
 	if hasCacheDir {
 		core.SaveProviderCaches(provider, cacheDir)
 	}
@@ -107,15 +121,13 @@ Flags:
 		return 1
 	}
 
-	names := core.NewSessionNames()
-	nameFor := func(s *model.Session) string {
-		if alias := names.Get(s.SessionID); alias != "" {
-			return alias
-		}
-		return s.Name
-	}
-
 	if *jsonOut {
+		nameFor := func(s *model.Session) string {
+			if alias := names.Get(s.SessionID); alias != "" {
+				return alias
+			}
+			return s.Name
+		}
 		if err := writeJSON(os.Stdout, filtered, nameFor); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return 1
@@ -127,32 +139,61 @@ Flags:
 		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
 		return 0
 	}
-	if !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stderr.Fd()) {
-		fmt.Fprintln(os.Stderr, "Error: the interactive picker needs a terminal (use --json for scripted output)")
-		return 2
-	}
+	fmt.Fprintln(os.Stderr, "Error: the interactive picker needs a terminal (use --json for scripted output)")
+	return 2
+}
 
-	titles := make([]string, len(filtered))
-	for i, s := range filtered {
-		titles[i] = titleFor(s, names.Get(s.SessionID))
-	}
-	chosen, action, err := runPicker(filtered, titles, abbreviateHome(dir))
+// runInteractive drives the streaming picker path: open the picker
+// immediately, let discovery results stream in, then act on whatever the
+// user chose. The resume/copy action always happens before any cache save
+// (which itself only happens when the stream had already completed by the
+// time the picker exited -- see runPicker's streamComplete and the
+// maybeSave comment below), so a user's chosen action is never delayed by
+// unfinished background discovery.
+func runInteractive(provider core.SessionProvider, match func(string) bool, dir string, names *core.SessionNames, hasCacheDir bool, cacheDir string) int {
+	dirLabel := abbreviateHome(dir)
+	chosen, action, streamComplete, err := runPicker(provider, match, dir, dirLabel, names)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1
 	}
+
+	// Only persist provider caches when the discovery stream had already
+	// fully finished by the time the picker exited -- if the user quit or
+	// acted early, the providers' in-memory caches may still be getting
+	// mutated by discovery goroutines running in the background (see
+	// runPicker), so saving then would race with them; skipping the save
+	// in that case is acceptable, since the next run just redoes the work.
+	maybeSave := func() {
+		if hasCacheDir && streamComplete {
+			core.SaveProviderCaches(provider, cacheDir)
+		}
+	}
+
 	switch action {
+	case actionEmpty:
+		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", dirLabel)
+		maybeSave()
+		return 0
 	case actionOpen:
-		return openSession(chosen)
+		code := openSession(chosen)
+		maybeSave()
+		return code
 	case actionCopy:
 		cmdStr := core.ResumeCommand(chosen.Agent, chosen.SessionID)
+		code := 0
 		if err := core.CopyToClipboard(cmdStr); err != nil {
 			fmt.Fprintf(os.Stderr, "Copy failed: %v\nCommand: %s\n", err, cmdStr)
-			return 1
+			code = 1
+		} else {
+			fmt.Fprintf(os.Stderr, "Copied to clipboard: %s\n", cmdStr)
 		}
-		fmt.Fprintf(os.Stderr, "Copied to clipboard: %s\n", cmdStr)
+		maybeSave()
+		return code
+	default: // actionQuit
+		maybeSave()
+		return 0
 	}
-	return 0
 }
 
 // openSession execs the agent's resume command in the current terminal,

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -73,7 +73,15 @@ Flags:
 
 	cfg := core.LoadConfig()
 	provider := core.BuildProvider(*agent, cfg)
-	all, err := provider.DiscoverSessions()
+
+	variants, err := targetVariants(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 1
+	}
+	match := func(cwd string) bool { return matchesDir(cwd, variants) }
+
+	all, err := core.DiscoverMatching(provider, match)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 1

--- a/internal/tray/service.go
+++ b/internal/tray/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/demo"
 	"github.com/illegalstudio/lazyagent/internal/limits"
 	"github.com/illegalstudio/lazyagent/internal/model"
+	"github.com/illegalstudio/lazyagent/internal/sessions"
 	"github.com/illegalstudio/lazyagent/internal/version"
 	"github.com/illegalstudio/lazyagent/internal/webhook"
 	"github.com/pkg/browser"
@@ -52,6 +53,9 @@ func (s *SessionService) ServiceStartup(ctx context.Context, options application
 	}
 	s.manager = core.NewSessionManager(cfg.WindowMinutes, provider)
 	s.manager.SetExcludeCWDSubstrings(cfg.ExcludeCWDSubstrings)
+	if dir, ok := sessions.ResolveCacheDir(); ok {
+		s.manager.EnableCachePersistence(dir)
+	}
 	if len(cfg.ValidWebhooks()) > 0 {
 		bus := core.NewEventBus()
 		s.manager.SetEventBus(bus)
@@ -83,7 +87,7 @@ func (s *SessionService) ServiceStartup(ctx context.Context, options application
 
 // ServiceShutdown is called by Wails when the app stops.
 func (s *SessionService) ServiceShutdown() error {
-	s.manager.StopWatcher()
+	s.manager.Close()
 	return nil
 }
 

--- a/internal/tray/service.go
+++ b/internal/tray/service.go
@@ -67,8 +67,15 @@ func (s *SessionService) ServiceStartup(ctx context.Context, options application
 		return err
 	}
 
-	// Initial load
-	_ = s.manager.Reload()
+	// Progressive first load: runs in the background (core.SessionManager.
+	// ReloadStreaming) so ServiceStartup returns immediately instead of
+	// blocking GUI/tray startup on the slowest provider. Each batch calls
+	// emitUpdate, so the frontend's existing "sessions:updated" listener
+	// (App.svelte) re-fetches via GetSessions and the list grows in place —
+	// no frontend change needed, since GetSessions already just returns
+	// whatever's currently in the manager. Subsequent reloads (watchLoop
+	// below) stay synchronous.
+	go s.manager.ReloadStreaming(s.emitUpdate)
 
 	// Background goroutine: watch for file changes + periodic refresh
 	go s.watchLoop()

--- a/internal/tray/service.go
+++ b/internal/tray/service.go
@@ -67,15 +67,24 @@ func (s *SessionService) ServiceStartup(ctx context.Context, options application
 		return err
 	}
 
-	// Progressive first load: runs in the background (core.SessionManager.
-	// ReloadStreaming) so ServiceStartup returns immediately instead of
-	// blocking GUI/tray startup on the slowest provider. Each batch calls
-	// emitUpdate, so the frontend's existing "sessions:updated" listener
-	// (App.svelte) re-fetches via GetSessions and the list grows in place —
-	// no frontend change needed, since GetSessions already just returns
-	// whatever's currently in the manager. Subsequent reloads (watchLoop
-	// below) stay synchronous.
-	go s.manager.ReloadStreaming(s.emitUpdate)
+	// Progressive first load: BeginReloadStreaming synchronously marks the
+	// stream as in-flight (core.SessionManager's streamInFlight guard)
+	// BEFORE watchLoop starts below -- watchLoop's ticker/event cases call
+	// Reload/UpdateActivities unconditionally on every tick or file event,
+	// so this ordering is what actually prevents a race: a bare
+	// `go s.manager.ReloadStreaming(...)` followed immediately by
+	// `go s.watchLoop()` could not otherwise guarantee the guard is active
+	// before watchLoop's first tick or an already-queued watcher event (the
+	// watcher was started above, so its channel can already have one
+	// buffered) gets processed. The actual (potentially slow) discovery
+	// work still runs in the background so ServiceStartup returns
+	// immediately. Each batch calls emitUpdate, so the frontend's existing
+	// "sessions:updated" listener (App.svelte) re-fetches via GetSessions
+	// and the list grows in place — no frontend change needed, since
+	// GetSessions already just returns whatever's currently in the
+	// manager. Subsequent reloads (watchLoop below) stay synchronous.
+	run := s.manager.BeginReloadStreaming()
+	go run(s.emitUpdate)
 
 	// Background goroutine: watch for file changes + periodic refresh
 	go s.watchLoop()

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -194,7 +194,19 @@ func (m Model) Init() tea.Cmd {
 	// provider member completes instead of waiting for the slowest one.
 	// Subsequent reloads (below, watcher/tick-driven) stay synchronous via
 	// makeLoadCmd/Reload -- they're incremental-fast already.
-	cmds := []tea.Cmd{startStreamingLoadCmd(m.manager), renderTickCmd(), checkUpdateCmd()}
+	//
+	// BeginReloadStreaming is called synchronously, right here, BEFORE any
+	// Cmd in this batch is dispatched -- including watchCmd, whose channel
+	// can already have a queued event waiting (StartWatcher ran earlier, in
+	// NewModel). That ordering is what actually guarantees
+	// core.SessionManager's streamInFlight guard is active before a watcher
+	// event or the first tick could otherwise race the stream's own
+	// startup; deferring the flag-set into a goroutine spawned by one of
+	// these Cmds would not give the same guarantee (Go makes no promise a
+	// spawned goroutine's first statement runs before a sibling Cmd's
+	// does). See BeginReloadStreaming's doc for the full reasoning.
+	run := m.manager.BeginReloadStreaming()
+	cmds := []tea.Cmd{runStreamingLoadCmd(run), renderTickCmd(), checkUpdateCmd()}
 	if events := m.manager.WatcherEvents(); events != nil {
 		cmds = append(cmds, watchCmd(events))
 	} else {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/core"
 	"github.com/illegalstudio/lazyagent/internal/limits"
 	"github.com/illegalstudio/lazyagent/internal/model"
+	"github.com/illegalstudio/lazyagent/internal/sessions"
 	"github.com/illegalstudio/lazyagent/internal/version"
 )
 
@@ -150,6 +151,9 @@ func NewModel(provider core.SessionProvider, bus *core.EventBus) Model {
 	if bus != nil {
 		mgr.SetEventBus(bus)
 	}
+	if dir, ok := sessions.ResolveCacheDir(); ok {
+		mgr.EnableCachePersistence(dir)
+	}
 	_ = mgr.StartWatcher()
 	return Model{
 		theme:     t,
@@ -158,6 +162,13 @@ func NewModel(provider core.SessionProvider, bus *core.EventBus) Model {
 		loading:   true,
 		manager:   mgr,
 	}
+}
+
+// Manager returns the underlying SessionManager so callers (main.go) can run
+// shutdown logic — e.g. Close(), which flushes the persisted discovery cache
+// if EnableCachePersistence was used — after the bubbletea program exits.
+func (m Model) Manager() *core.SessionManager {
+	return m.manager
 }
 
 func checkUpdateCmd() tea.Cmd {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -66,6 +66,14 @@ type Model struct {
 	listOffset   int
 	detailOffset int
 
+	// Progressive first load (see streaming.go): the update/done channels
+	// startStreamingLoadCmd created for the in-flight
+	// core.SessionManager.ReloadStreaming call, so streamNextCmd can keep
+	// waiting on them across repeated Update calls until the stream
+	// finishes.
+	streamUpdates <-chan struct{}
+	streamDone    <-chan struct{}
+
 	width  int
 	height int
 
@@ -181,7 +189,12 @@ func checkUpdateCmd() tea.Cmd {
 }
 
 func (m Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{makeLoadCmd(m.manager), renderTickCmd(), checkUpdateCmd()}
+	// The initial load is the manager's progressive first load (see
+	// streaming.go) rather than a plain Reload: sessions appear as each
+	// provider member completes instead of waiting for the slowest one.
+	// Subsequent reloads (below, watcher/tick-driven) stay synchronous via
+	// makeLoadCmd/Reload -- they're incremental-fast already.
+	cmds := []tea.Cmd{startStreamingLoadCmd(m.manager), renderTickCmd(), checkUpdateCmd()}
 	if events := m.manager.WatcherEvents(); events != nil {
 		cmds = append(cmds, watchCmd(events))
 	} else {
@@ -237,6 +250,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fileWatchMsg:
 		// A JSONL file changed — reload immediately and re-arm the watcher.
+		// If the progressive first load is still in flight, Reload() is a
+		// no-op (core.SessionManager absorbs it — see streamInFlight) rather
+		// than racing the stream's own merges; the sessionsMsg this produces
+		// still carries whatever's currently in the manager and is handled
+		// exactly like any other reload below.
 		return m, tea.Batch(makeLoadCmd(m.manager), watchCmd(m.manager.WatcherEvents()))
 
 	case renderTickMsg:
@@ -250,33 +268,39 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(makeLoadCmd(m.manager), tickCmd())
 
 	case sessionsMsg:
-		m.loading = false
+		// Deliberately does NOT touch m.loading: during the progressive
+		// first load, only streamDoneMsg (below) may clear it — a
+		// watcher/tick-driven reload landing mid-stream must not make the
+		// loading indicator disappear early (see fileWatchMsg above).
 		m.lastRefresh = time.Now()
 		if msg.err != nil {
 			m.err = msg.err
 		} else {
-			m.refreshVisible()
-			// Try to restore selection by session ID.
-			found := false
-			if m.selectedID != "" {
-				for i, s := range m.visible {
-					if s.SessionID == m.selectedID {
-						m.cursor = i
-						found = true
-						break
-					}
-				}
-			}
-			if !found {
-				if n := len(m.visible); m.cursor >= n && n > 0 {
-					m.cursor = n - 1
-				}
-				if len(m.visible) > 0 {
-					m.selectedID = m.visible[m.cursor].SessionID
-				}
-			}
-			m.ensureListVisible()
+			m.afterSessionsUpdate()
 		}
+
+	case streamStartedMsg:
+		// The progressive first load's background goroutine is running;
+		// remember its channels so streamNextCmd can keep waiting on them
+		// across every subsequent batch/done message.
+		m.streamUpdates = msg.updates
+		m.streamDone = msg.done
+		return m, streamNextCmd(msg.updates, msg.done)
+
+	case streamBatchMsg:
+		// A provider member's sessions were just merged into the manager —
+		// re-render with whatever's accumulated so far and keep waiting for
+		// the next batch or completion. loading stays true.
+		m.afterSessionsUpdate()
+		return m, streamNextCmd(m.streamUpdates, m.streamDone)
+
+	case streamDoneMsg:
+		// The stream has finished — every provider member has completed (or
+		// failed; best-effort). This is the only thing that clears loading.
+		m.loading = false
+		m.lastRefresh = time.Now()
+		m.afterSessionsUpdate()
+		return m, nil
 
 	case tea.MouseMsg:
 		if !m.searchMode {
@@ -632,6 +656,36 @@ func (m *Model) refreshVisible() {
 	m.visible = m.manager.VisibleSessions()
 }
 
+// afterSessionsUpdate recomputes the visible list and preserves cursor
+// selection by session ID (or clamps into range if the previously selected
+// session disappeared) whenever the underlying session set changes — shared
+// by the periodic-reload sessionsMsg handler and the progressive
+// first-load's streamBatchMsg/streamDoneMsg handlers, which all need
+// identical selection-preserving behavior each time the manager's snapshot
+// grows or is replaced.
+func (m *Model) afterSessionsUpdate() {
+	m.refreshVisible()
+	found := false
+	if m.selectedID != "" {
+		for i, s := range m.visible {
+			if s.SessionID == m.selectedID {
+				m.cursor = i
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		if n := len(m.visible); m.cursor >= n && n > 0 {
+			m.cursor = n - 1
+		}
+		if len(m.visible) > 0 {
+			m.selectedID = m.visible[m.cursor].SessionID
+		}
+	}
+	m.ensureListVisible()
+}
+
 func (m *Model) ensureListVisible() {
 	vis := m.listVisibleRows()
 	if vis <= 0 {
@@ -802,10 +856,16 @@ func (m Model) renderTitleBar() string {
 		title += " v" + version.Version
 	}
 	left := m.sty.title.Render(title)
+	countLabel := fmt.Sprintf("%d sessions [last %dm]", len(m.visible), m.manager.WindowMinutes())
+	if m.loading {
+		// Progressive first load still in flight (see streaming.go) —
+		// disappears the moment streamDoneMsg clears m.loading.
+		countLabel += "  loading…"
+	}
 	count := lipgloss.NewStyle().
 		Background(m.theme.Primary).Foreground(m.theme.TitleSubtext).
 		Padding(0, 1).
-		Render(fmt.Sprintf("%d sessions [last %dm]", len(m.visible), m.manager.WindowMinutes()))
+		Render(countLabel)
 
 	parts := []string{left, count}
 

--- a/internal/ui/streaming.go
+++ b/internal/ui/streaming.go
@@ -2,16 +2,15 @@ package ui
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/illegalstudio/lazyagent/internal/core"
 )
 
 // streamStartedMsg carries the update/done channels a just-launched
-// progressive-first-load goroutine will signal on. core.SessionManager.
-// ReloadStreaming itself has no channel of its own to expose (it just calls
-// onUpdate, like watchCmd's events channel is owned by the watcher) -- these
-// channels are created once, here, for the whole stream, and must be
-// threaded back into the model via Update so later batch/done messages can
-// keep waiting on them.
+// progressive-first-load goroutine will signal on. core.SessionManager's
+// streaming reload itself has no channel of its own to expose (it just
+// calls onUpdate, like watchCmd's events channel is owned by the watcher)
+// -- these channels are created once, here, for the whole stream, and must
+// be threaded back into the model via Update so later batch/done messages
+// can keep waiting on them.
 type streamStartedMsg struct {
 	updates <-chan struct{}
 	done    <-chan struct{}
@@ -28,18 +27,25 @@ type streamBatchMsg struct{}
 // completed).
 type streamDoneMsg struct{}
 
-// startStreamingLoadCmd starts the manager's progressive first load
-// (core.SessionManager.ReloadStreaming) in a background goroutine and
+// runStreamingLoadCmd starts the actual streaming discovery work (run, from
+// core.SessionManager.BeginReloadStreaming) in a background goroutine and
 // returns a tea.Cmd that reports back once it has: the actual discovery
 // work happens off of bubbletea's own command-runner goroutine so batches
 // can be delivered as they arrive, rather than bubbletea only learning
 // about the load once the whole thing finishes.
-func startStreamingLoadCmd(mgr *core.SessionManager) tea.Cmd {
+//
+// run must come from BeginReloadStreaming, called synchronously by the
+// caller (Init, below) BEFORE this Cmd -- or any other Cmd in the same
+// batch, including watchCmd -- is dispatched. That ordering is what
+// actually guards against a watcher event or poll tick racing the stream's
+// startup (see BeginReloadStreaming's doc): this function only owns
+// delivering batches progressively, not the guard itself.
+func runStreamingLoadCmd(run func(onUpdate func())) tea.Cmd {
 	return func() tea.Msg {
 		updates := make(chan struct{}, 1) // buffered: coalesce bursts, onUpdate must never block
 		done := make(chan struct{})
 		go func() {
-			mgr.ReloadStreaming(func() {
+			run(func() {
 				select {
 				case updates <- struct{}{}:
 				default:

--- a/internal/ui/streaming.go
+++ b/internal/ui/streaming.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/illegalstudio/lazyagent/internal/core"
+)
+
+// streamStartedMsg carries the update/done channels a just-launched
+// progressive-first-load goroutine will signal on. core.SessionManager.
+// ReloadStreaming itself has no channel of its own to expose (it just calls
+// onUpdate, like watchCmd's events channel is owned by the watcher) -- these
+// channels are created once, here, for the whole stream, and must be
+// threaded back into the model via Update so later batch/done messages can
+// keep waiting on them.
+type streamStartedMsg struct {
+	updates <-chan struct{}
+	done    <-chan struct{}
+}
+
+// streamBatchMsg is sent each time the progressive first load merges a new
+// provider member's sessions into the manager. Like fileWatchMsg, it
+// carries no data -- the handler just re-reads whatever's now in the
+// manager.
+type streamBatchMsg struct{}
+
+// streamDoneMsg is sent once the progressive first load's underlying
+// core.DiscoverMatchingStream has finished (every provider member has
+// completed).
+type streamDoneMsg struct{}
+
+// startStreamingLoadCmd starts the manager's progressive first load
+// (core.SessionManager.ReloadStreaming) in a background goroutine and
+// returns a tea.Cmd that reports back once it has: the actual discovery
+// work happens off of bubbletea's own command-runner goroutine so batches
+// can be delivered as they arrive, rather than bubbletea only learning
+// about the load once the whole thing finishes.
+func startStreamingLoadCmd(mgr *core.SessionManager) tea.Cmd {
+	return func() tea.Msg {
+		updates := make(chan struct{}, 1) // buffered: coalesce bursts, onUpdate must never block
+		done := make(chan struct{})
+		go func() {
+			mgr.ReloadStreaming(func() {
+				select {
+				case updates <- struct{}{}:
+				default:
+				}
+			})
+			close(done)
+		}()
+		return streamStartedMsg{updates: updates, done: done}
+	}
+}
+
+// streamNextCmd blocks until either channel fires and reuses watchCmd's
+// pattern for watcher events: a Cmd that waits for the next "something
+// happened" signal and translates it into a Msg, re-armed by the Update
+// handler after each message so the wait continues until the stream itself
+// finishes.
+func streamNextCmd(updates <-chan struct{}, done <-chan struct{}) tea.Cmd {
+	return func() tea.Msg {
+		select {
+		case <-updates:
+			return streamBatchMsg{}
+		case <-done:
+			return streamDoneMsg{}
+		}
+	}
+}

--- a/internal/ui/streaming_test.go
+++ b/internal/ui/streaming_test.go
@@ -1,0 +1,231 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+// loadingModel builds a Model in the same "not loaded yet" state NewModel
+// produces (loading: true, manager constructed but never Reload()'d), so
+// tests can drive the progressive-first-load message sequence
+// (streamStartedMsg/streamBatchMsg/streamDoneMsg) exactly as the real
+// bubbletea runtime would, without a TTY.
+func loadingModel(t *testing.T, provider core.SessionProvider) Model {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	theme := DarkTheme()
+	manager := core.NewSessionManager(60, provider)
+	return Model{
+		theme:     theme,
+		sty:       newStyles(theme),
+		actColors: activityColorMap(theme),
+		loading:   true,
+		manager:   manager,
+		width:     80,
+		height:    24,
+	}
+}
+
+// --- streamNextCmd: the self-re-arming Cmd, same shape as watchCmd ---
+
+func TestStreamNextCmd_ReturnsBatchMsgOnUpdate(t *testing.T) {
+	updates := make(chan struct{}, 1)
+	done := make(chan struct{})
+	updates <- struct{}{}
+
+	msg := streamNextCmd(updates, done)()
+	if _, ok := msg.(streamBatchMsg); !ok {
+		t.Fatalf("streamNextCmd() = %T, want streamBatchMsg", msg)
+	}
+}
+
+func TestStreamNextCmd_ReturnsDoneMsgWhenDoneClosed(t *testing.T) {
+	updates := make(chan struct{}, 1)
+	done := make(chan struct{})
+	close(done)
+
+	msg := streamNextCmd(updates, done)()
+	if _, ok := msg.(streamDoneMsg); !ok {
+		t.Fatalf("streamNextCmd() = %T, want streamDoneMsg", msg)
+	}
+}
+
+// --- Update: state transitions driven by streamStartedMsg / streamBatchMsg
+// / streamDoneMsg, at the model level (no TTY) ---
+
+func TestUpdate_StreamStartedMsg_StoresChannelsAndArmsNextCmd(t *testing.T) {
+	m := loadingModel(t, testProvider{})
+
+	updates := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	updated, cmd := m.Update(streamStartedMsg{updates: updates, done: done})
+	nm := updated.(Model)
+
+	if nm.streamUpdates == nil || nm.streamDone == nil {
+		t.Fatal("streamStartedMsg must store the update/done channels on the model")
+	}
+	if cmd == nil {
+		t.Fatal("streamStartedMsg must return a Cmd to keep waiting on the stream")
+	}
+	if !nm.loading {
+		t.Error("loading must still be true right after the stream starts")
+	}
+
+	// The returned Cmd must be armed against the same channels just stored.
+	close(done)
+	msg := cmd()
+	if _, ok := msg.(streamDoneMsg); !ok {
+		t.Fatalf("Cmd returned by the streamStartedMsg handler produced %T, want streamDoneMsg", msg)
+	}
+}
+
+func TestUpdate_StreamBatchMsg_RefreshesVisibleAndKeepsLoading(t *testing.T) {
+	now := time.Now()
+	provider := testProvider{sessions: []*model.Session{
+		{SessionID: "s1", CWD: "/p1", LastActivity: now},
+	}}
+	m := loadingModel(t, provider)
+	m.streamUpdates = make(chan struct{}, 1)
+	m.streamDone = make(chan struct{})
+
+	// Simulate the manager having merged a batch (what ReloadStreaming's
+	// onUpdate-triggering merge does under the hood) before the message
+	// arrives -- streamBatchMsg itself carries no data, exactly like
+	// fileWatchMsg, it's just a "go re-read from the manager" signal.
+	if err := m.manager.Reload(); err != nil {
+		t.Fatalf("seeding manager state: %v", err)
+	}
+
+	if len(m.visible) != 0 {
+		t.Fatalf("precondition: m.visible should start empty, got %d", len(m.visible))
+	}
+
+	updated, cmd := m.Update(streamBatchMsg{})
+	nm := updated.(Model)
+
+	if len(nm.visible) != 1 || nm.visible[0].SessionID != "s1" {
+		t.Fatalf("visible after streamBatchMsg = %#v, want [s1]", nm.visible)
+	}
+	if !nm.loading {
+		t.Error("loading must stay true on a batch message -- only streamDoneMsg clears it")
+	}
+	if cmd == nil {
+		t.Fatal("streamBatchMsg must re-arm the wait Cmd for the next batch/done")
+	}
+}
+
+func TestUpdate_StreamDoneMsg_ClearsLoadingAndRefreshesVisible(t *testing.T) {
+	now := time.Now()
+	provider := testProvider{sessions: []*model.Session{
+		{SessionID: "s1", CWD: "/p1", LastActivity: now},
+	}}
+	m := loadingModel(t, provider)
+	if err := m.manager.Reload(); err != nil {
+		t.Fatalf("seeding manager state: %v", err)
+	}
+
+	updated, cmd := m.Update(streamDoneMsg{})
+	nm := updated.(Model)
+
+	if nm.loading {
+		t.Error("loading must be false once streamDoneMsg arrives")
+	}
+	if len(nm.visible) != 1 {
+		t.Fatalf("visible after streamDoneMsg = %d, want 1", len(nm.visible))
+	}
+	if cmd != nil {
+		t.Error("streamDoneMsg must not re-arm any further wait Cmd")
+	}
+}
+
+// TestUpdate_SessionsMsg_DoesNotResetLoading guards the interplay between
+// the progressive first load and a normal (watcher/tick-driven) reload that
+// might race it: since core.SessionManager.Reload() is absorbed while a
+// stream is in flight, a fileWatchMsg/tickMsg landing mid-stream can still
+// produce a sessionsMsg (with whatever's currently in the manager). That
+// must not flip the loading indicator off early -- only streamDoneMsg owns
+// that transition now.
+func TestUpdate_SessionsMsg_DoesNotResetLoading(t *testing.T) {
+	m := loadingModel(t, testProvider{})
+
+	updated, _ := m.Update(sessionsMsg{sessions: nil})
+	nm := updated.(Model)
+
+	if !nm.loading {
+		t.Error("sessionsMsg must not clear loading -- that's streamDoneMsg's job during the progressive first load")
+	}
+}
+
+// --- startStreamingLoadCmd: end-to-end through the manager (no TTY) ---
+
+func TestStartStreamingLoadCmd_EndToEndReachesStreamDone(t *testing.T) {
+	now := time.Now()
+	p1 := testProvider{sessions: []*model.Session{{SessionID: "s1", CWD: "/p1", LastActivity: now}}}
+	p2 := testProvider{sessions: []*model.Session{{SessionID: "s2", CWD: "/p2", LastActivity: now}}}
+	mp := core.MultiProvider{Providers: []core.SessionProvider{p1, p2}}
+
+	m := loadingModel(t, mp)
+
+	startMsg := startStreamingLoadCmd(m.manager)()
+	started, ok := startMsg.(streamStartedMsg)
+	if !ok {
+		t.Fatalf("startStreamingLoadCmd()() = %T, want streamStartedMsg", startMsg)
+	}
+
+	updated, cmd := m.Update(started)
+	m = updated.(Model)
+
+	// Drain batch/done messages until streamDoneMsg, bounded so a bug can't
+	// hang the test suite.
+	deadline := time.After(5 * time.Second)
+	for i := 0; i < 10; i++ {
+		msgCh := make(chan tea.Msg, 1)
+		go func(c tea.Cmd) { msgCh <- c() }(cmd)
+
+		var msg tea.Msg
+		select {
+		case msg = <-msgCh:
+		case <-deadline:
+			t.Fatal("stream never completed (streamDoneMsg not observed within timeout)")
+		}
+
+		updated, cmd = m.Update(msg)
+		m = updated.(Model)
+		if _, done := msg.(streamDoneMsg); done {
+			break
+		}
+	}
+
+	if m.loading {
+		t.Fatal("model still loading after the stream reached streamDoneMsg")
+	}
+	if got := m.manager.Sessions(); len(got) != 2 {
+		t.Fatalf("manager.Sessions() after the stream completed = %d, want 2", len(got))
+	}
+}
+
+// --- Loading indicator in the title bar ---
+
+func TestRenderTitleBar_ShowsLoadingIndicatorWhileLoading(t *testing.T) {
+	m := loadingModel(t, testProvider{})
+	bar := m.renderTitleBar()
+	if !strings.Contains(bar, "loading") {
+		t.Errorf("title bar while loading = %q, want it to mention loading", bar)
+	}
+}
+
+func TestRenderTitleBar_HidesLoadingIndicatorOnceLoaded(t *testing.T) {
+	m := loadingModel(t, testProvider{})
+	m.loading = false
+	bar := m.renderTitleBar()
+	if strings.Contains(bar, "loading") {
+		t.Errorf("title bar once loaded = %q, want no loading mention", bar)
+	}
+}

--- a/internal/ui/streaming_test.go
+++ b/internal/ui/streaming_test.go
@@ -163,9 +163,9 @@ func TestUpdate_SessionsMsg_DoesNotResetLoading(t *testing.T) {
 	}
 }
 
-// --- startStreamingLoadCmd: end-to-end through the manager (no TTY) ---
+// --- runStreamingLoadCmd: end-to-end through the manager (no TTY) ---
 
-func TestStartStreamingLoadCmd_EndToEndReachesStreamDone(t *testing.T) {
+func TestRunStreamingLoadCmd_EndToEndReachesStreamDone(t *testing.T) {
 	now := time.Now()
 	p1 := testProvider{sessions: []*model.Session{{SessionID: "s1", CWD: "/p1", LastActivity: now}}}
 	p2 := testProvider{sessions: []*model.Session{{SessionID: "s2", CWD: "/p2", LastActivity: now}}}
@@ -173,10 +173,11 @@ func TestStartStreamingLoadCmd_EndToEndReachesStreamDone(t *testing.T) {
 
 	m := loadingModel(t, mp)
 
-	startMsg := startStreamingLoadCmd(m.manager)()
+	run := m.manager.BeginReloadStreaming()
+	startMsg := runStreamingLoadCmd(run)()
 	started, ok := startMsg.(streamStartedMsg)
 	if !ok {
-		t.Fatalf("startStreamingLoadCmd()() = %T, want streamStartedMsg", startMsg)
+		t.Fatalf("runStreamingLoadCmd()() = %T, want streamStartedMsg", startMsg)
 	}
 
 	updated, cmd := m.Update(started)

--- a/main.go
+++ b/main.go
@@ -247,7 +247,15 @@ If you find lazyagent useful, leave a ⭐ → https://github.com/illegalstudio/l
 			tea.WithMouseCellMotion(),
 		)
 
-		if _, err := p.Run(); err != nil {
+		finalModel, err := p.Run()
+		// Close stops the file watcher and, if the discovery cache was
+		// persisted (EnableCachePersistence in ui.NewModel), flushes it one
+		// last time if dirty — the TUI's only shutdown hook, run regardless
+		// of how p.Run() returned.
+		if tm, ok := finalModel.(ui.Model); ok {
+			tm.Manager().Close()
+		}
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/illegalstudio/lazyagent/internal/passphrase"
 	"github.com/illegalstudio/lazyagent/internal/prune"
 	"github.com/illegalstudio/lazyagent/internal/search"
+	"github.com/illegalstudio/lazyagent/internal/sessions"
 	"github.com/illegalstudio/lazyagent/internal/tray"
 	"github.com/illegalstudio/lazyagent/internal/ui"
 	"github.com/illegalstudio/lazyagent/internal/version"
@@ -49,6 +50,8 @@ func main() {
 			os.Exit(limits.Run(os.Args[2:]))
 		case "passphrase":
 			os.Exit(passphrase.Run(os.Args[2:]))
+		case "sessions":
+			os.Exit(sessions.Run(os.Args[2:]))
 		}
 	}
 
@@ -90,6 +93,8 @@ Subcommands:
   lazyagent compact             Shrink sessions by truncating bulky tool outputs
   lazyagent compact --help      Show compact options (--threshold-kb, --dry-run, ...)
   lazyagent search "query"      Search chat transcripts with highlighted snippets
+  lazyagent sessions            List sessions for the current directory and reopen one
+  lazyagent sessions --help     Show sessions options (--agent, --json, --dir)
   lazyagent limits              Show rate-limit / billing usage summary
   lazyagent limits --help       Show limits options (--agent claude|codex|grok|kimi|all, --detailed)
   lazyagent passphrase          Set or rotate the HTTP API passphrase


### PR DESCRIPTION
- **docs(specs): add sessions-list design**
- **docs(plans): add sessions-list implementation plan**
- **refactor(core): add ResumeArgv as single source of resume argv**
- **feat(sessions): add directory filter for session listing**
- **feat(sessions): add --json output encoder**
- **feat(sessions): add interactive session picker**
- **fix(sessions): guard picker against empty session list**
- **feat(sessions): add lazyagent sessions subcommand**
- **docs(sessions): document the sessions subcommand**
- **fix(sessions): restore spec CWD matching, deterministic sort**
- **fix(sessions): always emit all 7 fields in --json output**
- **fix(sessions): window the picker so the cursor stays visible**
- **fix(sessions): path-boundary home abbreviation, TTY guard on stderr**
