### PR TITLE
feat(gui): show limits in a floating resizable dialog

### DIFF
--- a/docs/interfaces/macos-gui.md
+++ b/docs/interfaces/macos-gui.md
@@ -39,7 +39,7 @@ Detaching turns lazyagent into a full desktop app: a Dock icon appears, it shows
 
 - **Search** is always visible (<kbd>/</kbd> focuses it, <kbd>esc</kbd> clears it).
 - A **density switch** — **compact**, **rich**, or **live** (also <kbd>⌘1</kbd>/<kbd>⌘2</kbd>/<kbd>⌘3</kbd> from the View menu) — controls how much detail each session card shows; your choice is persisted.
-- Toolbar buttons for the time window, **Limits**, **refresh** (<kbd>⌘R</kbd>), **pin always-on-top**, **Settings** (gear), and reattach.
+- Toolbar buttons for the time window, **Limits**, **refresh** (<kbd>⌘R</kbd>), **pin always-on-top**, **Settings** (gear), and reattach. Limits open in a centered floating dialog instead of replacing the dashboard. The dialog does not dim or block the dashboard, can be dragged and resized from its lower-right corner, has a position pin that disables dragging, and has its own refresh button. On open and whenever the app window changes size, its dimensions and position are clamped inside the window. Only its close button dismisses it.
 
 Each card carries an action bar: **Resume** opens the session's resume command in a new window of your configured terminal, **Editor** opens the project in your editor, and **✎** renames inline. Right-clicking a card (or the **⋯** button) opens a context menu with the same actions plus *Copy resume command* and *Copy project path*. Selecting a card pushes in a detail panel alongside the grid — drag its left edge to resize it (double-click resets), navigate with <kbd>j</kbd>/<kbd>k</kbd> while it's open.
 
@@ -66,13 +66,13 @@ Everything saves to the same `config.json` the CLI uses — see [Configuration](
 | <kbd>+</kbd> / <kbd>-</kbd> | Adjust time window |
 | <kbd>f</kbd> | Cycle activity filter |
 | <kbd>/</kbd> | Search sessions |
-| <kbd>l</kbd> | Open or close the limits view |
+| <kbd>l</kbd> | Open limits; close them in the attached panel |
 | <kbd>r</kbd> | Rename session; refresh while the limits view is open |
 | <kbd>d</kbd> | Detach / reattach panel |
 | <kbd>esc</kbd> | Close detail / dismiss search |
 | <kbd>?</kbd> | Keyboard-shortcut reference (desktop mode) |
 | <kbd>⌘1</kbd>–<kbd>⌘3</kbd> | Card density (desktop mode) |
-| <kbd>⌘L</kbd> | Toggle limits (desktop mode) |
+| <kbd>⌘L</kbd> | Open limits (desktop mode) |
 | <kbd>⌘R</kbd> | Refresh sessions (desktop mode) |
 
 ## Right-click menu

--- a/docs/maintenance/limits.md
+++ b/docs/maintenance/limits.md
@@ -11,7 +11,7 @@ Claude and Codex each expose a **5-hour** and a **7-day** window; Grok exposes a
 
 Use it to answer questions like *"am I burning the weekly limit faster than I should?"* before you commit to a long agent run, *"how much of my 5-hour budget is left until the next reset?"* when you suspect you're close to the wall, or *"how much of my Grok monthly credit have I burned this month?"* before kicking off a long Grok run.
 
-The same limits are viewable interactively without leaving lazyagent: in the **TUI** press `l` to open a centered modal with **Summary** and **Detailed** tabs (the Detailed tab scrolls inside the modal); in the **GUI** click **limits** in the header or press `l` to open the limits page (`l` or `Esc` closes it). Both read limits on entry and refresh on demand when you press `r`; neither view polls in the background.
+The same limits are viewable interactively without leaving lazyagent: in the **TUI** press `l` to open a centered modal with **Summary** and **Detailed** tabs (the Detailed tab scrolls inside the modal); in the **GUI** click **limits** in the header or press `l`. The attached menu-bar view uses the limits page and closes with `l` or `Esc`. Detached desktop mode instead opens a non-blocking floating dialog over the usable dashboard: it has explicit refresh and close controls, can be dragged and resized, and its local pin freezes the dialog position without pinning the app window. Its size and position are kept inside the app window when it opens or the containing window changes size. It does not dim the dashboard and closes only from its close button. Both interfaces read limits on entry and refresh on demand when you press `r`; neither view polls in the background.
 
 ## Synopsis
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -36,6 +36,14 @@
     }
   });
 
+  function handleLimitsRefresh(e: KeyboardEvent) {
+    if ($showLimits && (e.key === "r" || e.key === "R")) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      $limitsRefreshToken += 1;
+    }
+  }
+
   function handleKeydown(e: KeyboardEvent) {
     if ($searching) {
       if (e.key === "Escape") {
@@ -47,14 +55,11 @@
     }
 
     if ($showLimits) {
-      if (e.key === "Escape" || e.key === "l" || e.key === "L") {
+      if (!$isDetached && (e.key === "Escape" || e.key === "l" || e.key === "L")) {
         e.preventDefault();
         $showLimits = false;
-      } else if (e.key === "r" || e.key === "R") {
-        e.preventDefault();
-        $limitsRefreshToken += 1;
+        return;
       }
-      return;
     }
 
     if (e.key === "Escape") {
@@ -114,8 +119,8 @@
       const d = Array.isArray(ev?.data) ? ev.data[0] : ev?.data;
       if (d === "compact" || d === "rich" || d === "live") $cardDensity = d;
     });
-    Events.On("menu:toggleLimits", () => {
-      $showLimits = !$showLimits;
+    Events.On("menu:showLimits", () => {
+      $showLimits = true;
     });
 
     // Check for updates after a short delay (gives the backend time to fetch)
@@ -128,7 +133,7 @@
   });
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
+<svelte:window onkeydowncapture={handleLimitsRefresh} onkeydown={handleKeydown} />
 
 {#if $isDetached}
   <DesktopView />

--- a/frontend/src/lib/DesktopView.svelte
+++ b/frontend/src/lib/DesktopView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {
     sessions, selectedId, activeCount, windowMinutes, activityFilter,
-    searchQuery, showLimits, limitsRefreshToken, updateVersion,
+    searchQuery, showLimits, updateVersion,
     isPinned, cardDensity, detailWidth,
   } from "./stores";
   import type { CardDensity, SessionItem } from "./stores";
@@ -11,7 +11,7 @@
   } from "./actions";
   import SessionCard from "./SessionCard.svelte";
   import DetailPanel from "./DetailPanel.svelte";
-  import LimitsPage from "./LimitsPage.svelte";
+  import LimitsModal from "./LimitsModal.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import ShortcutsOverlay from "./ShortcutsOverlay.svelte";
   import SettingsModal from "./SettingsModal.svelte";
@@ -96,7 +96,6 @@
       shortcutsOpen = true;
       return;
     }
-    if ($showLimits) return;
     const list = $sessions;
     if (!list.length) return;
     const idx = list.findIndex((s) => s.sessionId === $selectedId);
@@ -161,8 +160,8 @@
 
     <button
       class="no-drag rounded-lg border px-2.5 py-1 text-[11px] {$showLimits ? 'border-accent bg-accent/10 text-accent font-semibold' : 'border-border bg-[#11111b] text-subtext hover:text-text'}"
-      onclick={() => ($showLimits = !$showLimits)}
-      title="Toggle limits (⌘L)"
+      onclick={() => ($showLimits = true)}
+      title="Show limits (⌘L)"
     >Limits</button>
 
     <button
@@ -198,58 +197,52 @@
 
   <!-- Content -->
   <div class="flex-1 flex min-h-0">
-    {#if $showLimits}
-      <div class="flex-1 overflow-hidden bg-surface">
-        <LimitsPage refreshToken={$limitsRefreshToken} />
-      </div>
-    {:else}
-      <div class="flex-1 min-w-0 overflow-y-auto p-3">
-        {#if $sessions.length}
-          <div
-            class="grid gap-3"
-            style="grid-template-columns: repeat(auto-fill, minmax({minCardWidth[$cardDensity]}px, 1fr));"
-          >
-            {#each $sessions as session (session.sessionId)}
-              <SessionCard
-                {session}
-                density={$cardDensity}
-                selected={session.sessionId === $selectedId}
-                onselect={select}
-                oncontext={openContext}
-                {renameRequest}
-                onrenamehandled={() => (renameRequest = null)}
-              />
-            {/each}
-          </div>
-        {:else}
-          <div class="flex flex-col items-center justify-center h-full gap-3 text-subtext">
-            <svg viewBox="0 0 24 24" class="w-12 h-12 opacity-40" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><circle cx="12" cy="12" r="1"/><path d="M18.944 12.33a1 1 0 0 0 0-.66 7.5 7.5 0 0 0-13.888 0 1 1 0 0 0 0 .66 7.5 7.5 0 0 0 13.888 0"/>
-            </svg>
-            <div class="text-[13px] font-medium text-text">No sessions in the last {$windowMinutes} minutes</div>
-            <div class="text-[11.5px]">Agents appear here as soon as they run — press <kbd class="bg-surface-hover border border-border rounded px-1">+</kbd> to widen the window.</div>
-          </div>
-        {/if}
-      </div>
-      {#if $selectedId}
+    <div class="flex-1 min-w-0 overflow-y-auto p-3">
+      {#if $sessions.length}
         <div
-          class="relative shrink-0 min-h-0 max-w-[60vw]"
-          style="width: {$detailWidth}px; min-width: 300px;"
+          class="grid gap-3"
+          style="grid-template-columns: repeat(auto-fill, minmax({minCardWidth[$cardDensity]}px, 1fr));"
         >
-          <div
-            class="absolute left-0 top-0 bottom-0 w-[5px] z-10 cursor-col-resize hover:bg-accent/30 {resizing ? 'bg-accent/30' : ''}"
-            role="separator"
-            aria-orientation="vertical"
-            title="Drag to resize, double-click to reset"
-            onpointerdown={startResize}
-            onpointermove={moveResize}
-            onpointerup={endResize}
-            onpointercancel={endResize}
-            ondblclick={resetWidth}
-          ></div>
-          <DetailPanel />
+          {#each $sessions as session (session.sessionId)}
+            <SessionCard
+              {session}
+              density={$cardDensity}
+              selected={session.sessionId === $selectedId}
+              onselect={select}
+              oncontext={openContext}
+              {renameRequest}
+              onrenamehandled={() => (renameRequest = null)}
+            />
+          {/each}
+        </div>
+      {:else}
+        <div class="flex flex-col items-center justify-center h-full gap-3 text-subtext">
+          <svg viewBox="0 0 24 24" class="w-12 h-12 opacity-40" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/><circle cx="12" cy="12" r="1"/><path d="M18.944 12.33a1 1 0 0 0 0-.66 7.5 7.5 0 0 0-13.888 0 1 1 0 0 0 0 .66 7.5 7.5 0 0 0 13.888 0"/>
+          </svg>
+          <div class="text-[13px] font-medium text-text">No sessions in the last {$windowMinutes} minutes</div>
+          <div class="text-[11.5px]">Agents appear here as soon as they run — press <kbd class="bg-surface-hover border border-border rounded px-1">+</kbd> to widen the window.</div>
         </div>
       {/if}
+    </div>
+    {#if $selectedId}
+      <div
+        class="relative shrink-0 min-h-0 max-w-[60vw]"
+        style="width: {$detailWidth}px; min-width: 300px;"
+      >
+        <div
+          class="absolute left-0 top-0 bottom-0 w-[5px] z-10 cursor-col-resize hover:bg-accent/30 {resizing ? 'bg-accent/30' : ''}"
+          role="separator"
+          aria-orientation="vertical"
+          title="Drag to resize, double-click to reset"
+          onpointerdown={startResize}
+          onpointermove={moveResize}
+          onpointerup={endResize}
+          onpointercancel={endResize}
+          ondblclick={resetWidth}
+        ></div>
+        <DetailPanel />
+      </div>
     {/if}
   </div>
 
@@ -290,4 +283,8 @@
 
 {#if settingsOpen}
   <SettingsModal onclose={() => (settingsOpen = false)} />
+{/if}
+
+{#if $showLimits}
+  <LimitsModal onclose={() => ($showLimits = false)} />
 {/if}

--- a/frontend/src/lib/LimitsModal.svelte
+++ b/frontend/src/lib/LimitsModal.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { limitsRefreshToken } from "./stores";
+  import LimitsPage from "./LimitsPage.svelte";
+
+  interface Props {
+    onclose: () => void;
+  }
+
+  let { onclose }: Props = $props();
+
+  const viewportMargin = 12;
+  const preferredWidth = 720;
+  const preferredHeight = 680;
+  const minimumWidth = 420;
+  const minimumHeight = 280;
+  let dialogEl = $state<HTMLDivElement | null>(null);
+  let dialogWidth = $state(preferredWidth);
+  let dialogHeight = $state(preferredHeight);
+  let offsetX = $state(0);
+  let offsetY = $state(0);
+  let dragging = $state(false);
+  let resizing = $state(false);
+  let pinned = $state(false);
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let dragStartOffsetX = 0;
+  let dragStartOffsetY = 0;
+  let resizeStartX = 0;
+  let resizeStartY = 0;
+  let resizeStartWidth = 0;
+  let resizeStartHeight = 0;
+  let resizeStartOffsetX = 0;
+  let resizeStartOffsetY = 0;
+  let resizeMaxWidth = 0;
+  let resizeMaxHeight = 0;
+
+  function clampOffset(x: number, y: number): { x: number; y: number } {
+    if (!dialogEl) return { x, y };
+
+    const { width, height } = dialogEl.getBoundingClientRect();
+    const centeredLeft = (window.innerWidth - width) / 2;
+    const centeredTop = (window.innerHeight - height) / 2;
+
+    return {
+      x: Math.min(
+        window.innerWidth - viewportMargin - width - centeredLeft,
+        Math.max(viewportMargin - centeredLeft, x),
+      ),
+      y: Math.min(
+        window.innerHeight - viewportMargin - height - centeredTop,
+        Math.max(viewportMargin - centeredTop, y),
+      ),
+    };
+  }
+
+  function startDrag(e: PointerEvent) {
+    if (pinned || e.button !== 0 || (e.target as Element).closest("button")) return;
+    dragging = true;
+    dragStartX = e.clientX;
+    dragStartY = e.clientY;
+    dragStartOffsetX = offsetX;
+    dragStartOffsetY = offsetY;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    e.preventDefault();
+  }
+
+  function moveDrag(e: PointerEvent) {
+    if (!dragging) return;
+    const next = clampOffset(
+      dragStartOffsetX + e.clientX - dragStartX,
+      dragStartOffsetY + e.clientY - dragStartY,
+    );
+    offsetX = next.x;
+    offsetY = next.y;
+  }
+
+  function endDrag(e: PointerEvent) {
+    if (!dragging) return;
+    dragging = false;
+    const target = e.currentTarget as HTMLElement;
+    if (target.hasPointerCapture(e.pointerId)) target.releasePointerCapture(e.pointerId);
+  }
+
+  function keepInViewport() {
+    const next = clampOffset(offsetX, offsetY);
+    offsetX = next.x;
+    offsetY = next.y;
+  }
+
+  // The CSS min() guard protects the very first paint. This synchronizes the
+  // state with the rendered size on open (and after a host-window resize),
+  // then clamps any translated position back inside the containing window.
+  function fitDialogToViewport() {
+    if (!dialogEl) return;
+    const rect = dialogEl.getBoundingClientRect();
+    dialogWidth = rect.width;
+    dialogHeight = rect.height;
+    keepInViewport();
+  }
+
+  function startResize(e: PointerEvent) {
+    if (e.button !== 0 || !dialogEl) return;
+    const rect = dialogEl.getBoundingClientRect();
+    resizing = true;
+    resizeStartX = e.clientX;
+    resizeStartY = e.clientY;
+    resizeStartWidth = rect.width;
+    resizeStartHeight = rect.height;
+    resizeStartOffsetX = offsetX;
+    resizeStartOffsetY = offsetY;
+    resizeMaxWidth = Math.max(1, window.innerWidth - viewportMargin - rect.left);
+    resizeMaxHeight = Math.max(1, window.innerHeight - viewportMargin - rect.top);
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  function moveResize(e: PointerEvent) {
+    if (!resizing) return;
+    const minWidth = Math.min(minimumWidth, resizeMaxWidth);
+    const minHeight = Math.min(minimumHeight, resizeMaxHeight);
+    const nextWidth = Math.min(
+      resizeMaxWidth,
+      Math.max(minWidth, resizeStartWidth + e.clientX - resizeStartX),
+    );
+    const nextHeight = Math.min(
+      resizeMaxHeight,
+      Math.max(minHeight, resizeStartHeight + e.clientY - resizeStartY),
+    );
+
+    // The dialog is flex-centered, so compensate by half the size delta to
+    // keep its top-left corner stationary while the bottom-right handle moves.
+    dialogWidth = nextWidth;
+    dialogHeight = nextHeight;
+    offsetX = resizeStartOffsetX + (nextWidth - resizeStartWidth) / 2;
+    offsetY = resizeStartOffsetY + (nextHeight - resizeStartHeight) / 2;
+  }
+
+  function endResize(e: PointerEvent) {
+    if (!resizing) return;
+    resizing = false;
+    const target = e.currentTarget as HTMLElement;
+    if (target.hasPointerCapture(e.pointerId)) target.releasePointerCapture(e.pointerId);
+  }
+
+  function refresh() {
+    $limitsRefreshToken += 1;
+  }
+
+  function togglePinned() {
+    pinned = !pinned;
+    if (pinned) dragging = false;
+  }
+
+  onMount(fitDialogToViewport);
+</script>
+
+<svelte:window onresize={fitDialogToViewport} />
+
+<div class="pointer-events-none fixed inset-0 z-30 flex items-center justify-center p-3">
+  <div
+    bind:this={dialogEl}
+    class="pointer-events-auto relative flex flex-col overflow-hidden rounded-xl border border-surface-active bg-surface shadow-[0_20px_60px_rgba(0,0,0,0.72)]"
+    class:select-none={dragging || resizing}
+    style="width: min({dialogWidth}px, calc(100vw - {viewportMargin * 2}px)); height: min({dialogHeight}px, calc(100vh - {viewportMargin * 2}px)); transform: translate({offsetX}px, {offsetY}px);"
+    role="dialog"
+    aria-labelledby="limits-modal-title"
+    tabindex="-1"
+  >
+    <header
+      class="flex shrink-0 items-center gap-2 border-b border-border bg-[#181825] px-3 py-2 {pinned ? 'cursor-default' : dragging ? 'cursor-grabbing' : 'cursor-move'}"
+      role="toolbar"
+      aria-label="Limits window controls"
+      tabindex="-1"
+      onpointerdown={startDrag}
+      onpointermove={moveDrag}
+      onpointerup={endDrag}
+      onpointercancel={endDrag}
+    >
+      <svg viewBox="0 0 24 24" class="h-3.5 w-3.5 shrink-0 text-subtext" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <path d="M5 9h14M5 15h14" />
+      </svg>
+      <h2 id="limits-modal-title" class="text-[13px] font-bold text-text">Limits</h2>
+      <span class="text-[10px] text-subtext">{pinned ? "pinned in place" : "drag to move"}</span>
+
+      <div class="ml-auto flex items-center gap-1.5">
+        <button
+          class="rounded-lg border border-border bg-[#11111b] px-2 py-1 text-[11px] text-subtext hover:text-text"
+          onclick={refresh}
+          title="Refresh limits (r)"
+        >
+          <span class="flex items-center gap-1.5">
+            <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>
+            Refresh
+          </span>
+        </button>
+        <button
+          class="rounded-lg border px-2 py-1 {pinned ? 'border-accent bg-accent text-surface' : 'border-border bg-[#11111b] text-subtext hover:text-text'}"
+          onclick={togglePinned}
+          title={pinned ? "Unpin dialog to move it" : "Pin dialog in place"}
+          aria-pressed={pinned}
+        >
+          <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 17v5"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1z"/></svg>
+        </button>
+        <button
+          class="rounded-lg border border-border bg-[#11111b] px-2 py-1 text-[13px] leading-none text-subtext hover:text-text"
+          onclick={onclose}
+          title="Close limits"
+        >✕</button>
+      </div>
+    </header>
+
+    <div class="min-h-0 flex-1">
+      <LimitsPage refreshToken={$limitsRefreshToken} closeHint="close with ×" />
+    </div>
+
+    <button
+      class="absolute bottom-0 right-0 z-10 flex h-5 w-5 cursor-nwse-resize items-end justify-end p-1 text-border hover:text-accent"
+      aria-label="Resize limits dialog"
+      title="Drag to resize"
+      onpointerdown={startResize}
+      onpointermove={moveResize}
+      onpointerup={endResize}
+      onpointercancel={endResize}
+    >
+      <svg viewBox="0 0 12 12" class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+        <path d="M4 10 10 4M7 10l3-3" />
+      </svg>
+    </button>
+  </div>
+</div>

--- a/frontend/src/lib/LimitsPage.svelte
+++ b/frontend/src/lib/LimitsPage.svelte
@@ -2,7 +2,12 @@
   import * as SessionService from "../bindings/github.com/illegalstudio/lazyagent/internal/tray/sessionservice";
   import { View, Severity } from "../bindings/github.com/illegalstudio/lazyagent/internal/limits/models";
 
-  let { refreshToken = 0 }: { refreshToken?: number } = $props();
+  interface Props {
+    refreshToken?: number;
+    closeHint?: string;
+  }
+
+  let { refreshToken = 0, closeHint = "esc / l to close" }: Props = $props();
   let loading = $state(true);
   let view = $state<View | null>(null);
   let tab = $state<"summary" | "detailed">("summary");
@@ -68,7 +73,9 @@
       class="rounded px-2 py-0.5 text-[12px] font-medium {tab === 'detailed' ? 'text-accent bg-accent/10' : 'text-subtext hover:text-text'}"
       onclick={() => (tab = "detailed")}
     >Detailed</button>
-    <span class="ml-auto text-[10px] text-subtext">r to refresh · esc / l to close</span>
+    <span class="ml-auto text-[10px] text-subtext">
+      r to refresh{#if closeHint} · {closeHint}{/if}
+    </span>
   </div>
 
   <div class="flex-1 overflow-auto p-3">

--- a/frontend/src/lib/ShortcutsOverlay.svelte
+++ b/frontend/src/lib/ShortcutsOverlay.svelte
@@ -11,11 +11,11 @@
     },
     {
       title: "View",
-      keys: [["⌘1 ⌘2 ⌘3", "Card density"], ["f", "Cycle activity filter"], ["l", "Toggle limits"], ["+ / −", "Time window"]],
+      keys: [["⌘1 ⌘2 ⌘3", "Card density"], ["f", "Cycle activity filter"], ["l", "Open limits"], ["+ / −", "Time window"]],
     },
     {
       title: "Session",
-      keys: [["r", "Rename selected"], ["double-click", "Rename card"], ["right-click", "Card actions"]],
+      keys: [["r", "Rename selected / refresh limits"], ["double-click", "Rename card"], ["right-click", "Card actions"]],
     },
     {
       title: "App",

--- a/internal/tray/menu.go
+++ b/internal/tray/menu.go
@@ -44,7 +44,7 @@ func installAppMenu(app *application.App, svc *SessionService) {
 
 	// View menu: density is persisted Go-side, then broadcast so the
 	// frontend store follows; limits is pure frontend state, so the menu
-	// only emits and the webview flips it.
+	// only emits and the webview opens it.
 	viewMenu := menu.AddSubmenu("View")
 	for i, d := range []string{"compact", "rich", "live"} {
 		density := d
@@ -56,10 +56,10 @@ func installAppMenu(app *application.App, svc *SessionService) {
 			})
 	}
 	viewMenu.AddSeparator()
-	viewMenu.Add("Toggle Limits").
+	viewMenu.Add("Show Limits").
 		SetAccelerator("CmdOrCtrl+l").
 		OnClick(func(ctx *application.Context) {
-			app.Event.Emit("menu:toggleLimits")
+			app.Event.Emit("menu:showLimits")
 		})
 	viewMenu.Add("Refresh Sessions").
 		SetAccelerator("CmdOrCtrl+r").


### PR DESCRIPTION
## Summary

- show limits as a non-blocking floating dialog in detached desktop mode
- support dragging, local position pinning, resizing, explicit refresh, and close-only dismissal
- keep the dialog inside its host window and reserve `r` exclusively for limits refresh
- document the detached limits behavior while leaving the attached view unchanged

## Validation

- `make build`
- `go test ./...`
- interactive GUI QA at 800x600 and 600x400, including drag, pin, resize, background interaction, close, refresh, and bounds clamping