### PR TITLE
feat(limits): add --json output and fix Cursor state path on Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ lazyagent history            Alias for lazyagent sessions
 lazyagent latest             Resume the most recent session here
 lazyagent latest --yolo      Resume the most recent session in YOLO mode
 lazyagent limits             Show 5h / weekly / monthly usage summary
+lazyagent limits --json      Same data as JSON, for scripts and widgets
 lazyagent passphrase         Set or rotate the HTTP API passphrase
 lazyagent --help             Show full help
 ```

--- a/docs/concepts/supported-agents.md
+++ b/docs/concepts/supported-agents.md
@@ -11,7 +11,7 @@ lazyagent supports ten agent sources out of the box. Each has a dedicated provid
 |-------|------|--------|--------|
 | [Claude Code CLI](https://claude.ai/code) | `~/.claude/projects/*/` | JSONL | — |
 | [Claude Code Desktop](https://claude.ai/code) | `~/.claude/projects/*/` + `~/Library/Application Support/Claude/claude-code-sessions/` | JSONL + JSON sidecar | `D` |
-| [Cursor](https://cursor.com/) | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | SQLite | `C` |
+| [Cursor](https://cursor.com/) | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` (macOS), `~/.config/Cursor/User/globalStorage/state.vscdb` (Linux), `%APPDATA%\Cursor\User\globalStorage\state.vscdb` (Windows) | SQLite | `C` |
 | [Codex CLI](https://developers.openai.com/codex/) | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` + `~/.codex/session_index.jsonl` | JSONL | `X` |
 | [Amp CLI](https://ampcode.com/) | `~/.local/share/amp/threads/*.json` | Per-thread JSON | `A` |
 | [pi coding agent](https://github.com/badlogic/pi-mono) | `~/.pi/agent/sessions/*/` | JSONL | `π` |
@@ -51,7 +51,7 @@ Extra Claude base directories (e.g. when `CLAUDE_CONFIG_DIR` points elsewhere) c
 
 ### Cursor
 
-Cursor stores everything in a single SQLite database (`state.vscdb`) as key-value entries: `composerData:<id>` for session metadata and `bubbleId:<id>:<bubble>` for message blocks. lazyagent polls this file every 3 seconds (no file watcher — WAL-mode writes don't trigger fsevents cleanly) and invalidates its cache based on journal position.
+Cursor stores everything in a single SQLite database (`state.vscdb`) as key-value entries. The database lives where VS Code keeps user data on each platform: `~/Library/Application Support/Cursor` on macOS, `$XDG_CONFIG_HOME/Cursor` (default `~/.config/Cursor`) on Linux, and `%APPDATA%\Cursor` on Windows, always under `User/globalStorage/`. The entries are `composerData:<id>` for session metadata and `bubbleId:<id>:<bubble>` for message blocks. lazyagent polls this file every 3 seconds (no file watcher — WAL-mode writes don't trigger fsevents cleanly) and invalidates its cache based on journal position.
 
 CWD is inferred from the Cursor workspace URI if available, otherwise from the first file path mentioned in the session.
 

--- a/docs/maintenance/limits.md
+++ b/docs/maintenance/limits.md
@@ -283,7 +283,7 @@ The response carries a top-level `usage` quota plus zero or more rolling `limits
 
 Cursor is the odd one out: it's an IDE, not a CLI, so its usage lives in the web dashboard rather than a `/status` endpoint. lazyagent reads it the way Cursor's own dashboard does — with the session token Cursor stores locally.
 
-Unlike the others, there is no OAuth file and no bearer env var. lazyagent reads one value straight from Cursor's local `state.vscdb` (the same SQLite database it already uses for Cursor session monitoring): **`cursorAuth/accessToken`**, the JWT session token. lazyagent decodes its `sub` claim to recover the user id and rebuilds the `WorkosCursorSessionToken=<userId>%3A%3A<token>` cookie the dashboard sends. The plan name (`pro`, `pro_plus`, `ultra`, …) comes from the API response's `membershipType` field instead of a separate database read.
+Unlike the others, there is no OAuth file and no bearer env var. lazyagent reads one value straight from Cursor's local `state.vscdb` (the same SQLite database it already uses for Cursor session monitoring, under `~/Library/Application Support/Cursor` on macOS, `~/.config/Cursor` on Linux, or `%APPDATA%\Cursor` on Windows): **`cursorAuth/accessToken`**, the JWT session token. lazyagent decodes its `sub` claim to recover the user id and rebuilds the `WorkosCursorSessionToken=<userId>%3A%3A<token>` cookie the dashboard sends. The plan name (`pro`, `pro_plus`, `ultra`, …) comes from the API response's `membershipType` field instead of a separate database read.
 
 With that cookie it makes one HTTPS call to `cursor.com`: `GET /api/usage-summary`, the same endpoint the dashboard uses for its usage headline.
 

--- a/docs/maintenance/limits.md
+++ b/docs/maintenance/limits.md
@@ -16,7 +16,7 @@ The same limits are viewable interactively without leaving lazyagent: in the **T
 ## Synopsis
 
 ```
-lazyagent limits [--agent claude|codex|grok|kimi|cursor|all] [--detailed]
+lazyagent limits [--agent claude|codex|grok|kimi|cursor|all] [--detailed] [--json]
 ```
 
 ## Flags
@@ -25,6 +25,7 @@ lazyagent limits [--agent claude|codex|grok|kimi|cursor|all] [--detailed]
 |------|------|---------|---------|
 | `--agent NAME` | string | `all` | Which agent to query: `claude`, `codex`, `grok`, `kimi`, `cursor`, or `all` |
 | `--detailed` | bool | `false` | Print the detailed per-window report with bars, reset times, sources, notes, and pace |
+| `--json` | bool | `false` | Print every window, pace, severity, reset time, and per-agent error as JSON (see [JSON output](#json-output)) |
 | `--help` | bool | `false` | Print usage and exit |
 
 Only `claude`, `codex`, `grok`, `kimi`, and `cursor` are supported — they're the agents in lazyagent's set that expose rate-limit or billing windows in a stable-enough, observable form.
@@ -39,6 +40,7 @@ lazyagent limits --agent codex     # only Codex
 lazyagent limits --agent grok      # only Grok
 lazyagent limits --agent kimi      # only Kimi Code
 lazyagent limits --agent cursor    # only Cursor (Models + API pools)
+lazyagent limits --json            # machine-readable report for scripts and widgets
 lazyagent limits --help            # full usage + disclaimers
 ```
 
@@ -118,6 +120,103 @@ Codex
 ```
 
 In an interactive terminal the bars and pace label are colored. When piped or redirected, lazyagent strips ANSI escapes automatically.
+
+## JSON output
+
+`--json` prints a single object to stdout and nothing else, so the output can be piped straight into `jq`, a status-bar widget, or a dashboard. It carries everything the `--detailed` view shows plus the summary-table cells, so `--detailed` has no effect when combined with it. Field names are part of the CLI contract and every key is always present; empty lists encode as `[]`.
+
+```bash
+lazyagent limits --json | jq '.reports[] | {agent, used: .summary.week_global.used_percent}'
+```
+
+```json
+{
+  "generated_at": "2026-09-07T13:44:48+02:00",
+  "reports": [
+    {
+      "agent": "claude",
+      "provider": "Claude Code",
+      "short_name": "Claude",
+      "source": "",
+      "note": "Note: reads /api/oauth/usage, an undocumented Claude endpoint. May break or be revoked by Anthropic without notice.",
+      "windows": [
+        {
+          "label": "5-hour",
+          "window_minutes": 300,
+          "used_percent": 21,
+          "expected_percent": 39.9,
+          "pace_known": true,
+          "pace_ratio": 0.53,
+          "pace_label": "underutilizing",
+          "used_severity": "ok",
+          "resets_at": "2026-09-07T14:30:00Z",
+          "reset_in_seconds": 9912,
+          "reset_relative": "in 2h 45m"
+        }
+      ],
+      "summary": {
+        "five_hour": { "used_percent": 21, "expected_percent": 39.9, "severity": "ok", "text": "21.0% used / 39.9% exp" },
+        "week_global": null
+      }
+    }
+  ],
+  "errors": [
+    {
+      "agent": "kimi",
+      "kind": "not_installed",
+      "message": "Kimi Code CLI is not installed or not logged in (no ~/.kimi-code/credentials/kimi-code.json). Run `kimi login`, or set KIMI_CODE_OAUTH_TOKEN."
+    }
+  ]
+}
+```
+
+Top level:
+
+| Field | Meaning |
+|-------|---------|
+| `generated_at` | When the reports were fetched, RFC 3339 in the local zone |
+| `reports` | One entry per metered pool, in the canonical order `claude`, `codex`, `grok`, `kimi`, `cursor`. Cursor contributes two entries (`Cursor Models`, `Cursor API`) that share `"agent": "cursor"` |
+| `errors` | Agents that produced no report, in the same order |
+
+Each report:
+
+| Field | Meaning |
+|-------|---------|
+| `agent` | Stable id to key on: `claude`, `codex`, `grok`, `kimi`, `cursor` |
+| `provider` | Display name used by the detailed view (`Claude Code`, `Cursor Models`, …) |
+| `short_name` | Label used by the summary table (`Claude`, `Kimi`, …) |
+| `source`, `note` | The provenance line and the disclaimer from the detailed view, or `""` |
+| `windows` | Every window the provider exposes, see below |
+| `summary.five_hour`, `summary.week_global` | The two summary-table cells, each `{used_percent, expected_percent, severity, text}` or `null` when the provider has no such window (what the table prints as `--`) |
+
+Each window:
+
+| Field | Meaning |
+|-------|---------|
+| `label` | Provider wording: `5-hour`, `7-day`, `weekly`, `monthly`, … |
+| `window_minutes` | Window length, `0` when the provider does not state it |
+| `used_percent` | Quota consumed, 0-100 |
+| `expected_percent` | Where a perfectly linear pace would be for the elapsed window time |
+| `pace_known` | `false` when the window has just reset (less than 1% elapsed) or has no reset time; the pace fields are then `0` and `""` |
+| `pace_ratio`, `pace_label` | `used / expected` and its bucket: `underutilizing`, `on track`, `overutilizing` |
+| `used_severity` | Absolute-usage bucket matching the detailed bars: `ok` (≤ 50%), `info` (≤ 75%), `warn` (≤ 90%), `danger` |
+| `resets_at` | RFC 3339 reset time, or `null` when unknown |
+| `reset_in_seconds` | Seconds until reset, `0` when unknown or already passed |
+| `reset_relative` | The `in 3h 17m` string from the detailed view, or `""` |
+
+Summary-cell `severity` blends pace and absolute usage the same way the table colors do: `danger` when used ≥ 90% or over pace, `warn` when used ≥ 75%, `ok` when comfortably under pace, `default` when on track.
+
+Each error:
+
+| Field | Meaning |
+|-------|---------|
+| `agent` | Which agent failed |
+| `kind` | `not_installed` (no credentials or footprint on this machine), `unavailable` (installed, but nothing to pace, such as an unlimited Cursor plan), or `error` (network, expired token, unexpected response) |
+| `message` | The same actionable text the human output prints on stderr |
+
+Unlike the human output, `--json` lists `not_installed` and `unavailable` agents even under `--agent all`, so a consumer can hide a provider that is simply absent instead of treating it as broken. The [exit codes](#exit-codes) are unchanged: a `not_installed` entry only fails the command when that agent was requested explicitly or when nothing at all was found.
+
+The polling caveat below applies doubly to anything built on `--json`: refresh on demand or on a generous timer, never in a tight loop.
 
 ## How it gets the data
 
@@ -248,7 +347,7 @@ The "don't poll" guidance applies equally to Grok, Kimi, and Cursor: run `lazyag
 | `1` | At least one agent failed (token missing, endpoint error, Codex login missing, …) — details on stderr |
 | `2` | Invalid flags (e.g. unknown `--agent` value) |
 
-Even on partial failure (`1`), the successful agents' output is printed to stdout. Errors go to stderr with a `Error (claude): …` / `Error (codex): …` / `Error (grok): …` / `Error (kimi): …` / `Error (cursor): …` prefix, so you can pipe stdout to a parser without losing the error context.
+Even on partial failure (`1`), the successful agents' output is printed to stdout. Errors go to stderr with a `Error (claude): …` / `Error (codex): …` / `Error (grok): …` / `Error (kimi): …` / `Error (cursor): …` prefix, so you can pipe stdout to a parser without losing the error context. With `--json`, errors are part of the stdout object under `errors` and nothing is written to stderr; the exit code follows the same rules.
 
 ## Environment
 

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -194,6 +194,7 @@ sidebar:
 - ✅ Native DEB, RPM, and Arch packages with desktop/AppStream metadata
 - ✅ Portable AppImage artifact
 - ✅ GitHub release CI built against the Ubuntu 22.04 compatibility baseline
+- ✅ Cursor session discovery and `lazyagent limits` on Linux and Windows, reading `state.vscdb` from the platform's VS Code user-data location instead of the macOS path
 
 ## Future ideas
 

--- a/docs/reference/roadmap.md
+++ b/docs/reference/roadmap.md
@@ -175,6 +175,7 @@ sidebar:
 - ✅ Kimi Code via `/coding/v1/usages` on `api.kimi.com`, token resolved from `KIMI_CODE_OAUTH_TOKEN` / `~/.kimi-code/credentials/kimi-code.json`
 - ✅ Cursor via `/api/usage-summary` on `cursor.com` (the same endpoint its dashboard uses), session token read from local `state.vscdb`; reports the Auto/Composer and usage-based API pools as two rows against Cursor's own per-pool percentages
 - ✅ Honest User-Agent (no Claude Code impersonation), graceful failure on 401/429, disclaimer in `--help` and output
+- ✅ `lazyagent limits --json` — stable machine-readable report (windows, pace, severity, reset times, per-agent errors) for widgets and scripts
 
 ## v0.10 — Outbound webhooks
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -10,7 +10,7 @@ This page documents the root `lazyagent` command — the one you run to monitor 
 - [`lazyagent prune`](../maintenance/prune.md) — delete old or orphaned chat files
 - [`lazyagent compact`](../maintenance/compact.md) — truncate bulky payloads in place
 - [`lazyagent search`](../maintenance/search.md) — search transcript-file agents with highlighted snippets
-- [`lazyagent limits`](../maintenance/limits.md) — show 5-hour, weekly, and monthly usage summary; add `--detailed` for pace
+- [`lazyagent limits`](../maintenance/limits.md) — show 5-hour, weekly, and monthly usage summary; add `--detailed` for pace or `--json` for scripts
 - [`lazyagent sessions`](sessions.md) — list sessions for the current directory and reopen one
 
 ## Synopsis
@@ -180,7 +180,7 @@ Full reference, including the index location, ranking, and resume commands: [`se
 
 ### `limits`
 
-`limits` prints a one-shot summary table of the rate-limit / billing windows exposed by Claude Code, Codex, Grok, Kimi, and Cursor. The default table labels each 5-hour and weekly/global cell as `used` and `exp`, where `exp` is the linear pace for elapsed window time; `--detailed` prints the full per-window report with reset times and the pace indicator (`underutilizing` / `on track` / `overutilizing`). Claude and Codex each expose a 5-hour and a 7-day window; Grok exposes a single monthly credit window; Kimi exposes the windows returned by Kimi Code CLI's `/status` endpoint; Cursor exposes two monthly rows sharing one billing-cycle window — its Auto/Composer pool and its usage-based API pool, each against its own allowance.
+`limits` prints a one-shot summary table of the rate-limit / billing windows exposed by Claude Code, Codex, Grok, Kimi, and Cursor. The default table labels each 5-hour and weekly/global cell as `used` and `exp`, where `exp` is the linear pace for elapsed window time; `--detailed` prints the full per-window report with reset times and the pace indicator (`underutilizing` / `on track` / `overutilizing`); `--json` prints the same data, plus per-agent errors, as one JSON object for scripts and status-bar widgets. Claude and Codex each expose a 5-hour and a 7-day window; Grok exposes a single monthly credit window; Kimi exposes the windows returned by Kimi Code CLI's `/status` endpoint; Cursor exposes two monthly rows sharing one billing-cycle window — its Auto/Composer pool and its usage-based API pool, each against its own allowance.
 
 ```bash
 lazyagent limits                 # summary table for all supported limits providers
@@ -190,6 +190,7 @@ lazyagent limits --agent codex   # only Codex
 lazyagent limits --agent grok    # only Grok
 lazyagent limits --agent kimi    # only Kimi Code
 lazyagent limits --agent cursor  # only Cursor (Models + API pools)
+lazyagent limits --json          # machine-readable report for scripts and widgets
 ```
 
 Claude data comes from `/api/oauth/usage` on `api.anthropic.com` — the same undocumented endpoint Claude Code's `/status` calls. Codex data comes from `/backend-api/wham/usage` on `chatgpt.com` — the same endpoint the Codex CLI's TUI polls for its rate-limit display. Grok data comes from `/v1/billing` on `cli-chat-proxy.grok.com` — the same undocumented endpoint Grok CLI's `/usage show` slash command calls. Kimi data comes from `/coding/v1/usages` on `api.kimi.com`, the endpoint Kimi Code CLI's `/status` slash command calls. Cursor data comes from `/api/usage-summary` on `cursor.com` — the same endpoint the Cursor dashboard uses for its usage headline — read with the session token from Cursor's local `state.vscdb`; it reports the Auto/Composer and usage-based API pools as separate percentages, shown as two rows.

--- a/docs/usage/recipes.md
+++ b/docs/usage/recipes.md
@@ -60,6 +60,7 @@ lazyagent limits --agent claude  # just Claude
 lazyagent limits --agent grok    # just Grok (monthly billing)
 lazyagent limits --agent kimi    # just Kimi Code
 lazyagent limits --agent cursor  # just Cursor (Models + API pools)
+lazyagent limits --json          # the same data as JSON, for scripts and widgets
 ```
 
 In the `--detailed` output, the `Pace` line tells you whether you're consuming faster than linear (`overutilizing`), in line, or slower (`underutilizing`). If Claude reports `overutilizing` on the 5-hour window with hours still to go, that's a strong hint to defer the run or fan it out across days.

--- a/internal/cursor/paths.go
+++ b/internal/cursor/paths.go
@@ -12,10 +12,9 @@ import (
 // through here, so a wrong platform path hides Cursor entirely rather than
 // producing an error.
 func stateDBPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
+	// The home directory is only needed on macOS and Linux; a failed lookup
+	// must not hide an APPDATA-based Windows path.
+	home, _ := os.UserHomeDir()
 	return stateDBPathFor(runtime.GOOS, home, os.Getenv("XDG_CONFIG_HOME"), os.Getenv("APPDATA"))
 }
 
@@ -25,13 +24,15 @@ func stateDBPath() string {
 //   - macOS:   ~/Library/Application Support/Cursor
 //   - Linux:   $XDG_CONFIG_HOME/Cursor, defaulting to ~/.config/Cursor
 //   - Windows: %APPDATA%\Cursor
+//
+// It returns "" when the input that platform depends on is missing.
 func stateDBPathFor(goos, home, xdgConfigHome, appData string) string {
-	if home == "" {
-		return ""
-	}
 	var base string
 	switch goos {
 	case "darwin":
+		if home == "" {
+			return ""
+		}
 		base = filepath.Join(home, "Library", "Application Support", "Cursor")
 	case "windows":
 		if appData == "" {
@@ -40,6 +41,9 @@ func stateDBPathFor(goos, home, xdgConfigHome, appData string) string {
 		base = filepath.Join(appData, "Cursor")
 	default:
 		if xdgConfigHome == "" {
+			if home == "" {
+				return ""
+			}
 			xdgConfigHome = filepath.Join(home, ".config")
 		}
 		base = filepath.Join(xdgConfigHome, "Cursor")

--- a/internal/cursor/paths.go
+++ b/internal/cursor/paths.go
@@ -1,0 +1,48 @@
+package cursor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// stateDBPath returns the path to Cursor's global state.vscdb for the current
+// platform, or "" when the home directory cannot be resolved. Every reader of
+// Cursor state (session discovery, watch directories, the limits token) goes
+// through here, so a wrong platform path hides Cursor entirely rather than
+// producing an error.
+func stateDBPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return stateDBPathFor(runtime.GOOS, home, os.Getenv("XDG_CONFIG_HOME"), os.Getenv("APPDATA"))
+}
+
+// stateDBPathFor is the platform-specific rule behind stateDBPath, with every
+// input explicit so tests can cover each OS without changing the environment.
+// Cursor keeps its user data where VS Code does on each platform:
+//   - macOS:   ~/Library/Application Support/Cursor
+//   - Linux:   $XDG_CONFIG_HOME/Cursor, defaulting to ~/.config/Cursor
+//   - Windows: %APPDATA%\Cursor
+func stateDBPathFor(goos, home, xdgConfigHome, appData string) string {
+	if home == "" {
+		return ""
+	}
+	var base string
+	switch goos {
+	case "darwin":
+		base = filepath.Join(home, "Library", "Application Support", "Cursor")
+	case "windows":
+		if appData == "" {
+			return ""
+		}
+		base = filepath.Join(appData, "Cursor")
+	default:
+		if xdgConfigHome == "" {
+			xdgConfigHome = filepath.Join(home, ".config")
+		}
+		base = filepath.Join(xdgConfigHome, "Cursor")
+	}
+	return filepath.Join(base, "User", "globalStorage", "state.vscdb")
+}

--- a/internal/cursor/paths_test.go
+++ b/internal/cursor/paths_test.go
@@ -22,7 +22,10 @@ func TestStateDBPathFor(t *testing.T) {
 		{"freebsd follows linux", "freebsd", "/home/me", "", "", filepath.Join("/home/me", ".config", tail)},
 		{"windows", "windows", `C:\Users\me`, "", `C:\Users\me\AppData\Roaming`, filepath.Join(`C:\Users\me\AppData\Roaming`, tail)},
 		{"windows without APPDATA", "windows", `C:\Users\me`, "", "", ""},
-		{"no home", "linux", "", "", "", ""},
+		{"windows without home still uses APPDATA", "windows", "", "", `C:\Users\me\AppData\Roaming`, filepath.Join(`C:\Users\me\AppData\Roaming`, tail)},
+		{"linux without home but with XDG_CONFIG_HOME", "linux", "", "/etc/xdg-home", "", filepath.Join("/etc/xdg-home", tail)},
+		{"linux without home", "linux", "", "", "", ""},
+		{"darwin without home", "darwin", "", "", "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cursor/paths_test.go
+++ b/internal/cursor/paths_test.go
@@ -1,0 +1,44 @@
+package cursor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestStateDBPathFor(t *testing.T) {
+	tail := filepath.Join("Cursor", "User", "globalStorage", "state.vscdb")
+	cases := []struct {
+		name          string
+		goos          string
+		home          string
+		xdgConfigHome string
+		appData       string
+		want          string
+	}{
+		{"darwin", "darwin", "/Users/me", "", "", filepath.Join("/Users/me", "Library", "Application Support", tail)},
+		{"darwin ignores XDG", "darwin", "/Users/me", "/xdg", "", filepath.Join("/Users/me", "Library", "Application Support", tail)},
+		{"linux default", "linux", "/home/me", "", "", filepath.Join("/home/me", ".config", tail)},
+		{"linux XDG_CONFIG_HOME", "linux", "/home/me", "/home/me/cfg", "", filepath.Join("/home/me/cfg", tail)},
+		{"freebsd follows linux", "freebsd", "/home/me", "", "", filepath.Join("/home/me", ".config", tail)},
+		{"windows", "windows", `C:\Users\me`, "", `C:\Users\me\AppData\Roaming`, filepath.Join(`C:\Users\me\AppData\Roaming`, tail)},
+		{"windows without APPDATA", "windows", `C:\Users\me`, "", "", ""},
+		{"no home", "linux", "", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stateDBPathFor(tc.goos, tc.home, tc.xdgConfigHome, tc.appData); got != tc.want {
+				t.Errorf("stateDBPathFor(%q) = %q, want %q", tc.goos, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStateDBDirIsParentOfPath(t *testing.T) {
+	p := stateDBPath()
+	if p == "" {
+		t.Skip("home directory not resolvable")
+	}
+	if got, want := StateDBDir(), filepath.Dir(p); got != want {
+		t.Errorf("StateDBDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/cursor/process.go
+++ b/internal/cursor/process.go
@@ -47,15 +47,6 @@ func NewSessionCache() *SessionCache {
 	return &SessionCache{entries: make(map[string]*cachedSession)}
 }
 
-// stateDBPath returns the path to Cursor's global state.vscdb.
-func stateDBPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb")
-}
-
 // StateDBDir returns the directory containing state.vscdb for WatchDirs.
 func StateDBDir() string {
 	p := stateDBPath()

--- a/internal/limits/json.go
+++ b/internal/limits/json.go
@@ -1,0 +1,155 @@
+package limits
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+// limitsJSON is the wire shape of `lazyagent limits --json`. Field names are
+// part of the CLI contract: external consumers (shell widgets, dashboards,
+// scripts) parse this instead of the human table, so keys are stable and
+// every field is always present. Slices encode as [] rather than null.
+type limitsJSON struct {
+	GeneratedAt time.Time    `json:"generated_at"`
+	Reports     []reportJSON `json:"reports"`
+	Errors      []errorJSON  `json:"errors"`
+}
+
+// reportJSON is one metered pool. Cursor emits two rows with the same agent id
+// ("cursor") and different provider names, matching the human table.
+type reportJSON struct {
+	Agent     string       `json:"agent"`      // "claude" | "codex" | "grok" | "kimi" | "cursor"
+	Provider  string       `json:"provider"`   // "Claude Code", "Cursor Models", ...
+	ShortName string       `json:"short_name"` // summary-table label: "Claude", "Kimi", ...
+	Source    string       `json:"source"`
+	Note      string       `json:"note"`
+	Windows   []windowJSON `json:"windows"`
+	Summary   summaryJSON  `json:"summary"`
+}
+
+type windowJSON struct {
+	Label           string     `json:"label"`
+	WindowMinutes   int        `json:"window_minutes"`
+	UsedPercent     float64    `json:"used_percent"`
+	ExpectedPercent float64    `json:"expected_percent"` // linear pace for elapsed window time
+	PaceKnown       bool       `json:"pace_known"`
+	PaceRatio       float64    `json:"pace_ratio"` // used / expected; 0 when pace is unknown
+	PaceLabel       string     `json:"pace_label"` // "underutilizing" | "on track" | "overutilizing" | ""
+	UsedSeverity    Severity   `json:"used_severity"`
+	ResetsAt        *time.Time `json:"resets_at"`        // null when the provider gives no reset time
+	ResetInSeconds  int64      `json:"reset_in_seconds"` // 0 when unknown or already passed
+	ResetRelative   string     `json:"reset_relative"`   // "in 3h 17m" or ""
+}
+
+// summaryJSON mirrors the two columns of the human table. A cell is null when
+// the provider does not expose that window, which is what the table prints
+// as "--".
+type summaryJSON struct {
+	FiveHour   *summaryCellJSON `json:"five_hour"`
+	WeekGlobal *summaryCellJSON `json:"week_global"`
+}
+
+type summaryCellJSON struct {
+	UsedPercent     float64  `json:"used_percent"`
+	ExpectedPercent float64  `json:"expected_percent"`
+	Severity        Severity `json:"severity"`
+	Text            string   `json:"text"`
+}
+
+// errorJSON records why an agent produced no report. Kinds:
+//   - "not_installed": no credentials or footprint on this machine
+//   - "unavailable":   installed, but nothing meaningful to report (e.g. an
+//     unlimited Cursor plan)
+//   - "error":         a real failure (network, expired token, bad response)
+//
+// The human output hides the first two kinds in `--agent all` mode; the JSON
+// output always lists them so a consumer can tell "not installed" from
+// "installed but failed" without re-deriving that from the machine.
+type errorJSON struct {
+	Agent   string `json:"agent"`
+	Kind    string `json:"kind"`
+	Message string `json:"message"`
+}
+
+func buildJSON(results []agentReport, errs []agentError, now time.Time) limitsJSON {
+	out := limitsJSON{
+		GeneratedAt: now,
+		Reports:     make([]reportJSON, 0, len(results)),
+		Errors:      make([]errorJSON, 0, len(errs)),
+	}
+	for _, ar := range results {
+		out.Reports = append(out.Reports, buildReportJSON(ar, now))
+	}
+	for _, ae := range errs {
+		out.Errors = append(out.Errors, errorJSON{
+			Agent:   ae.agent,
+			Kind:    ae.kind,
+			Message: ae.message(),
+		})
+	}
+	return out
+}
+
+func buildReportJSON(ar agentReport, now time.Time) reportJSON {
+	r := ar.report
+	rj := reportJSON{
+		Agent:     ar.agent,
+		Provider:  r.Provider,
+		ShortName: summaryProviderName(r.Provider),
+		Source:    r.Source,
+		Note:      r.Note,
+		Windows:   make([]windowJSON, 0, len(r.Windows)),
+		Summary: summaryJSON{
+			FiveHour:   buildSummaryCellJSON(r, summaryFiveHour, now),
+			WeekGlobal: buildSummaryCellJSON(r, summaryWeekGlobal, now),
+		},
+	}
+	for _, w := range r.Windows {
+		rj.Windows = append(rj.Windows, buildWindowJSON(w, now))
+	}
+	return rj
+}
+
+func buildWindowJSON(w Window, now time.Time) windowJSON {
+	wv := buildWindowView(w, now)
+	wj := windowJSON{
+		Label:           wv.Label,
+		WindowMinutes:   w.WindowMinutes,
+		UsedPercent:     wv.UsedPercent,
+		ExpectedPercent: wv.ExpectedPercent,
+		PaceKnown:       wv.PaceKnown,
+		PaceRatio:       wv.PaceRatio,
+		PaceLabel:       wv.PaceLabel,
+		UsedSeverity:    wv.UsedSeverity,
+		ResetRelative:   wv.ResetRelative,
+	}
+	if !w.ResetsAt.IsZero() {
+		resetsAt := w.ResetsAt
+		wj.ResetsAt = &resetsAt
+		if rem := w.ResetsAt.Sub(now); rem > 0 {
+			wj.ResetInSeconds = int64(rem.Seconds())
+		}
+	}
+	return wj
+}
+
+func buildSummaryCellJSON(r Report, kind summaryWindowKind, now time.Time) *summaryCellJSON {
+	cell := buildSummaryCell(r, kind, now)
+	if !cell.Present {
+		return nil
+	}
+	return &summaryCellJSON{
+		UsedPercent:     cell.UsedPercent,
+		ExpectedPercent: cell.ExpectedPercent,
+		Severity:        cell.Severity,
+		Text:            cell.Text,
+	}
+}
+
+// writeJSON emits the payload as indented JSON followed by a newline.
+func writeJSON(w io.Writer, results []agentReport, errs []agentError, now time.Time) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(buildJSON(results, errs, now))
+}

--- a/internal/limits/json_test.go
+++ b/internal/limits/json_test.go
@@ -1,0 +1,201 @@
+package limits
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteJSONShape(t *testing.T) {
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	results := []agentReport{
+		{agent: "claude", report: Report{
+			Provider: "Claude Code",
+			Source:   "source note",
+			Note:     "disclaimer",
+			Windows: []Window{
+				// 50% used, 50% elapsed => on track, info severity.
+				{Label: "5-hour", WindowMinutes: 300, UsedPercent: 50, ResetsAt: now.Add(150 * time.Minute)},
+				// 95% used => danger; reset 24h out of 7d.
+				{Label: "7-day", WindowMinutes: 7 * 24 * 60, UsedPercent: 95, ResetsAt: now.Add(24 * time.Hour)},
+			},
+		}},
+		{agent: "cursor", report: Report{
+			Provider: "Cursor API",
+			// No reset time and no known window length: pace and reset are unknown.
+			Windows: []Window{{Label: "monthly", UsedPercent: 12}},
+		}},
+	}
+	errs := []agentError{
+		{agent: "grok", kind: errKindNotInstalled, err: errAgentNotInstalled},
+		{agent: "kimi", kind: errKindError, err: errors.New("HTTP 401")},
+	}
+
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, results, errs, now); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	if !strings.HasSuffix(buf.String(), "\n") {
+		t.Error("output should end with a newline")
+	}
+
+	var got struct {
+		GeneratedAt time.Time `json:"generated_at"`
+		Reports     []struct {
+			Agent     string `json:"agent"`
+			Provider  string `json:"provider"`
+			ShortName string `json:"short_name"`
+			Source    string `json:"source"`
+			Note      string `json:"note"`
+			Windows   []struct {
+				Label           string     `json:"label"`
+				WindowMinutes   int        `json:"window_minutes"`
+				UsedPercent     float64    `json:"used_percent"`
+				ExpectedPercent float64    `json:"expected_percent"`
+				PaceKnown       bool       `json:"pace_known"`
+				PaceRatio       float64    `json:"pace_ratio"`
+				PaceLabel       string     `json:"pace_label"`
+				UsedSeverity    string     `json:"used_severity"`
+				ResetsAt        *time.Time `json:"resets_at"`
+				ResetInSeconds  int64      `json:"reset_in_seconds"`
+				ResetRelative   string     `json:"reset_relative"`
+			} `json:"windows"`
+			Summary struct {
+				FiveHour   *map[string]any `json:"five_hour"`
+				WeekGlobal *map[string]any `json:"week_global"`
+			} `json:"summary"`
+		} `json:"reports"`
+		Errors []struct {
+			Agent   string `json:"agent"`
+			Kind    string `json:"kind"`
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+
+	if !got.GeneratedAt.Equal(now) {
+		t.Errorf("generated_at = %v, want %v", got.GeneratedAt, now)
+	}
+	if len(got.Reports) != 2 {
+		t.Fatalf("reports = %d, want 2", len(got.Reports))
+	}
+
+	claude := got.Reports[0]
+	if claude.Agent != "claude" || claude.Provider != "Claude Code" || claude.ShortName != "Claude" {
+		t.Errorf("claude identity = %q/%q/%q", claude.Agent, claude.Provider, claude.ShortName)
+	}
+	if claude.Source != "source note" || claude.Note != "disclaimer" {
+		t.Errorf("claude source/note = %q/%q", claude.Source, claude.Note)
+	}
+	if len(claude.Windows) != 2 {
+		t.Fatalf("claude windows = %d, want 2", len(claude.Windows))
+	}
+	fiveH := claude.Windows[0]
+	if fiveH.Label != "5-hour" || fiveH.WindowMinutes != 300 || fiveH.UsedPercent != 50 {
+		t.Errorf("5h window = %+v", fiveH)
+	}
+	if fiveH.ExpectedPercent < 49 || fiveH.ExpectedPercent > 51 {
+		t.Errorf("5h expected_percent = %.1f, want ~50", fiveH.ExpectedPercent)
+	}
+	if !fiveH.PaceKnown || fiveH.PaceLabel != "on track" || fiveH.PaceRatio < 0.99 || fiveH.PaceRatio > 1.01 {
+		t.Errorf("5h pace = known=%v label=%q ratio=%.2f", fiveH.PaceKnown, fiveH.PaceLabel, fiveH.PaceRatio)
+	}
+	if fiveH.UsedSeverity != string(SevInfo) {
+		t.Errorf("5h used_severity = %q, want %q", fiveH.UsedSeverity, SevInfo)
+	}
+	if fiveH.ResetsAt == nil || !fiveH.ResetsAt.Equal(now.Add(150*time.Minute)) {
+		t.Errorf("5h resets_at = %v", fiveH.ResetsAt)
+	}
+	if fiveH.ResetInSeconds != 150*60 || fiveH.ResetRelative != "in 2h 30m" {
+		t.Errorf("5h reset = %d s / %q", fiveH.ResetInSeconds, fiveH.ResetRelative)
+	}
+	if claude.Windows[1].UsedSeverity != string(SevDanger) {
+		t.Errorf("7d used_severity = %q, want %q", claude.Windows[1].UsedSeverity, SevDanger)
+	}
+	if claude.Summary.FiveHour == nil || claude.Summary.WeekGlobal == nil {
+		t.Fatalf("claude summary cells missing: %+v", claude.Summary)
+	}
+	if sev := (*claude.Summary.WeekGlobal)["severity"]; sev != string(SevDanger) {
+		t.Errorf("week_global severity = %v, want %q", sev, SevDanger)
+	}
+	if text := (*claude.Summary.FiveHour)["text"]; !strings.Contains(text.(string), "50.0% used") {
+		t.Errorf("five_hour text = %v", text)
+	}
+
+	cursor := got.Reports[1]
+	if cursor.Agent != "cursor" || cursor.ShortName != "Cursor API" {
+		t.Errorf("cursor identity = %q/%q", cursor.Agent, cursor.ShortName)
+	}
+	if cursor.Summary.FiveHour != nil {
+		t.Errorf("cursor five_hour = %v, want null", *cursor.Summary.FiveHour)
+	}
+	if cursor.Summary.WeekGlobal == nil {
+		t.Error("cursor week_global = null, want the monthly window")
+	}
+	monthly := cursor.Windows[0]
+	if monthly.ResetsAt != nil || monthly.ResetInSeconds != 0 || monthly.ResetRelative != "" {
+		t.Errorf("monthly reset should be unknown: %+v", monthly)
+	}
+	if monthly.PaceKnown || monthly.PaceLabel != "" || monthly.PaceRatio != 0 {
+		t.Errorf("monthly pace should be unknown: %+v", monthly)
+	}
+
+	if len(got.Errors) != 2 {
+		t.Fatalf("errors = %d, want 2", len(got.Errors))
+	}
+	if got.Errors[0].Agent != "grok" || got.Errors[0].Kind != errKindNotInstalled ||
+		got.Errors[0].Message != notInstalledMessage("grok") {
+		t.Errorf("grok error = %+v", got.Errors[0])
+	}
+	if got.Errors[1].Agent != "kimi" || got.Errors[1].Kind != errKindError || got.Errors[1].Message != "HTTP 401" {
+		t.Errorf("kimi error = %+v", got.Errors[1])
+	}
+}
+
+func TestWriteJSONEmptyEncodesArrays(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeJSON(&buf, nil, nil, time.Now()); err != nil {
+		t.Fatalf("writeJSON: %v", err)
+	}
+	s := buf.String()
+	if !strings.Contains(s, `"reports": []`) || !strings.Contains(s, `"errors": []`) {
+		t.Errorf("empty slices should encode as [], got:\n%s", s)
+	}
+}
+
+func TestExitCodeFor(t *testing.T) {
+	report := agentReport{agent: "claude", report: Report{Provider: "Claude Code"}}
+	notInstalled := agentError{agent: "grok", kind: errKindNotInstalled, err: errAgentNotInstalled}
+	unavailable := agentError{agent: "cursor", kind: errKindUnavailable, err: errAgentUnavailable}
+	hard := agentError{agent: "kimi", kind: errKindError, err: errors.New("boom")}
+
+	cases := []struct {
+		name      string
+		results   []agentReport
+		errs      []agentError
+		requested int
+		explicit  bool
+		want      int
+	}{
+		{"all ok", []agentReport{report}, nil, 5, false, 0},
+		{"all mode skips missing", []agentReport{report}, []agentError{notInstalled, unavailable}, 5, false, 0},
+		{"all mode hard error", []agentReport{report}, []agentError{hard}, 5, false, 1},
+		{"all mode nothing found", nil, []agentError{notInstalled, notInstalled, unavailable, notInstalled, notInstalled}, 5, false, 1},
+		{"explicit ok", []agentReport{report}, nil, 1, true, 0},
+		{"explicit missing", nil, []agentError{notInstalled}, 1, true, 1},
+		{"explicit unavailable", nil, []agentError{unavailable}, 1, true, 1},
+		{"explicit hard error", nil, []agentError{hard}, 1, true, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exitCodeFor(tc.results, tc.errs, tc.requested, tc.explicit); got != tc.want {
+				t.Errorf("exitCodeFor = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/limits/run.go
+++ b/internal/limits/run.go
@@ -62,6 +62,39 @@ var errAgentUnavailable = errors.New("agent unavailable")
 type options struct {
 	agent    string
 	detailed bool
+	json     bool
+}
+
+// agentReport pairs a report with the agent id it was fetched for. The Report
+// itself only carries the display name ("Cursor Models"), and JSON consumers
+// need the stable id ("cursor") to key on.
+type agentReport struct {
+	agent  string
+	report Report
+}
+
+// Error kinds recorded by collect. They double as the "kind" value in the JSON
+// output, so they are stable strings rather than an enum.
+const (
+	errKindNotInstalled = "not_installed"
+	errKindUnavailable  = "unavailable"
+	errKindError        = "error"
+)
+
+// agentError records why one agent produced no report.
+type agentError struct {
+	agent string
+	kind  string
+	err   error
+}
+
+// message returns the user-facing text for the error, matching what the
+// human output prints on stderr for the same case.
+func (e agentError) message() string {
+	if e.kind == errKindNotInstalled {
+		return notInstalledMessage(e.agent)
+	}
+	return e.err.Error()
 }
 
 // Run is the entry point invoked by main.go for `lazyagent limits ...`.
@@ -72,6 +105,7 @@ func Run(args []string) int {
 	var opts options
 	fs.StringVar(&opts.agent, "agent", "all", "Which agent to query: claude, codex, grok, kimi, cursor, all")
 	fs.BoolVar(&opts.detailed, "detailed", false, "Show the detailed per-window report with bars, reset times, sources, and notes")
+	fs.BoolVar(&opts.json, "json", false, "Print every window, pace, and per-agent error as JSON (for scripts and widgets)")
 
 	fs.Usage = func() {
 		fmt.Fprint(os.Stderr, `lazyagent limits — show rate-limit usage
@@ -79,6 +113,7 @@ func Run(args []string) int {
 Usage:
   lazyagent limits                  Show a summary table for Claude Code, Codex, Grok, Kimi, and Cursor
   lazyagent limits --detailed       Show detailed per-window reports with pace and reset times
+  lazyagent limits --json           Print the full report as JSON (windows, pace, reset times, errors)
   lazyagent limits --agent claude   Show only Claude Code limits
   lazyagent limits --agent codex    Show only Codex limits
   lazyagent limits --agent grok     Show only Grok limits
@@ -89,6 +124,12 @@ Summary output:
   The default table shows used % and expected % for the 5-hour window and the
   weekly/global window. Expected % is the linear pace for elapsed window time.
   Missing windows are shown as --.
+
+JSON output:
+  --json prints one object with "reports" (every window with used %, expected %,
+  pace, severity, and reset time) and "errors" (agents that produced no report,
+  each tagged not_installed, unavailable, or error). Nothing else is written to
+  stdout, and --detailed is redundant because the JSON is always complete.
 
 Detailed output explains:
   - Used %:    how much of the window has been consumed
@@ -149,50 +190,42 @@ Flags:
 	defer cancel()
 
 	now := time.Now()
-	var out strings.Builder
-	exitCode := 0
-	var reports []Report
-	missing := 0
 	explicit := len(agents) == 1
-	for _, a := range agents {
-		rs, err := fetchReports(ctx, a)
-		if err != nil {
-			if errors.Is(err, errAgentNotInstalled) {
-				missing++
-				if explicit {
-					fmt.Fprintln(os.Stderr, notInstalledMessage(a))
-					exitCode = 1
-				}
-				// In `all` mode, silently skip — we'll print a single combined
-				// message at the end if nothing was shown.
-				continue
-			}
-			if errors.Is(err, errAgentUnavailable) {
-				missing++
-				if explicit {
-					// The wrapped error already carries a user-facing, actionable
-					// message (unlike the generic not-installed text).
-					fmt.Fprintf(os.Stderr, "%v\n", err)
-					exitCode = 1
-				}
-				// In `all` mode, skip silently like a missing agent.
-				continue
-			}
-			fmt.Fprintf(os.Stderr, "Error (%s): %v\n", a, err)
-			exitCode = 1
-			continue
+	results, errs := collect(ctx, agents)
+	exitCode := exitCodeFor(results, errs, len(agents), explicit)
+
+	if opts.json {
+		if err := writeJSON(os.Stdout, results, errs, now); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
 		}
-		reports = append(reports, rs...)
+		return exitCode
 	}
 
-	// All agents were missing AND no real errors fired: tell the user once,
-	// rather than letting them stare at an empty stdout and wonder what happened.
-	if len(reports) == 0 && !explicit && missing == len(agents) {
+	// Missing and unavailable agents are only worth a message when the user
+	// asked for that agent by name. In `all` mode they are skipped silently,
+	// and a single combined message covers the case where nothing was found.
+	for _, ae := range errs {
+		switch ae.kind {
+		case errKindNotInstalled, errKindUnavailable:
+			if explicit {
+				fmt.Fprintln(os.Stderr, ae.message())
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "Error (%s): %v\n", ae.agent, ae.err)
+		}
+	}
+	if allMissing(results, errs, len(agents), explicit) {
 		fmt.Fprintln(os.Stderr, "No supported agents are installed (none of Claude Code, Codex, Grok, Kimi, or Cursor was detected).")
 		fmt.Fprintln(os.Stderr, "Run `claude` / `codex` / `grok login` / `kimi login`, or sign in to Cursor.")
-		exitCode = 1
 	}
 
+	reports := make([]Report, 0, len(results))
+	for _, ar := range results {
+		reports = append(reports, ar.report)
+	}
+
+	var out strings.Builder
 	if len(reports) > 0 {
 		if opts.detailed {
 			for i, report := range reports {
@@ -208,6 +241,62 @@ Flags:
 
 	fmt.Print(out.String())
 	return exitCode
+}
+
+// collect fetches every requested agent in order and classifies each failure.
+// It never prints; the caller decides what each error kind means for its
+// output format.
+func collect(ctx context.Context, agents []string) ([]agentReport, []agentError) {
+	var results []agentReport
+	var errs []agentError
+	for _, a := range agents {
+		rs, err := fetchReports(ctx, a)
+		if err != nil {
+			kind := errKindError
+			switch {
+			case errors.Is(err, errAgentNotInstalled):
+				kind = errKindNotInstalled
+			case errors.Is(err, errAgentUnavailable):
+				kind = errKindUnavailable
+			}
+			errs = append(errs, agentError{agent: a, kind: kind, err: err})
+			continue
+		}
+		for _, r := range rs {
+			results = append(results, agentReport{agent: a, report: r})
+		}
+	}
+	return results, errs
+}
+
+// allMissing reports the `--agent all` case where every agent was skipped as
+// not installed or unavailable and nothing else went wrong.
+func allMissing(results []agentReport, errs []agentError, requested int, explicit bool) bool {
+	if explicit || len(results) > 0 {
+		return false
+	}
+	missing := 0
+	for _, ae := range errs {
+		if ae.kind == errKindNotInstalled || ae.kind == errKindUnavailable {
+			missing++
+		}
+	}
+	return missing == requested
+}
+
+// exitCodeFor applies the documented exit-code rules, shared by the human and
+// JSON outputs: 1 when any agent failed outright, when an explicitly requested
+// agent is missing or unavailable, or when `--agent all` found nothing at all.
+func exitCodeFor(results []agentReport, errs []agentError, requested int, explicit bool) int {
+	for _, ae := range errs {
+		if ae.kind == errKindError || explicit {
+			return 1
+		}
+	}
+	if allMissing(results, errs, requested, explicit) {
+		return 1
+	}
+	return 0
 }
 
 // notInstalledMessage returns the user-facing string when --agent X is explicit

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ Subcommands:
   lazyagent latest              Resume the most recent session for the current directory
   lazyagent latest --help       Show latest options (--agent, --dir, --yolo)
   lazyagent limits              Show rate-limit / billing usage summary
-  lazyagent limits --help       Show limits options (--agent claude|codex|grok|kimi|all, --detailed)
+  lazyagent limits --help       Show limits options (--agent claude|codex|grok|kimi|cursor|all, --detailed, --json)
   lazyagent passphrase          Set or rotate the HTTP API passphrase
   lazyagent passphrase --show   Print the current bearer token without prompting
 


### PR DESCRIPTION
## Summary

Two changes to `lazyagent limits`, both needed by external consumers such as status-bar widgets.

### `lazyagent limits --json`

Prints one JSON object to stdout and nothing else, so the output can go straight into `jq`, a dashboard, or a shell widget.

- `reports`: one entry per metered pool in canonical order (`claude`, `codex`, `grok`, `kimi`, `cursor`). Each carries the stable `agent` id, `provider` and `short_name` display names, `source` and `note`, every window with `used_percent`, `expected_percent`, pace (`pace_known`, `pace_ratio`, `pace_label`), `used_severity`, and the reset time as RFC 3339, seconds, and relative string, plus the two summary-table cells (`five_hour`, `week_global`, `null` when the provider has no such window).
- `errors`: agents that produced no report, tagged `not_installed`, `unavailable`, or `error`, with the same actionable message the human output prints. Unlike the table, JSON lists absent agents even under `--agent all`, so a consumer can hide a provider that is simply missing instead of treating it as broken.
- Exit codes are unchanged. `--detailed` is redundant with `--json` and is ignored.
- Field names are part of the CLI contract; every key is always present and empty lists encode as `[]`.

Internally `Run` is split into `collect` (fetch and classify, no printing) and `exitCodeFor` (shared rules), so the human and JSON paths cannot drift.

### Cursor on Linux and Windows

`stateDBPath` was hardcoded to `~/Library/Application Support/Cursor`, so outside macOS Cursor looked uninstalled: no sessions in the TUI or GUI, and no Cursor rows in `limits`. The path is now chosen per platform, following VS Code's user-data locations:

| OS | Path |
|----|------|
| macOS | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` |
| Linux | `$XDG_CONFIG_HOME/Cursor/User/globalStorage/state.vscdb` (default `~/.config/Cursor/...`) |
| Windows | `%APPDATA%\Cursor\User\globalStorage\state.vscdb` |

Every reader of Cursor state (session discovery, watch directories, the limits token) goes through this function, so the fix covers all of them.

## Docs

- New "JSON output" section in `docs/maintenance/limits.md` with an example and per-field tables; `--json` mentioned in the CLI reference, recipes, README, and `--help`.
- Per-platform Cursor paths in `docs/concepts/supported-agents.md` and `docs/maintenance/limits.md`.
- Roadmap entries for both changes.

## Testing

- `internal/limits/json_test.go`: output shape and values, unknown pace and reset, `[]` for empty slices, exit-code matrix.
- `internal/cursor/paths_test.go`: path resolution per OS, including `XDG_CONFIG_HOME` and missing `APPDATA`.
- `go vet ./...` and `go test ./...` pass.
- Verified on Linux against real accounts: Claude, Codex, Grok, and both Cursor rows reported; Kimi listed under `errors` as `not_installed`; `--agent kimi --json` exits 1 with the error in the payload.
