### PR TITLE
feat(sessions): add history and latest subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ That said, lazyagent and its API are **fully open source**. If you'd rather not 
 - **[`lazyagent search`](docs/maintenance/search.md)** — search transcript-file agents (Claude, Codex, pi, Amp, Grok, Kimi) with highlighted snippets and an incremental local index.
 - **[`lazyagent limits`](docs/maintenance/limits.md)** — on-demand rate-limit / billing summary for Claude Code (5h + 7d), Codex (5h + 7d), Grok (monthly), Kimi Code, and Cursor (monthly, Models + API pools), with a detailed pace view available via `--detailed`.
 - **[`lazyagent sessions`](docs/usage/sessions.md)** — list every session recorded for the current directory — across all agents — and reopen one with the originating agent's CLI. Interactive picker, `--json` for scripts.
+- **[`lazyagent history`](docs/usage/history.md)** — print a table of the current directory's past sessions (oldest at the top, newest at the bottom as row #1): agent, title, branch, message count, last activity. Shows the 20 most recent (`--all` for everything), then lets you pick a row to resume.
+- **[`lazyagent latest`](docs/usage/latest.md)** — resume the current directory's most recent session immediately, with the originating agent's CLI. No table, no prompt.
 - **Outbound webhooks on session state transitions** — send a signed JSON payload to Slack, a custom dashboard, or a CI endpoint whenever a session goes idle, waits for input, or changes state. See [Webhooks](docs/reference/webhooks.md).
 
 Typical savings on a year of daily use: **80+ MiB reclaimed** across the cleanup commands, with every rewrite validated and backed up by default.
@@ -156,6 +158,8 @@ lazyagent prune --days N     Delete chat sessions older than N days
 lazyagent compact            Shrink chat files by truncating bulky payloads
 lazyagent search "query"     Search chat transcripts with snippets
 lazyagent sessions           List and reopen sessions for the current directory
+lazyagent history            Table of past sessions here; pick one to resume
+lazyagent latest             Resume the most recent session here
 lazyagent limits             Show 5h / weekly / monthly usage summary
 lazyagent passphrase         Set or rotate the HTTP API passphrase
 lazyagent --help             Show full help

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,8 @@ Three interfaces ship in a single binary: a terminal UI, a macOS/Linux desktop a
 - [CLI reference](usage/cli.md) — every `lazyagent` flag, with syntax and examples
 - [Recipes](usage/recipes.md) — end-to-end walkthroughs for common workflows
 - [Sessions for a directory](usage/sessions.md) — list every recorded session for a directory and reopen one, across all agents
+- [Session history for a directory](usage/history.md) — print a table of a directory's past sessions, across all agents, and resume one by row number
+- [Resume the latest session](usage/latest.md) — jump straight back into a directory's most recent session
 
 ## Maintenance
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -145,19 +145,21 @@ Prints the full usage text, including short keybinding reference.
 
 ## Subcommand dispatch
 
-When the first positional argument is `prune`, `compact`, `search`, `sessions`, `limits`, or `passphrase`, lazyagent switches into subcommand mode — root-level flags are ignored and the subcommand parses its own set.
+When the first positional argument is `prune`, `compact`, `search`, `sessions`, `history`, `latest`, `limits`, or `passphrase`, lazyagent switches into subcommand mode — root-level flags are ignored and the subcommand parses its own set.
 
 ```bash
 lazyagent prune --days 30          # prune subcommand
 lazyagent compact --agent claude   # compact subcommand
 lazyagent search --agent codex api # search subcommand
 lazyagent sessions --agent codex   # sessions subcommand
+lazyagent history --all            # history subcommand
+lazyagent latest                   # resume the newest session here
 lazyagent limits --agent claude    # limits subcommand
 lazyagent passphrase               # rotate the API passphrase
 lazyagent --agent claude prune     # ❌ wrong: prune is not a flag value
 ```
 
-See [`prune`](../maintenance/prune.md), [`compact`](../maintenance/compact.md), [`search`](../maintenance/search.md), [`sessions`](sessions.md), and [`limits`](../maintenance/limits.md) for their flag tables.
+See [`prune`](../maintenance/prune.md), [`compact`](../maintenance/compact.md), [`search`](../maintenance/search.md), [`sessions`](sessions.md), [`history`](history.md), [`latest`](latest.md), and [`limits`](../maintenance/limits.md) for their flag tables.
 
 ### `search`
 
@@ -235,6 +237,12 @@ lazyagent search "api server"
 
 # List and reopen sessions for the current directory
 lazyagent sessions
+
+# Table of past sessions for the current directory
+lazyagent history
+
+# Jump straight back into the newest session here
+lazyagent latest
 ```
 
 ## Exit codes

--- a/docs/usage/history.md
+++ b/docs/usage/history.md
@@ -1,0 +1,74 @@
+---
+title: "Session history for a directory"
+description: "Print a table of every recorded session for the current directory, across all agents."
+sidebar:
+  order: 4
+---
+
+`lazyagent history` prints a table of every session whose working directory
+is the current directory (or a subdirectory of it), across all supported
+agents — oldest at the top, most recent at the bottom as row `#1`, right
+above the prompt. In a terminal it then offers to resume one by row number. It is the flat sibling of [`lazyagent sessions`](sessions.md): same
+discovery, directory filter, and resume behavior, but a plain table plus a
+one-shot prompt instead of an interactive picker.
+
+By default only the **20 most recent** sessions are shown; pass `--all` to
+see every one.
+
+## Synopsis
+
+```
+lazyagent history [--all] [--agent NAME] [--dir PATH]
+```
+
+## Output
+
+```
+  #   AGENT    SESSION                                   BRANCH            MSGS   LAST ACTIVITY
+  3   grok     docs limits                               -                 12     2026-08-27 18:03
+  2   codex    webhook config models                     feat/webhooks     31     2026-08-30 09:10
+  1   claude   fix build embed placeholder               main              84     2026-08-31 14:52
+
+3 session(s) in ~/projects/foo.
+
+Resume a session? Enter row #, or press Enter to quit:
+```
+
+Each row shows the agent, a title (your custom session name when set,
+otherwise the agent-provided name or a preview of the first user message),
+the git branch recorded for the session (`-` when unknown), the message
+count, and the local last-activity timestamp. Row `#1` is always the most
+recent session — the numbers count down from the top so the newest entry
+ends up next to the prompt, like shell history. When more sessions exist
+than the 20 shown, the footer says so and points at `--all`. To skip the
+table and jump straight into the newest session, use
+[`lazyagent latest`](latest.md).
+
+## Resuming
+
+When stdin and stdout are terminals, the table is followed by a prompt:
+entering a row number resumes that session with the originating agent's CLI
+(e.g. `claude --resume <id>`), run from the session's own working directory
+when it still exists. Pressing Enter on an empty line — or `ctrl+c` —
+quits without resuming. Piped or redirected output skips the prompt
+entirely, so `lazyagent history | cat` stays non-interactive.
+
+Agents lazyagent can exec directly: Claude Code, Codex, Amp, pi, and Kimi.
+Other agents print a "no resume command" notice instead. For scripted
+output, `lazyagent sessions --json` emits the same list as JSON.
+
+## Flags
+
+| Flag | Type | Default | Summary |
+|------|------|---------|---------|
+| `--all` | bool | `false` | Show every session instead of the 20 most recent |
+| `--agent NAME` | string | `all` | Restrict the listing to one agent |
+| `--dir PATH` | string | current dir | Show history for another directory |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Normal exit (including "no sessions found" and quitting the prompt) |
+| `1` | Discovery or resume error — details printed to stderr |
+| `2` | Bad invocation (unknown flag or `--agent` value, `--dir` not a directory) or an invalid row selection |

--- a/docs/usage/latest.md
+++ b/docs/usage/latest.md
@@ -1,0 +1,44 @@
+---
+title: "Resume the latest session"
+description: "Resume the most recent session recorded for the current directory, across all agents."
+sidebar:
+  order: 5
+---
+
+`lazyagent latest` finds the most recently active session whose working
+directory is the current directory (or a subdirectory of it), across all
+supported agents, and resumes it immediately with the originating agent's
+CLI — no table, no prompt. It opens exactly the session
+[`lazyagent history`](history.md) shows as row `#1`.
+
+## Synopsis
+
+```
+lazyagent latest [--agent NAME] [--dir PATH]
+```
+
+```
+$ lazyagent latest
+Opening: claude --resume 3f2a…
+```
+
+The resume command runs with this terminal attached, from the session's own
+working directory when it still exists. Agents lazyagent can exec directly:
+Claude Code, Codex, Amp, pi, and Kimi; for other agents a "no resume
+command" notice is printed instead. "Most recent" means latest activity in
+the transcript (lazyagent does not record a separate creation time).
+
+## Flags
+
+| Flag | Type | Default | Summary |
+|------|------|---------|---------|
+| `--agent NAME` | string | `all` | Consider only one agent's sessions |
+| `--dir PATH` | string | current dir | Resume the latest session for another directory |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Session resumed and exited normally |
+| `1` | No session found for the directory, discovery error, or resume error |
+| `2` | Bad invocation (unknown flag or `--agent` value, `--dir` not a directory) |

--- a/internal/sessions/history.go
+++ b/internal/sessions/history.go
@@ -1,0 +1,179 @@
+package sessions
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/chatops"
+	"github.com/illegalstudio/lazyagent/internal/core"
+	"github.com/illegalstudio/lazyagent/internal/model"
+	"github.com/mattn/go-isatty"
+)
+
+// historyDefaultLimit is how many sessions `lazyagent history` shows unless
+// --all is given.
+const historyDefaultLimit = 20
+
+// RunHistory implements `lazyagent history`. It prints a table of the
+// sessions recorded for the current (or --dir) directory across agents,
+// most recent first, then — in a terminal — offers to resume one by row
+// number. Sibling of Run (the `sessions` picker): same discovery, same
+// directory filter, but a plain table plus a one-shot prompt instead of an
+// interactive picker.
+func RunHistory(args []string) int {
+	fs := flag.NewFlagSet("history", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	agent := fs.String("agent", "all", "Agent to list: claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, all")
+	showAll := fs.Bool("all", false, fmt.Sprintf("Show every session instead of the %d most recent", historyDefaultLimit))
+	dirFlag := fs.String("dir", "", "Show history for this directory instead of the current one")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `lazyagent history — show past sessions for a directory
+
+Prints a table of every recorded session whose working directory is the
+current directory (or --dir) or a subdirectory of it, across all agents —
+oldest at the top, most recent at the bottom as row #1. Only the %d most
+recent are shown unless --all is given. In a terminal, entering a row
+number then resumes that session with the originating agent's CLI; press
+Enter or ctrl+c to quit instead.
+
+Usage:
+  lazyagent history
+  lazyagent history --all
+  lazyagent history --agent claude
+  lazyagent history --dir ~/projects/foo
+
+Flags:
+`, historyDefaultLimit)
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	if !validAgents[*agent] {
+		fmt.Fprintf(os.Stderr, "Error: unknown --agent value %q (use claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, or all)\n", *agent)
+		return 2
+	}
+
+	dir, err := resolveTargetDir(*dirFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 2
+	}
+
+	filtered, code := discoverDirSessions(*agent, dir)
+	if code != 0 {
+		return code
+	}
+
+	if len(filtered) == 0 {
+		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
+		return 0
+	}
+
+	names := core.NewSessionNames()
+	nameFor := func(s *model.Session) string {
+		return titleFor(s, names.Get(s.SessionID))
+	}
+	limit := historyDefaultLimit
+	if *showAll {
+		limit = 0
+	}
+	shown := renderHistory(os.Stdout, filtered, nameFor, abbreviateHome(dir), limit)
+	return promptResumeSession(shown)
+}
+
+// promptResumeSession asks for a row number and resumes the chosen session.
+// Skipped entirely (exit 0) when stdin/stdout are not terminals, so piped
+// output stays non-interactive — same rule as search's promptOpenResult.
+// Empty input, EOF, and ctrl+c (SIGINT's default handling) all quit without
+// resuming.
+func promptResumeSession(shown []*model.Session) int {
+	if len(shown) == 0 || !isatty.IsTerminal(os.Stdin.Fd()) || !isatty.IsTerminal(os.Stdout.Fd()) {
+		return 0
+	}
+	fmt.Printf("\n%s ", chatops.StyleMuted.Render("Resume a session? Enter row #, or press Enter to quit:"))
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Println()
+		return 0
+	}
+	answer := strings.TrimSpace(line)
+	if answer == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(answer)
+	if err != nil || n < 1 || n > len(shown) {
+		fmt.Fprintf(os.Stderr, "Invalid selection %q.\n", answer)
+		return 2
+	}
+	return openSession(shown[n-1])
+}
+
+// renderHistory prints the history table plus a footer line and returns the
+// slice of sessions actually rendered, newest first — the prompt's row
+// numbers index into it (#1 = shown[0]). Rows are printed oldest at the
+// top, newest at the bottom with row number 1, so the most recent session
+// sits right above the resume prompt. limit <= 0 means "show everything";
+// otherwise only the first limit sessions are rendered and the footer
+// points at --all. sessions must already be sorted most recent first
+// (FilterByDir's order).
+func renderHistory(w io.Writer, sessions []*model.Session, nameFor func(*model.Session) string, dirLabel string, limit int) []*model.Session {
+	total := len(sessions)
+	shown := sessions
+	if limit > 0 && total > limit {
+		shown = sessions[:limit]
+	}
+
+	t := chatops.NewTable().Headers("#", "AGENT", "SESSION", "BRANCH", "MSGS", "LAST ACTIVITY")
+	for i := len(shown) - 1; i >= 0; i-- {
+		s := shown[i]
+		t.Row(
+			chatops.StyleMuted.Render(strconv.Itoa(i+1)),
+			chatops.StyleAgent.Render(s.Agent),
+			truncate(nameFor(s), 60),
+			branchLabel(s.GitBranch),
+			chatops.StyleCount.Render(strconv.Itoa(s.TotalMessages)),
+			chatops.StyleMuted.Render(historyFormatWhen(s.LastActivity)),
+		)
+	}
+	fmt.Fprintln(w, t)
+
+	if len(shown) < total {
+		fmt.Fprintln(w, chatops.StyleFooter.Render(fmt.Sprintf(
+			"Showing %d of %d session(s) in %s — use --all to see every session.",
+			len(shown), total, dirLabel,
+		)))
+		return shown
+	}
+	fmt.Fprintln(w, chatops.StyleFooter.Render(fmt.Sprintf(
+		"%d session(s) in %s.", total, dirLabel,
+	)))
+	return shown
+}
+
+func branchLabel(branch string) string {
+	if branch == "" {
+		return chatops.StyleMuted.Render("-")
+	}
+	return branch
+}
+
+func historyFormatWhen(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.Local().Format("2006-01-02 15:04")
+}

--- a/internal/sessions/history.go
+++ b/internal/sessions/history.go
@@ -143,8 +143,8 @@ func renderHistory(w io.Writer, sessions []*model.Session, nameFor func(*model.S
 		t.Row(
 			chatops.StyleMuted.Render(strconv.Itoa(i+1)),
 			chatops.StyleAgent.Render(s.Agent),
-			truncate(nameFor(s), 60),
-			branchLabel(s.GitBranch),
+			truncate(stripControl(nameFor(s)), 60),
+			branchLabel(stripControl(s.GitBranch)),
 			chatops.StyleCount.Render(strconv.Itoa(s.TotalMessages)),
 			chatops.StyleMuted.Render(historyFormatWhen(s.LastActivity)),
 		)
@@ -162,6 +162,21 @@ func renderHistory(w io.Writer, sessions []*model.Session, nameFor func(*model.S
 		"%d session(s) in %s.", total, dirLabel,
 	)))
 	return shown
+}
+
+// stripControl removes control runes — C0 (including ESC and BEL), DEL, and
+// C1 (including the CSI and OSC introducers) — so session titles and branch
+// names, which come from persisted transcript content an agent's
+// counterparty can influence, cannot inject terminal escape sequences
+// through the table. Printable text passes through untouched; truncate's
+// whitespace collapsing handles tabs and newlines separately.
+func stripControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || (r >= 0x7f && r <= 0x9f) {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 func branchLabel(branch string) string {

--- a/internal/sessions/history.go
+++ b/internal/sessions/history.go
@@ -78,7 +78,7 @@ Flags:
 	}
 
 	if len(filtered) == 0 {
-		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
+		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", stripControl(abbreviateHome(dir)))
 		return 0
 	}
 
@@ -136,6 +136,10 @@ func renderHistory(w io.Writer, sessions []*model.Session, nameFor func(*model.S
 	if limit > 0 && total > limit {
 		shown = sessions[:limit]
 	}
+	// The directory label is the user's own path, but a hostile repo can
+	// still plant control bytes in a directory name — same neutralization
+	// as the title and branch cells.
+	dirLabel = stripControl(dirLabel)
 
 	t := chatops.NewTable().Headers("#", "AGENT", "SESSION", "BRANCH", "MSGS", "LAST ACTIVITY")
 	for i := len(shown) - 1; i >= 0; i-- {

--- a/internal/sessions/history_test.go
+++ b/internal/sessions/history_test.go
@@ -1,0 +1,143 @@
+package sessions
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestRunHistoryRejectsUnknownAgent(t *testing.T) {
+	if code := RunHistory([]string{"--agent", "nope"}); code != 2 {
+		t.Errorf("unknown agent: exit = %d, want 2", code)
+	}
+}
+
+func TestRunHistoryRejectsMissingDir(t *testing.T) {
+	if code := RunHistory([]string{"--dir", "/nonexistent-lazyagent-test-dir"}); code != 2 {
+		t.Errorf("missing dir: exit = %d, want 2", code)
+	}
+}
+
+func TestRunHistoryHelp(t *testing.T) {
+	if code := RunHistory([]string{"--help"}); code != 0 {
+		t.Errorf("--help: exit = %d, want 0", code)
+	}
+}
+
+func TestRunHistoryRejectsUnknownFlag(t *testing.T) {
+	if code := RunHistory([]string{"--bogus"}); code != 2 {
+		t.Errorf("unknown flag: exit = %d, want 2", code)
+	}
+}
+
+// historyFixture builds n sessions, most recent first, named s1..sn.
+func historyFixture(n int) []*model.Session {
+	base := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	out := make([]*model.Session, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, &model.Session{
+			SessionID:     fmt.Sprintf("id-%02d", i+1),
+			Agent:         "claude",
+			Name:          fmt.Sprintf("s%d", i+1),
+			TotalMessages: i + 1,
+			LastActivity:  base.Add(-time.Duration(i) * time.Hour),
+		})
+	}
+	return out
+}
+
+func nameByField(s *model.Session) string { return s.Name }
+
+func TestRenderHistoryTruncatesToLimit(t *testing.T) {
+	sessions := historyFixture(25)
+	var buf bytes.Buffer
+	renderHistory(&buf, sessions, nameByField, "~/proj", historyDefaultLimit)
+	got := buf.String()
+
+	if !strings.Contains(got, "s20") {
+		t.Errorf("output missing 20th session; got:\n%s", got)
+	}
+	if strings.Contains(got, "s21") {
+		t.Errorf("output should not include the 21st session; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Showing 20 of 25 session(s) in ~/proj") {
+		t.Errorf("footer missing truncation notice; got:\n%s", got)
+	}
+	if !strings.Contains(got, "--all") {
+		t.Errorf("footer should point at --all; got:\n%s", got)
+	}
+}
+
+func TestRenderHistoryNoLimitShowsEverything(t *testing.T) {
+	sessions := historyFixture(25)
+	var buf bytes.Buffer
+	renderHistory(&buf, sessions, nameByField, "~/proj", 0)
+	got := buf.String()
+
+	if !strings.Contains(got, "s25") {
+		t.Errorf("output missing last session; got:\n%s", got)
+	}
+	if !strings.Contains(got, "25 session(s) in ~/proj.") {
+		t.Errorf("footer missing full count; got:\n%s", got)
+	}
+	if strings.Contains(got, "--all") {
+		t.Errorf("footer should not mention --all when nothing is hidden; got:\n%s", got)
+	}
+}
+
+// historyRowRE captures a data row's number cell and fixture name (sN):
+// leading whitespace, row number, agent, name.
+var historyRowRE = regexp.MustCompile(`^\s*(\d+)\s+claude\s+(s\d+)\b`)
+
+func TestRenderHistoryOldestOnTopNewestAsRowOne(t *testing.T) {
+	sessions := historyFixture(5)
+	var buf bytes.Buffer
+	renderHistory(&buf, sessions, nameByField, "~/proj", 0)
+
+	var numbers, names []string
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if m := historyRowRE.FindStringSubmatch(line); m != nil {
+			numbers = append(numbers, m[1])
+			names = append(names, m[2])
+		}
+	}
+	wantNames := []string{"s5", "s4", "s3", "s2", "s1"} // oldest first
+	wantNumbers := []string{"5", "4", "3", "2", "1"}    // countdown to the newest
+	if fmt.Sprint(names) != fmt.Sprint(wantNames) {
+		t.Errorf("row order = %v, want %v", names, wantNames)
+	}
+	if fmt.Sprint(numbers) != fmt.Sprint(wantNumbers) {
+		t.Errorf("row numbers = %v, want %v", numbers, wantNumbers)
+	}
+}
+
+func TestRenderHistoryReturnsShownRows(t *testing.T) {
+	sessions := historyFixture(25)
+	var buf bytes.Buffer
+	shown := renderHistory(&buf, sessions, nameByField, "~/proj", historyDefaultLimit)
+	if len(shown) != historyDefaultLimit {
+		t.Fatalf("returned %d rows, want %d", len(shown), historyDefaultLimit)
+	}
+	if shown[0].SessionID != "id-01" || shown[19].SessionID != "id-20" {
+		t.Errorf("returned rows out of order: first %q, last %q", shown[0].SessionID, shown[19].SessionID)
+	}
+}
+
+func TestRenderHistoryUnderLimitOmitsHint(t *testing.T) {
+	sessions := historyFixture(3)
+	var buf bytes.Buffer
+	renderHistory(&buf, sessions, nameByField, "~/proj", historyDefaultLimit)
+	got := buf.String()
+
+	if !strings.Contains(got, "3 session(s) in ~/proj.") {
+		t.Errorf("footer missing full count; got:\n%s", got)
+	}
+	if strings.Contains(got, "--all") {
+		t.Errorf("footer should not mention --all when nothing is hidden; got:\n%s", got)
+	}
+}

--- a/internal/sessions/history_test.go
+++ b/internal/sessions/history_test.go
@@ -137,7 +137,7 @@ func TestRenderHistoryStripsControlSequences(t *testing.T) {
 		LastActivity: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
 	}}
 	var buf bytes.Buffer
-	renderHistory(&buf, sessions, nameByField, "~/proj", 0)
+	renderHistory(&buf, sessions, nameByField, "~/pro\x1b[2Jj", 0)
 	got := buf.String()
 
 	for _, r := range []rune{0x1b, 0x07, 0x9b} {
@@ -152,6 +152,9 @@ func TestRenderHistoryStripsControlSequences(t *testing.T) {
 	}
 	if !strings.Contains(got, "feat[2Jbranch") {
 		t.Errorf("branch not neutralized in place; got:\n%q", got)
+	}
+	if !strings.Contains(got, "~/pro[2Jj") {
+		t.Errorf("directory label not neutralized in footer; got:\n%q", got)
 	}
 }
 

--- a/internal/sessions/history_test.go
+++ b/internal/sessions/history_test.go
@@ -128,6 +128,33 @@ func TestRenderHistoryReturnsShownRows(t *testing.T) {
 	}
 }
 
+func TestRenderHistoryStripsControlSequences(t *testing.T) {
+	sessions := []*model.Session{{
+		SessionID:    "id-01",
+		Agent:        "claude",
+		Name:         "evil\x1b]0;pwned\x07title\x9b31mred",
+		GitBranch:    "feat\x1b[2Jbranch",
+		LastActivity: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+	}}
+	var buf bytes.Buffer
+	renderHistory(&buf, sessions, nameByField, "~/proj", 0)
+	got := buf.String()
+
+	for _, r := range []rune{0x1b, 0x07, 0x9b} {
+		if strings.ContainsRune(got, r) {
+			t.Errorf("output contains control rune %#x; got:\n%q", r, got)
+		}
+	}
+	// The introducer bytes are gone; what trailed them survives as inert
+	// printable text.
+	if !strings.Contains(got, "evil]0;pwnedtitle") {
+		t.Errorf("title not neutralized in place; got:\n%q", got)
+	}
+	if !strings.Contains(got, "feat[2Jbranch") {
+		t.Errorf("branch not neutralized in place; got:\n%q", got)
+	}
+}
+
 func TestRenderHistoryUnderLimitOmitsHint(t *testing.T) {
 	sessions := historyFixture(3)
 	var buf bytes.Buffer

--- a/internal/sessions/latest.go
+++ b/internal/sessions/latest.go
@@ -1,0 +1,68 @@
+package sessions
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// RunLatest implements `lazyagent latest`. It resumes the most recently
+// active session recorded for the current (or --dir) directory, without any
+// table or prompt: same discovery and directory filter as Run and
+// RunHistory, then straight into openSession on the newest match.
+func RunLatest(args []string) int {
+	fs := flag.NewFlagSet("latest", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	agent := fs.String("agent", "all", "Agent to consider: claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, all")
+	dirFlag := fs.String("dir", "", "Resume the latest session for this directory instead of the current one")
+
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, `lazyagent latest — resume the most recent session for a directory
+
+Finds the most recently active session whose working directory is the
+current directory (or --dir) or a subdirectory of it, across all agents,
+and resumes it with the originating agent's CLI. Use "lazyagent history"
+to see the sessions it picks from.
+
+Usage:
+  lazyagent latest
+  lazyagent latest --agent claude
+  lazyagent latest --dir ~/projects/foo
+
+Flags:
+`)
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		return 2
+	}
+	if !validAgents[*agent] {
+		fmt.Fprintf(os.Stderr, "Error: unknown --agent value %q (use claude, pi, opencode, kilo, cursor, codex, amp, grok, kimi, or all)\n", *agent)
+		return 2
+	}
+
+	dir, err := resolveTargetDir(*dirFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 2
+	}
+
+	filtered, code := discoverDirSessions(*agent, dir)
+	if code != 0 {
+		return code
+	}
+
+	// Unlike the listing commands, an empty result here is a failure: the
+	// whole point was to open a session, and there is none to open.
+	if len(filtered) == 0 {
+		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
+		return 1
+	}
+
+	return openSession(filtered[0])
+}

--- a/internal/sessions/latest.go
+++ b/internal/sessions/latest.go
@@ -60,7 +60,7 @@ Flags:
 	// Unlike the listing commands, an empty result here is a failure: the
 	// whole point was to open a session, and there is none to open.
 	if len(filtered) == 0 {
-		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", abbreviateHome(dir))
+		fmt.Fprintf(os.Stderr, "No sessions found in %s.\n", stripControl(abbreviateHome(dir)))
 		return 1
 	}
 

--- a/internal/sessions/latest_test.go
+++ b/internal/sessions/latest_test.go
@@ -1,0 +1,27 @@
+package sessions
+
+import "testing"
+
+func TestRunLatestRejectsUnknownAgent(t *testing.T) {
+	if code := RunLatest([]string{"--agent", "nope"}); code != 2 {
+		t.Errorf("unknown agent: exit = %d, want 2", code)
+	}
+}
+
+func TestRunLatestRejectsMissingDir(t *testing.T) {
+	if code := RunLatest([]string{"--dir", "/nonexistent-lazyagent-test-dir"}); code != 2 {
+		t.Errorf("missing dir: exit = %d, want 2", code)
+	}
+}
+
+func TestRunLatestHelp(t *testing.T) {
+	if code := RunLatest([]string{"--help"}); code != 0 {
+		t.Errorf("--help: exit = %d, want 0", code)
+	}
+}
+
+func TestRunLatestRejectsUnknownFlag(t *testing.T) {
+	if code := RunLatest([]string{"--bogus"}); code != 2 {
+		t.Errorf("unknown flag: exit = %d, want 2", code)
+	}
+}

--- a/internal/sessions/sessions.go
+++ b/internal/sessions/sessions.go
@@ -57,17 +57,9 @@ Flags:
 		return 2
 	}
 
-	dir := *dirFlag
-	if dir == "" {
-		wd, err := os.Getwd()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: cannot determine working directory: %v\n", err)
-			return 2
-		}
-		dir = wd
-	}
-	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-		fmt.Fprintf(os.Stderr, "Error: %q is not a directory\n", dir)
+	dir, err := resolveTargetDir(*dirFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return 2
 	}
 
@@ -234,6 +226,62 @@ func openSession(s *model.Session) int {
 		return 1
 	}
 	return 0
+}
+
+// discoverDirSessions runs a full blocking discovery for agentMode and
+// returns dir's sessions, recency-sorted (FilterByDir), with the advisory
+// provider caches loaded before and saved after — the same wiring as Run's
+// non-interactive path. Shared by RunHistory and RunLatest, which have no
+// picker and therefore no reason to stream. On failure it prints the error
+// to stderr and returns a non-zero exit code for the caller to return.
+func discoverDirSessions(agentMode, dir string) ([]*model.Session, int) {
+	cfg := core.LoadConfig()
+	provider := core.BuildProvider(agentMode, cfg)
+
+	cacheDir, hasCacheDir := ResolveCacheDir()
+	if hasCacheDir {
+		core.LoadProviderCaches(provider, cacheDir)
+	}
+
+	variants, err := targetVariants(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return nil, 1
+	}
+	match := func(cwd string) bool { return matchesDir(cwd, variants) }
+
+	all, err := core.DiscoverMatching(provider, match)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return nil, 1
+	}
+	if hasCacheDir {
+		core.SaveProviderCaches(provider, cacheDir)
+	}
+	filtered, err := FilterByDir(all, dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return nil, 1
+	}
+	return filtered, 0
+}
+
+// resolveTargetDir returns the directory a subcommand should operate on:
+// dirFlag when given, otherwise the current working directory. The returned
+// error is user-facing (callers prefix it with "Error: " and exit 2).
+func resolveTargetDir(dirFlag string) (string, error) {
+	dir := dirFlag
+	if dir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("cannot determine working directory: %v", err)
+		}
+		dir = wd
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return "", fmt.Errorf("%q is not a directory", dir)
+	}
+	return dir, nil
 }
 
 // abbreviateHome shortens a path with the user's home directory to ~/...

--- a/main.go
+++ b/main.go
@@ -69,6 +69,10 @@ func main() {
 			os.Exit(passphrase.Run(os.Args[2:]))
 		case "sessions":
 			os.Exit(sessions.Run(os.Args[2:]))
+		case "history":
+			os.Exit(sessions.RunHistory(os.Args[2:]))
+		case "latest":
+			os.Exit(sessions.RunLatest(os.Args[2:]))
 		}
 	}
 
@@ -112,6 +116,10 @@ Subcommands:
   lazyagent search "query"      Search chat transcripts with highlighted snippets
   lazyagent sessions            List sessions for the current directory and reopen one
   lazyagent sessions --help     Show sessions options (--agent, --json, --dir)
+  lazyagent history             Table of past sessions for the current directory; pick one to resume
+  lazyagent history --help      Show history options (--all, --agent, --dir)
+  lazyagent latest              Resume the most recent session for the current directory
+  lazyagent latest --help       Show latest options (--agent, --dir)
   lazyagent limits              Show rate-limit / billing usage summary
   lazyagent limits --help       Show limits options (--agent claude|codex|grok|kimi|all, --detailed)
   lazyagent passphrase          Set or rotate the HTTP API passphrase


### PR DESCRIPTION
`lazyagent history` prints a table of the sessions recorded for the
current (or --dir) directory across all agents — oldest at the top,
newest at the bottom as row #1 — showing the 20 most recent unless
--all is given, then offers to resume one by row number (Enter or
ctrl+c quits; piped output skips the prompt).

`lazyagent latest` resumes the directory's most recently active session
immediately, with no table or prompt — exactly the session history
shows as row #1.

Both reuse the sessions package's discovery, directory filter, and
resume path; the shared blocking-discovery block is factored into
discoverDirSessions, and Run's target-directory resolution into
resolveTargetDir.
