### PR TITLE
style(gui): unify limits view with omarchy-style meters

### DIFF
--- a/frontend/src/lib/LimitsPage.svelte
+++ b/frontend/src/lib/LimitsPage.svelte
@@ -135,7 +135,7 @@
         Log in to Claude Code, Codex, Grok, Kimi, or Cursor and refresh.
       </div>
     {:else}
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2.5">
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(min(260px,100%),1fr))] gap-2.5">
         {#each view.Reports as report}
           <div class="rounded-lg border border-border bg-surface-hover/30 p-2.5">
             <div class="mb-2 text-[11px] font-bold uppercase tracking-wide text-accent">

--- a/frontend/src/lib/LimitsPage.svelte
+++ b/frontend/src/lib/LimitsPage.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import * as SessionService from "../bindings/github.com/illegalstudio/lazyagent/internal/tray/sessionservice";
-  import { View, Severity } from "../bindings/github.com/illegalstudio/lazyagent/internal/limits/models";
+  import {
+    View,
+    Severity,
+    type WindowView,
+  } from "../bindings/github.com/illegalstudio/lazyagent/internal/limits/models";
 
   interface Props {
     refreshToken?: number;
@@ -10,7 +14,8 @@
   let { refreshToken = 0, closeHint = "esc / l to close" }: Props = $props();
   let loading = $state(true);
   let view = $state<View | null>(null);
-  let tab = $state<"summary" | "detailed">("summary");
+  let fetchedAt = $state(0);
+  let now = $state(Date.now());
 
   $effect(() => {
     refreshToken;
@@ -21,12 +26,15 @@
       .then((v) => {
         if (!cancelled) {
           view = v;
+          fetchedAt = Date.now();
+          now = fetchedAt;
           loading = false;
         }
       })
       .catch(() => {
         if (!cancelled) {
           view = new View({ Reports: [], Summary: [], Available: false });
+          fetchedAt = Date.now();
           loading = false;
         }
       });
@@ -35,6 +43,53 @@
       cancelled = true;
     };
   });
+
+  // The reset countdowns and the "updated ago" line tick on their own so the
+  // panel stays truthful between refreshes.
+  $effect(() => {
+    const id = setInterval(() => (now = Date.now()), 1000);
+    return () => clearInterval(id);
+  });
+
+  const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+  function percentText(value: number): string {
+    const rounded = Math.round(value * 10) / 10;
+    return `${rounded.toFixed(1).replace(/\.0$/, "")}%`;
+  }
+
+  function ratioText(value: number): string {
+    if (value >= 10) return `${Math.round(value)}×`;
+    return `${(Math.round(value * 100) / 100).toFixed(2).replace(/\.?0+$/, "")}×`;
+  }
+
+  // Seconds → "6d 17h", "1h 19m", "12m", "45s".
+  function formatDuration(seconds: number): string {
+    const total = Math.max(0, Math.floor(seconds));
+    if (total < 60) return `${total}s`;
+    const days = Math.floor(total / 86400);
+    const hours = Math.floor((total % 86400) / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    if (days > 0) return `${days}d ${hours}h`;
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    return `${minutes}m`;
+  }
+
+  // Live countdown when the window carries a reset instant, otherwise the
+  // relative string the backend already computed.
+  function resetText(w: WindowView): string {
+    if (w.ResetUnix > 0) {
+      const remaining = w.ResetUnix * 1000 - now;
+      return remaining > 0 ? `resets in ${formatDuration(remaining / 1000)}` : "reset due";
+    }
+    return w.ResetRelative ? `resets ${w.ResetRelative}` : "";
+  }
+
+  function agoText(): string {
+    if (fetchedAt <= 0) return "";
+    const seconds = Math.max(0, (now - fetchedAt) / 1000);
+    return seconds < 10 ? "updated just now" : `updated ${formatDuration(seconds)} ago`;
+  }
 
   function sevText(sev: Severity): string {
     switch (sev) {
@@ -56,82 +111,93 @@
     }
   }
 
+  // Pace as lazyagent defines it: below 0.85× of the elapsed share is
+  // underutilizing, above 1.15× is overutilizing.
   function paceClass(label: string): string {
-    if (label === "overutilizing") return "text-activity-spawning";
-    if (label === "on track") return "text-activity-writing";
-    return "text-subtext";
+    if (label === "overutilizing") return "text-activity-spawning border-activity-spawning/60";
+    if (label === "on track") return "text-activity-writing border-activity-writing/60";
+    return "text-subtext border-border";
+  }
+
+  function paceDetail(w: WindowView): string {
+    if (!w.PaceKnown) return "";
+    return `${ratioText(w.PaceRatio)} of expected ${percentText(w.ExpectedPercent)}`;
   }
 </script>
 
-<div class="flex flex-col h-full bg-surface">
-  <div class="flex items-center gap-2 px-3 py-2 border-b border-border">
-    <button
-      class="rounded px-2 py-0.5 text-[12px] font-medium {tab === 'summary' ? 'text-accent bg-accent/10' : 'text-subtext hover:text-text'}"
-      onclick={() => (tab = "summary")}
-    >Summary</button>
-    <button
-      class="rounded px-2 py-0.5 text-[12px] font-medium {tab === 'detailed' ? 'text-accent bg-accent/10' : 'text-subtext hover:text-text'}"
-      onclick={() => (tab = "detailed")}
-    >Detailed</button>
-    <span class="ml-auto text-[10px] text-subtext">
-      r to refresh{#if closeHint} · {closeHint}{/if}
-    </span>
-  </div>
-
-  <div class="flex-1 overflow-auto p-3">
+<div class="flex h-full flex-col bg-surface">
+  <div class="min-h-0 flex-1 overflow-auto p-3">
     {#if loading}
-      <div class="text-[13px] text-subtext">Loading limits…</div>
+      <div class="py-8 text-center text-[13px] text-subtext">Reading rate limits…</div>
     {:else if !view || !view.Available}
-      <div class="text-[13px] text-subtext">No supported agents detected.</div>
-    {:else if tab === "summary"}
-      <table class="w-full text-[12px]">
-        <thead>
-          <tr class="text-subtext text-left">
-            <th class="font-medium py-1 pr-3">Agent</th>
-            <th class="font-medium py-1 pr-3">5h</th>
-            <th class="font-medium py-1">Week / Global</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each view.Summary as row}
-            <tr class="border-t border-border/50">
-              <td class="py-1 pr-3 text-text">{row.Provider}</td>
-              <td class="py-1 pr-3 {sevText(row.FiveHour.Severity)}">{row.FiveHour.Text}</td>
-              <td class="py-1 {sevText(row.WeekGlobal.Severity)}">{row.WeekGlobal.Text}</td>
-            </tr>
-          {/each}
-        </tbody>
-      </table>
+      <div class="py-8 text-center text-[13px] text-subtext">
+        No supported agents detected.<br />
+        Log in to Claude Code, Codex, Grok, Kimi, or Cursor and refresh.
+      </div>
     {:else}
-      <div class="flex flex-col gap-4">
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2.5">
         {#each view.Reports as report}
-          <div class="rounded border border-border p-2">
-            <div class="text-[13px] font-bold text-accent mb-1">{report.Provider}</div>
-            {#each report.Windows as w}
-              <div class="mb-2">
-                <div class="text-[12px] font-medium text-text">{w.Label} window</div>
-                <div class="flex items-center gap-2 text-[11px] text-subtext">
-                  <span class="w-20">Used {w.UsedPercent.toFixed(1)}%</span>
-                  <div class="flex-1 h-1.5 rounded bg-border overflow-hidden">
-                    <div class="h-full {sevBar(w.UsedSeverity)}" style="width: {Math.max(0, Math.min(100, w.UsedPercent))}%"></div>
+          <div class="rounded-lg border border-border bg-surface-hover/30 p-2.5">
+            <div class="mb-2 text-[11px] font-bold uppercase tracking-wide text-accent">
+              {report.Provider}
+            </div>
+
+            {#if report.Windows.length === 0}
+              <div class="text-[11px] text-subtext">No windows reported.</div>
+            {/if}
+
+            <div class="flex flex-col gap-3">
+              {#each report.Windows as w}
+                <div class="flex flex-col gap-1.5">
+                  <div class="flex items-baseline gap-2">
+                    <span class="truncate text-[12px] text-text">{w.Label} window</span>
+                    <span class="ml-auto shrink-0 text-[12px] font-bold tabular-nums {sevText(w.UsedSeverity)}">
+                      {percentText(w.UsedPercent)} used
+                    </span>
+                  </div>
+
+                  <div class="relative h-1.5 w-full rounded-full bg-border/50">
+                    <div
+                      class="absolute inset-y-0 left-0 rounded-full transition-[width] duration-200 ease-out {sevBar(w.UsedSeverity)}"
+                      style="width: {clamp(w.UsedPercent, 0, 100)}%"
+                    ></div>
+                    {#if w.PaceKnown}
+                      <!-- Where a perfectly linear consumer would be right now. -->
+                      <div
+                        class="absolute -top-1 h-3.5 w-0.5 rounded-full bg-text/80 ring-1 ring-surface"
+                        style="left: calc({clamp(w.ExpectedPercent, 0, 100)}% - 1px)"
+                        title="Expected pace {percentText(w.ExpectedPercent)}"
+                      ></div>
+                    {/if}
+                  </div>
+
+                  <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span class="rounded border px-1.5 py-px text-[10px] font-bold {paceClass(w.PaceKnown ? w.PaceLabel : '')}">
+                      {w.PaceKnown ? w.PaceLabel : "pace unknown"}
+                    </span>
+                    {#if w.PaceKnown}
+                      <span class="truncate text-[10px] text-subtext tabular-nums">{paceDetail(w)}</span>
+                    {/if}
+                    {#if resetText(w)}
+                      <span
+                        class="ml-auto shrink-0 text-[10px] text-subtext tabular-nums"
+                        title={w.ResetAbsolute}
+                      >{resetText(w)}</span>
+                    {/if}
                   </div>
                 </div>
-                <div class="text-[11px] text-subtext">Expected {w.ExpectedPercent.toFixed(1)}%</div>
-                {#if w.ResetRelative}
-                  <div class="text-[11px] text-subtext">Resets {w.ResetRelative} ({w.ResetAbsolute})</div>
-                {/if}
-                {#if w.PaceKnown}
-                  <div class="text-[11px] {paceClass(w.PaceLabel)}">
-                    {w.PaceLabel} ({w.PaceRatio.toFixed(2)}× of expected {w.ExpectedPercent.toFixed(1)}%)
-                  </div>
-                {/if}
-              </div>
-            {/each}
-            {#if report.Source}<div class="text-[10px] text-subtext">{report.Source}</div>{/if}
-            {#if report.Note}<div class="text-[10px] text-subtext">{report.Note}</div>{/if}
+              {/each}
+            </div>
           </div>
         {/each}
       </div>
     {/if}
+  </div>
+
+  <div class="flex shrink-0 items-center gap-2 border-t border-border px-3 py-1.5 text-[10px] text-subtext">
+    <span class="truncate">{loading ? "refreshing…" : agoText()}</span>
+    <span class="ml-auto shrink-0">
+      r to refresh{#if closeHint} · {closeHint}{/if}
+    </span>
   </div>
 </div>


### PR DESCRIPTION
Drop the summary/detailed tab split and render every provider as a card in the same shape as the omarchy plugin panel: one meter per window with the expected-pace marker, a pace-verdict pill, and a live reset countdown. Source/note strings are omitted because they only carried internal debug info.
