### PR TITLE
fix(test): make cwdindex invalidation test change mtime and size

### DIFF
--- a/internal/claude/process_test.go
+++ b/internal/claude/process_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
@@ -560,6 +561,17 @@ func TestDiscoverSessionsFiltered_IncrementalAppendAlwaysReparsedPostParseFilter
 		t.Fatal(err)
 	}
 	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// GetIncremental treats same-mtime as a full hit (mtime-only by
+	// design). On 1-second filesystems the append can share the priming
+	// write's mtime, so force a later timestamp.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	later := info.ModTime().Add(2 * time.Second)
+	if err := os.Chtimes(path, later, later); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/codex/process_test.go
+++ b/internal/codex/process_test.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/illegalstudio/lazyagent/internal/model"
 )
@@ -670,6 +671,17 @@ func TestDiscoverSessionsFiltered_IncrementalCacheHitUsesPostParseFilterNotStale
 		t.Fatal(err)
 	}
 	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// GetIncremental treats same-mtime as a full hit (mtime-only by
+	// design). On 1-second filesystems the append can share the priming
+	// write's mtime, so force a later timestamp.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	later := info.ModTime().Add(2 * time.Second)
+	if err := os.Chtimes(path, later, later); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto current `main`. The original Linux CI failure (`TestCWDIndex_InvalidatedOnChange`) is already fixed on main via #53.

**What this PR still adds:** incremental-discovery tests that append and then rely on `SessionCache.GetIncremental` (mtime-only full-hit by design). On 1-second Linux filesystems the append can share the priming mtime, so those tests `Chtimes` after the append.

Does not retag or republish 0.14.0.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a3dfac7-7a4d-4da3-8329-0ffcf8fec8ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a3dfac7-7a4d-4da3-8329-0ffcf8fec8ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

