### PR TITLE
fix(ci): unblock Linux desktop releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
   goreleaser:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
@@ -46,7 +46,7 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
 
       # Build, sign, archive, publish release, and update Homebrew cask
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: "~> v2"
           args: release --clean
@@ -152,15 +152,15 @@ jobs:
     needs: goreleaser
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm

--- a/internal/claude/cwdindex_test.go
+++ b/internal/claude/cwdindex_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
@@ -59,11 +60,11 @@ func TestCWDIndex_HeadHitAvoidsReread(t *testing.T) {
 	}
 }
 
-// TestCWDIndex_InvalidatedOnChange confirms a changed file (different mtime
-// and size) is never trusted from a stale entry -- the brief's "use the
+// TestCWDIndex_InvalidatedOnSizeChange confirms a changed file with a new
+// size is never trusted from a stale entry -- the brief's "use the
 // same invalidate-on-change rule for uniformity and safety" requirement for
 // claude, even though first-cwd-wins is technically stable across appends.
-func TestCWDIndex_InvalidatedOnChange(t *testing.T) {
+func TestCWDIndex_InvalidatedOnSizeChange(t *testing.T) {
 	const replacementCWD = "/tmp/project-b-longer"
 
 	dir := t.TempDir()
@@ -99,6 +100,52 @@ func TestCWDIndex_InvalidatedOnChange(t *testing.T) {
 	cwd, ok = idx.headCWDIndexed(path, mtime2, size2)
 	if !ok || cwd != replacementCWD {
 		t.Fatalf("after replace, headCWDIndexed = (%q, %v), want (%s, true) -- the stale project-a entry must not be trusted", cwd, ok, replacementCWD)
+	}
+}
+
+// TestCWDIndex_InvalidatedOnMtimeChange covers the other half of the cache
+// key: a same-size rewrite must be detected when only mtime changes. Set the
+// timestamp explicitly so the test is reliable on coarse-mtime filesystems.
+func TestCWDIndex_InvalidatedOnMtimeChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime1, size1 := info.ModTime(), info.Size()
+
+	idx := NewCWDIndex()
+	cwd, ok := idx.headCWDIndexed(path, mtime1, size1)
+	if !ok || cwd != "/tmp/project-a" {
+		t.Fatalf("first scan = (%q, %v), want (/tmp/project-a, true)", cwd, ok)
+	}
+
+	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-b")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	replacementMtime := mtime1.Add(2 * time.Second)
+	if err := os.Chtimes(path, replacementMtime, replacementMtime); err != nil {
+		t.Fatal(err)
+	}
+	info2, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mtime2, size2 := info2.ModTime(), info2.Size()
+	if size2 != size1 {
+		t.Fatalf("replacement size = %d, want original size %d", size2, size1)
+	}
+	if mtime2.Equal(mtime1) {
+		t.Fatalf("replacement mtime = %s, want a different mtime from original %s", mtime2, mtime1)
+	}
+
+	cwd, ok = idx.headCWDIndexed(path, mtime2, size2)
+	if !ok || cwd != "/tmp/project-b" {
+		t.Fatalf("after replace, headCWDIndexed = (%q, %v), want (/tmp/project-b, true) -- the stale project-a entry must not be trusted", cwd, ok)
 	}
 }
 

--- a/internal/claude/cwdindex_test.go
+++ b/internal/claude/cwdindex_test.go
@@ -64,6 +64,8 @@ func TestCWDIndex_HeadHitAvoidsReread(t *testing.T) {
 // same invalidate-on-change rule for uniformity and safety" requirement for
 // claude, even though first-cwd-wins is technically stable across appends.
 func TestCWDIndex_InvalidatedOnChange(t *testing.T) {
+	const replacementCWD = "/tmp/project-b-longer"
+
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-a")+"\n"), 0o644); err != nil {
@@ -82,7 +84,7 @@ func TestCWDIndex_InvalidatedOnChange(t *testing.T) {
 	}
 
 	// Replace the file with new (different-length) content under a new cwd.
-	if err := os.WriteFile(path, []byte(cwdLine("/tmp/project-b")+"\n"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(cwdLine(replacementCWD)+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	info2, err := os.Stat(path)
@@ -90,10 +92,13 @@ func TestCWDIndex_InvalidatedOnChange(t *testing.T) {
 		t.Fatal(err)
 	}
 	mtime2, size2 := info2.ModTime(), info2.Size()
+	if size2 == size1 {
+		t.Fatalf("replacement size = %d, want a different size from original %d", size2, size1)
+	}
 
 	cwd, ok = idx.headCWDIndexed(path, mtime2, size2)
-	if !ok || cwd != "/tmp/project-b" {
-		t.Fatalf("after replace, headCWDIndexed = (%q, %v), want (/tmp/project-b, true) -- the stale project-a entry must not be trusted", cwd, ok)
+	if !ok || cwd != replacementCWD {
+		t.Fatalf("after replace, headCWDIndexed = (%q, %v), want (%s, true) -- the stale project-a entry must not be trusted", cwd, ok, replacementCWD)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make the CWD index invalidation test deterministic on filesystems with coarse mtime resolution
- update pinned GitHub Actions to their Node.js 24 releases
- keep the Linux desktop release job unchanged apart from the CI fixes

## Validation

- `go test ./...`
- `go test -tags notray ./...`
- `go vet ./...`
- `go test ./internal/claude -run ^TestCWDIndex_InvalidatedOnChange$ -count=100`
- `actionlint .github/workflows/release.yml`
- `goreleaser check`