### PR TITLE
fix(codex): read oversized rollout records without losing activity

### DIFF
--- a/docs/concepts/supported-agents.md
+++ b/docs/concepts/supported-agents.md
@@ -61,6 +61,8 @@ CWD is inferred from the Cursor workspace URI if available, otherwise from the f
 
 Codex writes one JSONL per session under `~/.codex/sessions/YYYY/MM/DD/`. A separate `~/.codex/session_index.jsonl` carries the user-chosen thread names, which lazyagent joins into the session list.
 
+Session discovery reads records larger than 4 MiB, including embedded tool output, so large records do not hide later activity. If the last record is still being written, lazyagent retries it on the next refresh.
+
 ### Amp CLI
 
 Amp keeps a JSON blob per thread under `~/.local/share/amp/threads/*.json`. Newer Amp versions no longer write this locally — they sync from the server on demand. lazyagent works around this by running `amp threads export` every 15 seconds, diffing the result, and refreshing the local cache so you still see live threads.

--- a/docs/concepts/supported-agents.md
+++ b/docs/concepts/supported-agents.md
@@ -61,7 +61,7 @@ CWD is inferred from the Cursor workspace URI if available, otherwise from the f
 
 Codex writes one JSONL per session under `~/.codex/sessions/YYYY/MM/DD/`. A separate `~/.codex/session_index.jsonl` carries the user-chosen thread names, which lazyagent joins into the session list.
 
-Session discovery reads records larger than 4 MiB, including embedded tool output, so large records do not hide later activity. If the last record is still being written, lazyagent retries it on the next refresh.
+Session discovery reads records larger than 4 MiB, including embedded tool output, so large records do not hide later activity. Large records are processed with bounded memory: unused payloads are streamed past and message previews are truncated. If the last record is still being written, lazyagent retries it on the next refresh.
 
 ### Amp CLI
 

--- a/internal/codex/process.go
+++ b/internal/codex/process.go
@@ -555,6 +555,10 @@ func parseJSONL(path string, offset int64, base *model.Session) (*model.Session,
 		}
 	}
 
+	return parseJSONLReader(f, path, offset, base)
+}
+
+func parseJSONLReader(r io.Reader, path string, offset int64, base *model.Session) (*model.Session, int64, error) {
 	var session *model.Session
 	if base != nil {
 		session = base.Clone()
@@ -566,8 +570,9 @@ func parseJSONL(path string, offset int64, base *model.Session) (*model.Session,
 		}
 	}
 
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	// Rollouts can contain individual records much larger than Scanner's
+	// token limit, for example item_completed events with embedded output.
+	reader := bufio.NewReaderSize(r, 64*1024)
 
 	bytesConsumed := offset
 	var last lastMeaningful
@@ -575,13 +580,28 @@ func parseJSONL(path string, offset int64, base *model.Session) (*model.Session,
 		last = lastMeaningful{Kind: statusKind(base.Status), Timestamp: base.LastActivity, ToolName: base.CurrentTool}
 	}
 
-	for scanner.Scan() {
-		bytesConsumed += int64(len(scanner.Bytes())) + 1
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if readErr != nil && readErr != io.EOF {
+			return nil, 0, fmt.Errorf("read codex session %q: %w", path, readErr)
+		}
+		if len(line) == 0 {
+			break
+		}
 
 		var env jsonlEnvelope
-		if err := json.Unmarshal(scanner.Bytes(), &env); err != nil {
+		if err := json.Unmarshal(line, &env); err != nil {
+			if readErr == io.EOF {
+				// The writer may still be appending this record. Leave the
+				// offset at its start so the next refresh can read it again.
+				break
+			}
+			bytesConsumed += int64(len(line))
 			continue
 		}
+		// Count actual bytes, including CRLF, and accept complete JSON at
+		// EOF even when the final newline has not been written yet.
+		bytesConsumed += int64(len(line))
 
 		ts, _ := time.Parse(time.RFC3339Nano, env.Timestamp)
 		if !ts.IsZero() {
@@ -687,10 +707,6 @@ func parseJSONL(path string, offset int64, base *model.Session) (*model.Session,
 	}
 	if !last.Timestamp.IsZero() {
 		session.LastActivity = last.Timestamp
-	}
-
-	if fi, err := f.Stat(); err == nil && bytesConsumed > fi.Size() {
-		bytesConsumed = fi.Size()
 	}
 
 	return session, bytesConsumed, nil

--- a/internal/codex/process.go
+++ b/internal/codex/process.go
@@ -570,9 +570,7 @@ func parseJSONLReader(r io.Reader, path string, offset int64, base *model.Sessio
 		}
 	}
 
-	// Rollouts can contain individual records much larger than Scanner's
-	// token limit, for example item_completed events with embedded output.
-	reader := bufio.NewReaderSize(r, 64*1024)
+	reader := bufio.NewReaderSize(r, rolloutBufferSize)
 
 	bytesConsumed := offset
 	var last lastMeaningful
@@ -581,27 +579,27 @@ func parseJSONLReader(r io.Reader, path string, offset int64, base *model.Sessio
 	}
 
 	for {
-		line, readErr := reader.ReadBytes('\n')
-		if readErr != nil && readErr != io.EOF {
+		line, consumed, terminated, readErr := readRolloutRecord(reader)
+		if readErr != nil {
 			return nil, 0, fmt.Errorf("read codex session %q: %w", path, readErr)
 		}
-		if len(line) == 0 {
+		if consumed == 0 {
 			break
 		}
 
 		var env jsonlEnvelope
 		if err := json.Unmarshal(line, &env); err != nil {
-			if readErr == io.EOF {
+			if !terminated {
 				// The writer may still be appending this record. Leave the
 				// offset at its start so the next refresh can read it again.
 				break
 			}
-			bytesConsumed += int64(len(line))
+			bytesConsumed += consumed
 			continue
 		}
 		// Count actual bytes, including CRLF, and accept complete JSON at
 		// EOF even when the final newline has not been written yet.
-		bytesConsumed += int64(len(line))
+		bytesConsumed += consumed
 
 		ts, _ := time.Parse(time.RFC3339Nano, env.Timestamp)
 		if !ts.IsZero() {

--- a/internal/codex/reader_test.go
+++ b/internal/codex/reader_test.go
@@ -1,0 +1,190 @@
+package codex
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"time"
+
+	"github.com/illegalstudio/lazyagent/internal/model"
+)
+
+func TestParseJSONLLargeRecords(t *testing.T) {
+	initial := `{"timestamp":"2026-09-04T13:00:00Z","type":"session_meta","payload":{"id":"large-session","cwd":"/tmp/project"}}` + "\n" +
+		`{"timestamp":"2026-09-04T13:00:01Z","type":"event_msg","payload":{"type":"user_message"}}` + "\n"
+	// Codex can embed large tool results in item_completed events. Large
+	// messages must also be parsed, including the records after them.
+	largeText := strings.Repeat("x", 5*1024*1024)
+	more := `{"timestamp":"2026-09-04T13:00:02Z","type":"event_msg","payload":{"type":"item_completed","item":{"output":"` + largeText + `"}}}` + "\n" +
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"` + largeText + `"}]}}` + "\n" +
+		`{"timestamp":"2026-09-08T17:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}` + "\n"
+
+	for _, incremental := range []bool{false, true} {
+		name := "full"
+		if incremental {
+			name = "incremental"
+		}
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "session.jsonl")
+			var base *model.Session
+			var offset int64
+			if incremental {
+				if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				var err error
+				base, offset, err = ParseJSONL(path)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			if err := os.WriteFile(path, []byte(initial+more), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got, consumed, err := ParseJSONLIncremental(path, offset, base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if consumed != int64(len(initial)+len(more)) {
+				t.Fatalf("consumed = %d, want %d", consumed, len(initial)+len(more))
+			}
+			wantActivity := time.Date(2026, 9, 8, 17, 0, 1, 0, time.UTC)
+			if !got.LastActivity.Equal(wantActivity) || got.Status != model.StatusWaitingForUser {
+				t.Fatalf("activity/status = %s/%v, want %s/waiting", got.LastActivity, got.Status, wantActivity)
+			}
+			if got.UserMessages != 1 || got.AssistantMessages != 1 || got.TotalMessages != 2 {
+				t.Fatalf("message counts = %d/%d/%d, want 1/1/2", got.UserMessages, got.AssistantMessages, got.TotalMessages)
+			}
+			if len(got.RecentMessages) != 2 || got.RecentMessages[0].Text != strings.Repeat("x", 300) || got.RecentMessages[1].Text != "done" {
+				t.Fatal("large message preview or subsequent assistant message missing")
+			}
+			if base != nil && (base.TotalMessages != 0 || !base.LastActivity.Before(wantActivity)) {
+				t.Fatal("incremental parse changed the cached base session")
+			}
+		})
+	}
+}
+
+func TestParseJSONLIncrementalLineBoundaries(t *testing.T) {
+	meta := `{"timestamp":"2026-09-08T17:00:00Z","type":"session_meta","payload":{"id":"boundaries"}}`
+	message := `{"timestamp":"2026-09-08T17:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}`
+	next := `{"timestamp":"2026-09-08T17:00:02Z","type":"event_msg","payload":{"type":"user_message"}}` + "\n"
+	for _, tt := range []struct {
+		name     string
+		first    string
+		more     string
+		offset   int
+		messages int
+	}{
+		{"LF", meta + "\n" + message + "\n", next, len(meta) + len(message) + 2, 1},
+		{"CRLF", meta + "\r\n" + message + "\r\n", next, len(meta) + len(message) + 4, 1},
+		{"no final newline", meta + "\n" + message, "\n" + next, len(meta) + len(message) + 1, 1},
+		{"partial final record", meta + "\n" + message[:80], message[80:] + "\n" + next, len(meta) + 1, 0},
+		{"malformed complete record", meta + "\ninvalid\n" + message + "\n", next, len(meta) + len(message) + 10, 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "session.jsonl")
+			if err := os.WriteFile(path, []byte(tt.first), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			base, offset, err := ParseJSONL(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if offset != int64(tt.offset) || base.TotalMessages != tt.messages {
+				t.Fatalf("offset/messages = %d/%d, want %d/%d", offset, base.TotalMessages, tt.offset, tt.messages)
+			}
+			appendRollout(t, path, tt.more)
+			got, consumed, err := ParseJSONLIncremental(path, offset, base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if consumed != int64(len(tt.first)+len(tt.more)) || got.TotalMessages != 1 {
+				t.Fatalf("offset/messages after append = %d/%d, want %d/1", consumed, got.TotalMessages, len(tt.first)+len(tt.more))
+			}
+			wantActivity := time.Date(2026, 9, 8, 17, 0, 2, 0, time.UTC)
+			if !got.LastActivity.Equal(wantActivity) || got.Status != model.StatusThinking {
+				t.Fatalf("activity/status after append = %s/%v, want %s/thinking", got.LastActivity, got.Status, wantActivity)
+			}
+		})
+	}
+}
+
+func TestDiscoverSessionsRecoversTruncatedPersistedCache(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	initial := `{"timestamp":"2026-09-04T13:00:00Z","type":"session_meta","payload":{"id":"cached-session"}}` + "\n" +
+		`{"timestamp":"2026-09-04T13:00:01Z","type":"event_msg","payload":{"type":"agent_message"}}` + "\n"
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base, offset, err := ParseJSONL(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendRollout(t, path,
+		`{"timestamp":"2026-09-04T13:00:02Z","type":"event_msg","payload":{"type":"item_completed","item":{"output":"`+strings.Repeat("x", 5*1024*1024)+`"}}}`+"\n"+
+			`{"timestamp":"2026-09-08T17:00:00Z","type":"event_msg","payload":{"type":"user_message"}}`+"\n")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The old scanner cached the file's current mtime with an offset just
+	// before the oversized record and an activity timestamp from days ago.
+	cache := model.NewSessionCache()
+	cache.Put(path, info.ModTime(), offset, base)
+	cachePath := filepath.Join(t.TempDir(), "discovery-codex.json")
+	if err := cache.SaveTo(cachePath); err != nil {
+		t.Fatal(err)
+	}
+	loaded := model.NewSessionCache()
+	if err := loaded.LoadFrom(cachePath); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := discoverSessionsFromDir(dir, "", loaded, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("sessions = %d, want 1", len(sessions))
+	}
+	wantActivity := time.Date(2026, 9, 8, 17, 0, 0, 0, time.UTC)
+	if !sessions[0].LastActivity.Equal(wantActivity) || sessions[0].Status != model.StatusThinking {
+		t.Fatalf("recovered activity/status = %s/%v, want %s/thinking", sessions[0].LastActivity, sessions[0].Status, wantActivity)
+	}
+}
+
+func appendRollout(t *testing.T, path, content string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseJSONLReaderReadError(t *testing.T) {
+	content := `{"timestamp":"2026-09-08T17:00:00Z","type":"event_msg","payload":{"type":"user_message"}}` + "\n"
+	readErr := errors.New("rollout read failed")
+	for _, suffix := range []string{"", `{"timestamp":"2026-09-08`} {
+		reader := io.MultiReader(strings.NewReader(content+suffix), iotest.ErrReader(readErr))
+		base := &model.Session{SessionID: "read-error", Status: model.StatusWaitingForUser}
+		got, offset, err := parseJSONLReader(reader, "session.jsonl", 123, base)
+		if !errors.Is(err, readErr) {
+			t.Fatalf("error = %v, want wrapped read failure", err)
+		}
+		if got != nil || offset != 0 {
+			t.Fatal("read failure returned a partial session that could be cached")
+		}
+		if base.Status != model.StatusWaitingForUser || !base.LastActivity.IsZero() {
+			t.Fatal("failed parse changed the cached base session")
+		}
+	}
+}

--- a/internal/codex/rollout_json.go
+++ b/internal/codex/rollout_json.go
@@ -1,0 +1,536 @@
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"unicode"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+const (
+	rolloutBufferSize = 64 * 1024
+	maxMetadataBytes  = 64 * 1024
+	maxPreviewRunes   = 1024
+	maxJSONDepth      = 10000 // Match encoding/json's nesting limit.
+)
+
+// Small records use encoding/json directly. For larger records, retain only
+// the fields discovery consumes. The projection has a fixed set of fields,
+// bounded strings and one bounded message preview, independent of input size.
+type jsonProjection struct {
+	fields      map[string]*jsonProjection
+	preview     bool
+	trimLeading bool
+	content     bool
+	source      bool
+}
+
+var rolloutProjection = func() *jsonProjection {
+	scalar := &jsonProjection{}
+	preview := &jsonProjection{preview: true, trimLeading: true}
+	object := func(fields map[string]*jsonProjection) *jsonProjection {
+		return &jsonProjection{fields: fields}
+	}
+	return object(map[string]*jsonProjection{
+		"timestamp": scalar,
+		"type":      scalar,
+		"payload": object(map[string]*jsonProjection{
+			"id": scalar, "cwd": scalar, "cli_version": scalar,
+			"agent_nickname": {preview: true}, "source": {source: true},
+			"model": scalar, "git": object(map[string]*jsonProjection{"branch": scalar}),
+			"type": scalar, "name": scalar, "role": scalar,
+			"content":            {content: true},
+			"last_agent_message": preview,
+			"info": object(map[string]*jsonProjection{
+				"total_token_usage": object(map[string]*jsonProjection{
+					"input_tokens": scalar, "cached_input_tokens": scalar,
+					"output_tokens": scalar, "reasoning_output_tokens": scalar,
+				}),
+			}),
+		}),
+	})
+}()
+
+var contentProjection = &jsonProjection{fields: map[string]*jsonProjection{
+	"type": {}, "text": {preview: true},
+}}
+
+var firstContentProjection = &jsonProjection{fields: map[string]*jsonProjection{
+	"type": {}, "text": {preview: true, trimLeading: true},
+}}
+
+// rolloutLineReader exposes exactly one line, including its delimiter. This
+// prevents the projection's buffered reader from reading into the next record.
+type rolloutLineReader struct {
+	reader     *bufio.Reader
+	pending    []byte
+	done       bool
+	terminated bool
+	consumed   int64
+	readErr    error
+}
+
+func (r *rolloutLineReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(r.pending) == 0 && !r.done {
+		var err error
+		r.pending, err = r.reader.ReadSlice('\n')
+		switch err {
+		case nil:
+			r.done, r.terminated = true, true
+		case io.EOF:
+			r.done = true
+		case bufio.ErrBufferFull:
+		default:
+			r.done, r.readErr = true, err
+		}
+	}
+	n := copy(p, r.pending)
+	r.pending = r.pending[n:]
+	r.consumed += int64(n)
+	if len(r.pending) == 0 && r.done {
+		if r.readErr != nil {
+			return n, r.readErr
+		}
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func readRolloutRecord(reader *bufio.Reader) ([]byte, int64, bool, error) {
+	fragment, err := reader.ReadSlice('\n')
+	if err != bufio.ErrBufferFull {
+		if err == io.EOF {
+			return fragment, int64(len(fragment)), false, nil
+		}
+		return fragment, int64(len(fragment)), err == nil, err
+	}
+	line := &rolloutLineReader{reader: reader, pending: fragment}
+	parser := rolloutJSONParser{reader: bufio.NewReaderSize(line, 4096)}
+	value, parseErr := parser.value(rolloutProjection, 0, nil)
+	if parseErr == nil {
+		if _, err := parser.peek(); err != io.EOF {
+			parseErr = errInvalidRolloutJSON
+		}
+	}
+	// Even malformed or excessively nested records must be drained through
+	// the newline so subsequent activity is readable at the exact next offset.
+	_, drainErr := io.Copy(io.Discard, parser.reader)
+	if line.readErr != nil {
+		return nil, 0, false, line.readErr
+	}
+	if drainErr != nil {
+		return nil, 0, false, drainErr
+	}
+	if parseErr != nil {
+		return nil, line.consumed, line.terminated, nil
+	}
+	projected, err := json.Marshal(value)
+	return projected, line.consumed, line.terminated, err
+}
+
+var errInvalidRolloutJSON = errors.New("invalid rollout JSON")
+
+type rolloutJSONParser struct {
+	reader *bufio.Reader
+}
+
+// peek skips JSON whitespace without consuming the next token.
+func (p *rolloutJSONParser) peek() (byte, error) {
+	for {
+		b, err := p.reader.Peek(1)
+		if err != nil {
+			return 0, err
+		}
+		switch b[0] {
+		case ' ', '\t', '\r', '\n':
+			_, _ = p.reader.ReadByte()
+		default:
+			return b[0], nil
+		}
+	}
+}
+
+func (p *rolloutJSONParser) take(want byte) error {
+	b, err := p.peek()
+	if err != nil {
+		return err
+	}
+	if b != want {
+		return errInvalidRolloutJSON
+	}
+	_, err = p.reader.ReadByte()
+	return err
+}
+
+func (p *rolloutJSONParser) value(rule *jsonProjection, depth int, subagent *bool) (any, error) {
+	if rule != nil && rule.source {
+		found := false
+		_, err := p.value(nil, depth, &found)
+		if found {
+			return "subagent", err
+		}
+		return nil, err
+	}
+	b, err := p.peek()
+	if err != nil {
+		return nil, err
+	}
+	if depth >= maxJSONDepth && (b == '{' || b == '[') {
+		return nil, errInvalidRolloutJSON
+	}
+	switch b {
+	case '{':
+		_, _ = p.reader.ReadByte()
+		var result map[string]any
+		if rule != nil {
+			result = make(map[string]any)
+		}
+		if b, _ := p.peek(); b == '}' {
+			_, err := p.reader.ReadByte()
+			return result, err
+		}
+		for {
+			keyLimit := 0
+			if rule != nil {
+				keyLimit = 256
+			}
+			key, _, err := p.string(keyLimit, false, false, subagent)
+			if err != nil {
+				return nil, err
+			}
+			if err := p.take(':'); err != nil {
+				return nil, err
+			}
+			var child *jsonProjection
+			if rule != nil {
+				child = rule.fields[key]
+				if child == nil {
+					// Match encoding/json's case-insensitive struct fields.
+					for name, candidate := range rule.fields {
+						if strings.EqualFold(key, name) {
+							key, child = name, candidate
+							break
+						}
+					}
+				}
+			}
+			v, err := p.value(child, depth+1, subagent)
+			if err != nil {
+				return nil, err
+			}
+			if child != nil {
+				result[key] = v
+			}
+			b, err := p.peek()
+			if err != nil {
+				return nil, err
+			}
+			if b == '}' {
+				_, err := p.reader.ReadByte()
+				return result, err
+			}
+			if err := p.take(','); err != nil {
+				return nil, err
+			}
+		}
+	case '[':
+		return p.array(rule, depth, subagent)
+	case '"':
+		limit := 0
+		preview := rule != nil && rule.preview
+		if rule != nil {
+			limit = maxMetadataBytes
+		}
+		s, overflow, err := p.string(limit, preview, rule != nil && rule.trimLeading, subagent)
+		if overflow && !preview {
+			// Never manufacture a truncated session ID, cwd or tool name.
+			return nil, err
+		}
+		return s, err
+	case 't', 'f', 'n':
+		literal, value := "null", any(nil)
+		if b == 't' {
+			literal, value = "true", true
+		} else if b == 'f' {
+			literal, value = "false", false
+		}
+		for i := range literal {
+			got, err := p.reader.ReadByte()
+			if err != nil {
+				return nil, err
+			}
+			if got != literal[i] {
+				return nil, errInvalidRolloutJSON
+			}
+		}
+		return value, nil
+	default:
+		return p.number(rule != nil)
+	}
+}
+
+func (p *rolloutJSONParser) array(rule *jsonProjection, depth int, subagent *bool) (any, error) {
+	_, _ = p.reader.ReadByte()
+	var preview strings.Builder
+	runes := 0
+	tailContent, invalidContent := false, false
+	emit := func(r rune) {
+		if runes < maxPreviewRunes {
+			preview.WriteRune(r)
+			runes++
+		} else if !unicode.IsSpace(r) {
+			tailContent = true
+		}
+	}
+	if b, _ := p.peek(); b != ']' {
+		for {
+			var child *jsonProjection
+			if rule != nil && rule.content {
+				child = contentProjection
+				if preview.Len() == 0 {
+					child = firstContentProjection
+				}
+			}
+			v, err := p.value(child, depth+1, subagent)
+			if err != nil {
+				return nil, err
+			}
+			if block, ok := v.(map[string]any); ok && child != nil {
+				text, _ := block["text"].(string)
+				kind, _ := block["type"].(string)
+				for _, field := range []string{"type", "text"} {
+					if value := block[field]; value != nil {
+						if _, ok := value.(string); !ok {
+							invalidContent = true
+						}
+					}
+				}
+				if text != "" && (kind == "input_text" || kind == "output_text") {
+					if preview.Len() > 0 {
+						emit('\n')
+					}
+					for _, r := range text {
+						emit(r)
+					}
+				}
+			} else if child != nil && v != nil {
+				invalidContent = true
+			}
+			b, err := p.peek()
+			if err != nil {
+				return nil, err
+			}
+			if b == ']' {
+				break
+			}
+			if err := p.take(','); err != nil {
+				return nil, err
+			}
+		}
+	}
+	_, err := p.reader.ReadByte()
+	if rule == nil {
+		return nil, err
+	}
+	if invalidContent {
+		return []any{false}, err // Preserve responseItemBlock's type error.
+	}
+	if tailContent {
+		// Keep TrimSpace from stripping whitespace inside the preview when
+		// the original message has more text after the retained prefix.
+		preview.WriteRune('…')
+	}
+	if rule != nil && rule.content && preview.Len() > 0 {
+		return []any{map[string]any{"type": "input_text", "text": preview.String()}}, err
+	}
+	return []any{}, err
+}
+
+// string validates the whole JSON string, including discarded suffixes.
+// Retained metadata has a byte cap; previews skip leading whitespace and
+// retain a bounded number of decoded runes. Escaped surrogate pairs are
+// combined before counting, matching encoding/json's string decoding.
+func (p *rolloutJSONParser) string(limit int, preview, trimLeading bool, subagent *bool) (string, bool, error) {
+	if err := p.take('"'); err != nil {
+		return "", false, err
+	}
+	if subagent != nil && limit < len("subagent") {
+		limit = len("subagent")
+	}
+	var out strings.Builder
+	count, size := 0, 0
+	overflow := false
+	tailContent := false
+	emit := func(r rune) {
+		if trimLeading && count == 0 && unicode.IsSpace(r) {
+			return
+		}
+		if (preview && count < maxPreviewRunes) || (!preview && size+utf8.RuneLen(r) <= limit) {
+			out.WriteRune(r)
+		} else {
+			overflow = true
+			if !unicode.IsSpace(r) {
+				tailContent = true
+			}
+		}
+		if count <= maxPreviewRunes {
+			count++
+		}
+		if size <= limit {
+			size += utf8.RuneLen(r)
+		}
+	}
+	var high rune
+	for {
+		r, _, err := p.reader.ReadRune()
+		if err != nil {
+			return "", false, err
+		}
+		if r == '"' {
+			if high != 0 {
+				emit(utf8.RuneError)
+			}
+			if preview && tailContent {
+				out.WriteRune('…')
+			}
+			s := out.String()
+			if subagent != nil && !overflow && s == "subagent" {
+				*subagent = true
+			}
+			if overflow && !preview {
+				return "", true, nil
+			}
+			return s, overflow, nil
+		}
+		if r < 0x20 {
+			return "", false, errInvalidRolloutJSON
+		}
+		escapedUnicode := false
+		if r == '\\' {
+			b, err := p.reader.ReadByte()
+			if err != nil {
+				return "", false, err
+			}
+			switch b {
+			case '"', '\\', '/':
+				r = rune(b)
+			case 'b':
+				r = '\b'
+			case 'f':
+				r = '\f'
+			case 'n':
+				r = '\n'
+			case 'r':
+				r = '\r'
+			case 't':
+				r = '\t'
+			case 'u':
+				r, escapedUnicode = 0, true
+				for range 4 {
+					b, err := p.reader.ReadByte()
+					if err != nil {
+						return "", false, err
+					}
+					var digit byte
+					switch {
+					case b >= '0' && b <= '9':
+						digit = b - '0'
+					case b >= 'a' && b <= 'f':
+						digit = b - 'a' + 10
+					case b >= 'A' && b <= 'F':
+						digit = b - 'A' + 10
+					default:
+						return "", false, errInvalidRolloutJSON
+					}
+					r = r*16 + rune(digit)
+				}
+			default:
+				return "", false, errInvalidRolloutJSON
+			}
+		}
+		if high != 0 {
+			if escapedUnicode && r >= 0xdc00 && r <= 0xdfff {
+				emit(utf16.DecodeRune(high, r))
+				high = 0
+				continue
+			}
+			emit(utf8.RuneError)
+			high = 0
+		}
+		if escapedUnicode && r >= 0xd800 && r <= 0xdbff {
+			high = r
+		} else if escapedUnicode && r >= 0xdc00 && r <= 0xdfff {
+			emit(utf8.RuneError)
+		} else {
+			emit(r)
+		}
+	}
+}
+
+func (p *rolloutJSONParser) number(keep bool) (any, error) {
+	var token [64]byte
+	n := 0
+	take := func() {
+		b, _ := p.reader.ReadByte()
+		if n < len(token) {
+			token[n] = b
+		}
+		if n <= len(token) {
+			n++
+		}
+	}
+	peek := func() byte {
+		b, err := p.reader.Peek(1)
+		if err != nil {
+			return 0
+		}
+		return b[0]
+	}
+	digits := func() bool {
+		any := false
+		for b := peek(); b >= '0' && b <= '9'; b = peek() {
+			take()
+			any = true
+		}
+		return any
+	}
+	if peek() == '-' {
+		take()
+	}
+	if peek() == '0' {
+		take()
+	} else if !digits() {
+		return nil, errInvalidRolloutJSON
+	}
+	if peek() == '.' {
+		take()
+		if !digits() {
+			return nil, errInvalidRolloutJSON
+		}
+	}
+	if b := peek(); b == 'e' || b == 'E' {
+		take()
+		if b := peek(); b == '+' || b == '-' {
+			take()
+		}
+		if !digits() {
+			return nil, errInvalidRolloutJSON
+		}
+	}
+	if !keep {
+		return nil, nil
+	}
+	if n > len(token) {
+		// All selected numeric fields are ints. Preserve their decode failure
+		// for numbers too large to retain, without buffering arbitrary digits.
+		return json.Number("1e999999999"), nil
+	}
+	return json.Number(token[:n]), nil
+}

--- a/internal/codex/rollout_json_test.go
+++ b/internal/codex/rollout_json_test.go
@@ -1,0 +1,219 @@
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"time"
+)
+
+// repeatJSONReader generates large inputs without allocating their contents.
+type repeatJSONReader struct {
+	pattern string
+	offset  int
+}
+
+func (r *repeatJSONReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.pattern[r.offset]
+		r.offset = (r.offset + 1) % len(r.pattern)
+	}
+	return len(p), nil
+}
+
+func TestParseJSONLBoundedMemory(t *testing.T) {
+	const size = 64 * 1024 * 1024
+	for _, tt := range []struct {
+		name, prefix, pattern, suffix string
+		messages                      int
+	}{
+		{"tool output", `{"payload":{"type":"function_call_output","output":"`, "x", `"},"type":"response_item","timestamp":"2026-09-08T17:00:00Z"}`, 0},
+		{"message", `{"payload":{"content":[{"text":"`, "x", `","type":"output_text"}],"role":"assistant","type":"message"},"type":"response_item","timestamp":"2026-09-08T17:00:00Z"}`, 1},
+		{"structured output", `{"payload":{"type":"function_call_output","output":[`, `{"x":0},`, `null]},"type":"response_item","timestamp":"2026-09-08T17:00:00Z"}`, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			length := int64(size / len(tt.pattern) * len(tt.pattern))
+			input := io.MultiReader(strings.NewReader(tt.prefix), io.LimitReader(&repeatJSONReader{pattern: tt.pattern}, length), strings.NewReader(tt.suffix+"\n"))
+			runtime.GC()
+			var before, after runtime.MemStats
+			runtime.ReadMemStats(&before)
+			got, offset, err := parseJSONLReader(input, "generated.jsonl", 0, nil)
+			runtime.ReadMemStats(&after)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// This bounds even cumulative allocation, a stronger check than
+			// peak live memory. ReadBytes allocated multiples of the input.
+			if allocated := after.TotalAlloc - before.TotalAlloc; allocated > 2*1024*1024 {
+				t.Fatalf("allocated %d bytes for a %d-byte record, want < 2 MiB", allocated, length)
+			}
+			t.Logf("record bytes=%d, allocated bytes=%d", length, after.TotalAlloc-before.TotalAlloc)
+			if want := int64(len(tt.prefix)+len(tt.suffix)+1) + length; offset != want {
+				t.Fatalf("offset = %d, want %d", offset, want)
+			}
+			if want := time.Date(2026, 9, 8, 17, 0, 0, 0, time.UTC); !got.LastActivity.Equal(want) {
+				t.Fatalf("activity = %s, want %s", got.LastActivity, want)
+			}
+			if got.TotalMessages != tt.messages {
+				t.Fatalf("messages = %d, want %d", got.TotalMessages, tt.messages)
+			}
+			if tt.messages > 0 && (len(got.RecentMessages) != 1 || got.RecentMessages[0].Text != strings.Repeat("x", 300)) {
+				t.Fatal("large message preview was not preserved")
+			}
+		})
+	}
+}
+
+func TestLargeRolloutMessagePreview(t *testing.T) {
+	for _, text := range []string{
+		strings.Repeat(" \n\u2003", rolloutBufferSize) + strings.Repeat("😀", 400),
+		"start" + strings.Repeat(" ", rolloutBufferSize) + "end",
+		"start" + strings.Repeat(" ", rolloutBufferSize),
+	} {
+		encoded, err := json.Marshal(text)
+		if err != nil {
+			t.Fatal(err)
+		}
+		record := `{"timestamp":"2026-09-08T17:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":` + string(encoded) + `}]}}` + "\n"
+		got, offset, err := parseJSONLReader(strings.NewReader(record), "preview.jsonl", 0, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []rune(strings.TrimSpace(text))
+		if len(want) > 300 {
+			want = want[:300]
+		}
+		if offset != int64(len(record)) || len(got.RecentMessages) != 1 || got.RecentMessages[0].Text != string(want) {
+			t.Fatal("preview changed after streaming whitespace or Unicode")
+		}
+	}
+}
+
+func TestLargeRolloutContentArray(t *testing.T) {
+	ignored := `{"type":"image","text":"ignored"},`
+	content := io.MultiReader(
+		strings.NewReader(`{"payload":{"type":"message","role":"assistant","content":[`),
+		io.LimitReader(&repeatJSONReader{pattern: ignored}, int64(len(ignored)*100000)),
+		strings.NewReader(`{"type":"output_text","text":"still visible"}]},"type":"response_item","timestamp":"2026-09-08T17:00:00Z"}`+"\n"),
+	)
+	got, _, err := parseJSONLReader(content, "array.jsonl", 0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.RecentMessages) != 1 || got.RecentMessages[0].Text != "still visible" {
+		t.Fatal("content after a large array of non-text blocks was lost")
+	}
+}
+
+func TestLargeRolloutMetadataLimit(t *testing.T) {
+	record := `{"timestamp":"2026-09-08T17:00:00Z","type":"session_meta","payload":{"cwd":"` + strings.Repeat("x", maxMetadataBytes+1) + `","id":"valid-id"}}` + "\n"
+	got, offset, err := parseJSONLReader(strings.NewReader(record), "metadata.jsonl", 0, nil)
+	if err != nil || offset != int64(len(record)) || got.CWD != "" || got.SessionID != "valid-id" {
+		t.Fatalf("oversized metadata produced a truncated identity: session=%#v offset=%d err=%v", got, offset, err)
+	}
+}
+
+func TestRolloutProjectionMatchesSmallRecords(t *testing.T) {
+	for _, record := range []string{
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"session_meta","payload":{"id":"s1","cwd":"/tmp/project","cli_version":"1.0","agent_nickname":" ","source":"cli"}}`,
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"session_meta","payload":{"id":"s1","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent"}}}}}`,
+		`{"TIMESTAMP":"2026-09-08T17:00:00Z","TYPE":"turn_context","PAYLOAD":{"CWD":"/tmp/new","MODEL":"model","GIT":{"BRANCH":"feature"}}}`,
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"  hello\n\uD83D\uDE00\ud800x\udc00","type":"output_text"},{"type":"image","text":"ignored"},{"type":"output_text","text":"  world  "}]}}`,
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":false,"type":"output_text"}]}}`,
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[false]}}`,
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"response_item","payload":{"name":"apply_patch","arguments":"ignored","type":"function_call"}}`,
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":12,"cached_input_tokens":3,"output_tokens":4,"reasoning_output_tokens":5}}}}`,
+		`{"timestamp":"2026-09-08T17:00:00Z","type":"event_msg","payload":{"type":"task_complete","last_agent_message":"\u0020\tfinished"}}`,
+	} {
+		for _, ending := range []string{"", "\n", "\r\n"} {
+			want, _, err := parseJSONLReader(strings.NewReader(record+ending), "session.jsonl", 0, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Whitespace forces the streaming path without changing the JSON.
+			large := strings.Repeat(" ", rolloutBufferSize+1) + record + ending
+			got, offset, err := parseJSONLReader(strings.NewReader(large), "session.jsonl", 0, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) || offset != int64(len(large)) {
+				t.Fatalf("projection changed session or offset for %s (ending %q):\ngot %#v, offset %d\nwant %#v, offset %d", record, ending, got, offset, want, len(large))
+			}
+		}
+	}
+}
+
+func TestLargeRolloutPartialAndInvalidRecords(t *testing.T) {
+	prefix := `{"ignored":"` + strings.Repeat("x", rolloutBufferSize*2)
+	suffix := `","timestamp":"2026-09-08T17:00:00Z","type":"event_msg","payload":{"type":"user_message"}}`
+	for _, tt := range []struct {
+		name, content string
+		terminated    bool
+	}{
+		{"partial string", prefix, false},
+		{"invalid escape", prefix + `\q"}` + "\n", true},
+		{"invalid suffix", prefix + suffix + "!\n", true},
+		{"deep nesting", strings.Repeat("[", maxJSONDepth+2) + prefix + "\n", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bufio.NewReaderSize(strings.NewReader(tt.content), rolloutBufferSize)
+			projected, consumed, terminated, err := readRolloutRecord(reader)
+			if err != nil || projected != nil || consumed != int64(len(tt.content)) || terminated != tt.terminated {
+				t.Fatalf("invalid/partial record: projected=%s consumed=%d terminated=%v err=%v", projected, consumed, terminated, err)
+			}
+		})
+	}
+	path := t.TempDir() + "/partial.jsonl"
+	if err := os.WriteFile(path, []byte(prefix), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base, offset, err := ParseJSONL(path)
+	if err != nil || offset != 0 {
+		t.Fatalf("partial parse offset=%d err=%v", offset, err)
+	}
+	appendRollout(t, path, suffix+"\n")
+	got, offset, err := ParseJSONLIncremental(path, offset, base)
+	if err != nil || offset != int64(len(prefix)+len(suffix)+1) || got.LastActivity.IsZero() {
+		t.Fatalf("completed record offset=%d err=%v session=%#v", offset, err, got)
+	}
+}
+
+func TestLargeRolloutReadError(t *testing.T) {
+	readErr := errors.New("read failure after large prefix")
+	for _, prefix := range []string{`{"ignored":"`, `!`} {
+		input := io.MultiReader(strings.NewReader(prefix), io.LimitReader(&repeatJSONReader{pattern: "x"}, rolloutBufferSize*2), iotest.ErrReader(readErr))
+		got, offset, err := parseJSONLReader(input, "session.jsonl", 0, nil)
+		if !errors.Is(err, readErr) || got != nil || offset != 0 {
+			t.Fatalf("read failure returned session=%#v offset=%d err=%v", got, offset, err)
+		}
+	}
+}
+
+func FuzzRolloutJSONSyntax(f *testing.F) {
+	for _, seed := range []string{
+		`{"payload":{"content":[{"type":"input_text","text":"hello"}]}}`,
+		`{"a":[0,-12.3e+4,true,false,null,"\ud83d\ude00"]}`,
+		`{"a":"\ud800\ud800\udc00"}`, `{"a":"\q"}`, `[01]`, `[1.]`, `[1e]`, `{"a":0,}`, `[]`, `null`,
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		if len(input) > 4096 {
+			t.Skip()
+		}
+		p := rolloutJSONParser{reader: bufio.NewReader(strings.NewReader(input))}
+		_, err := p.value(rolloutProjection, 0, nil)
+		_, endErr := p.peek()
+		valid := err == nil && endErr == io.EOF
+		if valid != json.Valid([]byte(input)) {
+			t.Fatalf("valid=%v, encoding/json valid=%v for %q", valid, json.Valid([]byte(input)), input)
+		}
+	})
+}


### PR DESCRIPTION
Codex sessions containing a JSONL record larger than 4 MiB could disappear from the active session list. The scanner stopped silently at that record, leaving `LastActivity` stale and causing the time-window filter to hide the session.

Read small records directly from a fixed 64 KiB buffer. Process larger records with a streaming JSON projection that retains only the fields discovery uses, without buffering discarded strings, objects, or arrays. Retained metadata strings are capped at 64 KiB; oversized identity fields are omitted. Message text is reduced to a bounded preview before the existing display truncation.

Preserve exact source byte offsets across both paths, including CRLF, missing final newlines, and partially written records. Validate discarded JSON and propagate underlying read errors so incomplete parses cannot be cached as successful reads.

Validation:

- `go test -tags notray ./...` passes.
- Generated 64 MiB tool outputs, messages, and structured outputs each allocate less than 2 MiB in regression tests.
- Coverage includes field ordering, Unicode, whitespace, large content arrays, incremental boundaries, stale-cache recovery, and reader failures.
- A 15-second syntax fuzz run exercised approximately 397,000 inputs against `encoding/json` validation.
- The affected real rollout, now 511 MB, parses through EOF in 4.1 seconds with a peak process RSS of approximately 16 MiB and current session activity.
